### PR TITLE
TOOLS-2079 Support dns load-balancer

### DIFF
--- a/lib/live_cluster/client/cluster.py
+++ b/lib/live_cluster/client/cluster.py
@@ -351,6 +351,7 @@ class Cluster(AsyncObject):
                         if node is not None
                     ]
                 )
+                self.logger.debug("Added nodes to the cluster: %s", visited)
                 visited |= unvisited
                 unvisited.clear()
 
@@ -533,6 +534,11 @@ class Cluster(AsyncObject):
                 # Alias entry already added for this endpoint
                 n = self.get_node_for_alias(addr, port)
                 if n:
+                    self.logger.debug(
+                        "{}:{} is present as an alias for [{},{},{}]. Do not create a new node".format(
+                            addr, port, n.ip, n.tls_name, n.port
+                        )
+                    )
                     # Node already added for this endpoint
                     # No need to check for offline/online as we already did
                     # this while finding new nodes to add


### PR DESCRIPTION
Asadm currently supports a proxy load-balancer in which an LB routes each request to a new node and proxies the node response.  When a DNS LB is used it is the responsibility of the DNS server to return a new IP every time the lookup is done.  The former was handled by making a single request to the node for all the needed connection information.  However, we were less careful when getting the IP and fqdn.  This caused the initial connection to happen on one node while the DNS lookup responded with a different node.  This eventually caused a later node to appear already in the cluster, triggering an eviction.