### PR TITLE
Make asadm work when HOME is not set.

### DIFF
--- a/asadm.py
+++ b/asadm.py
@@ -473,7 +473,7 @@ def main():
 
 
     global ADMINHOME, ADMINHIST
-    ADMINHOME = os.environ['HOME'] + '/.aerospike/'
+    ADMINHOME = os.path.expanduser('~') + '/.aerospike/'
     ADMINHIST = ADMINHOME + 'admin_hist'
 
     if not os.path.isdir(ADMINHOME):


### PR DESCRIPTION
With $HOME unset, asadm fails with the following error:

Traceback (most recent call last):
  File "/usr/lib64/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/usr/bin/asadm/__main__.py", line 20, in <module>
  File "/usr/bin/asadm/asadm.py", line 476, in main
  File "/usr/lib64/python2.7/UserDict.py", line 23, in **getitem**
    raise KeyError(key)
KeyError: 'HOME'
