### PR TITLE
Adding support for non tty input stream

### DIFF
--- a/asadm.py
+++ b/asadm.py
@@ -117,7 +117,10 @@ class AerospikeShell(cmd.Cmd):
             else:
                 if user != None:
                     if password == "prompt":
-                        password = getpass.getpass("Enter Password:")
+			if sys.stdin.isatty():
+				password = getpass.getpass('Enter Password:')
+			else:
+    				password = sys.stdin.readline().rstrip()
                     password = info.hashpassword(password)
 
                 self.ctrl = BasicRootController(seed_nodes=[seed], user=user,


### PR DESCRIPTION
asadm uses getpass as one of its component. In order to support automation where password could come from a script and not a terminal, we can also check for the type used as input stream. For tty we keep using getpass() and for non tty we can use sys.stdin.readline()

This will allow scripts to be able to send password outside of terminal and clear text passwords not to be visible through a ps.