### PR TITLE
[TOOLS-152] fixed sindex crash for offline node

### DIFF
--- a/lib/controller.py
+++ b/lib/controller.py
@@ -189,6 +189,8 @@ class InfoController(CommandController):
         sindexes = {}
 
         for host, stat_list in stats.iteritems():
+            if isinstance(stat_list, Exception):
+                continue
             for stat in stat_list:
                 if not stat:
                     continue
@@ -198,7 +200,7 @@ class InfoController(CommandController):
                     sindexes[indexname] = {}
                 sindexes[indexname][host] = stat
 
-        return util.Future(self.view.infoSIndex, stats, self.cluster, **self.mods)
+        return util.Future(self.view.infoSIndex, sindexes, self.cluster, **self.mods)
 
 
 @CommandHelp('"asinfo" provides raw access to the info protocol.'

--- a/lib/view.py
+++ b/lib/view.py
@@ -321,15 +321,13 @@ class CliView(object):
                         , 'sync_state')
 
         t = Table(title, column_names, group_by=1)
-
-        for node_key, n_stats in stats.iteritems():
-            node = prefixes[node_key]
-            for index_stats in n_stats:
-                if isinstance(index_stats, Exception):
+        for stat in stats.values():
+            for node_key, n_stats in stat.iteritems():
+                node = prefixes[node_key]
+                if isinstance(n_stats, Exception):
                     row = {}
                 else:
-                    row = index_stats
-
+                    row = n_stats
                 row['node'] = node
                 t.insertRow(row)
 


### PR DESCRIPTION
Fixed sindex crash for offline node
If the node is offline (local asd not running), it was causing show sindex to throw exception.
