### PR TITLE
Set default connect host to 127.0.0.1

### DIFF
--- a/pkg/astools.conf
+++ b/pkg/astools.conf
@@ -19,7 +19,7 @@
 #------------------------------------------------------------------------------
 #
 [global]
-host = "localhost:3000,[::1]:cluster_a:3000"                     # host = [ <host>[:<tls-name>][:<port>], ...]
+host = "127.0.0.1:3000"                     # host = [ <host>[:<tls-name>][:<port>], ...]
 
 #user = ""
 #password = ""


### PR DESCRIPTION
If IPv6 is enabled and there is no IPv6 address set on a host, `asadm` cannot connect to `localhost`, because it probably tries to connect to an IPv6 host which isn't possible. More details in this thread https://discuss.aerospike.com/t/asadm-h-localhost-doesnt-work-in-version-0-1-17/5016/8

I set the default to 127.0.0.1, I also removed [::1] because if Aerospike isn't listening on IPv6 it displays the IPv6 nodes as offline.