### PR TITLE
Tools 2063 sindex cdt

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ pyOpenSSL = "==18.0.0"
 setuptools = "*"
 aiohttp = "==3.8.1"
 python-dateutil = "*"
+msgpack = "*"
 
 [dev-packages]
 pyinstaller = "==4.10"

--- a/Pipfile
+++ b/Pipfile
@@ -16,8 +16,8 @@ yappi = "==0.98"
 pyOpenSSL = "==18.0.0"
 setuptools = "*"
 aiohttp = "==3.8.1"
-python-dateutil = "*"
-msgpack = "*"
+python-dateutil = "2.8.2"
+msgpack = "1.0.4"
 
 [dev-packages]
 pyinstaller = "==4.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bcb03a4ea7bba1f1137eb04a75daf94aec94f5b908fdfed2a23e4cdb08eff6b1"
+            "sha256": "ce93766c10d647151780f011d6a131ac8eecf6d0185c4b346e05436f4816b8a4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -215,11 +215,11 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
-                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
+                "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5",
+                "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==2.0.12"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.1.0"
         },
         "cryptography": {
             "hashes": [
@@ -330,6 +330,64 @@
             ],
             "index": "pypi",
             "version": "==2.5.1"
+        },
+        "msgpack": {
+            "hashes": [
+                "sha256:002b5c72b6cd9b4bafd790f364b8480e859b4712e91f43014fe01e4f957b8467",
+                "sha256:0a68d3ac0104e2d3510de90a1091720157c319ceeb90d74f7b5295a6bee51bae",
+                "sha256:0df96d6eaf45ceca04b3f3b4b111b86b33785683d682c655063ef8057d61fd92",
+                "sha256:0dfe3947db5fb9ce52aaea6ca28112a170db9eae75adf9339a1aec434dc954ef",
+                "sha256:0e3590f9fb9f7fbc36df366267870e77269c03172d086fa76bb4eba8b2b46624",
+                "sha256:11184bc7e56fd74c00ead4f9cc9a3091d62ecb96e97653add7a879a14b003227",
+                "sha256:112b0f93202d7c0fef0b7810d465fde23c746a2d482e1e2de2aafd2ce1492c88",
+                "sha256:1276e8f34e139aeff1c77a3cefb295598b504ac5314d32c8c3d54d24fadb94c9",
+                "sha256:1576bd97527a93c44fa856770197dec00d223b0b9f36ef03f65bac60197cedf8",
+                "sha256:1e91d641d2bfe91ba4c52039adc5bccf27c335356055825c7f88742c8bb900dd",
+                "sha256:26b8feaca40a90cbe031b03d82b2898bf560027160d3eae1423f4a67654ec5d6",
+                "sha256:2999623886c5c02deefe156e8f869c3b0aaeba14bfc50aa2486a0415178fce55",
+                "sha256:2a2df1b55a78eb5f5b7d2a4bb221cd8363913830145fad05374a80bf0877cb1e",
+                "sha256:2bb8cdf50dd623392fa75525cce44a65a12a00c98e1e37bf0fb08ddce2ff60d2",
+                "sha256:2cc5ca2712ac0003bcb625c96368fd08a0f86bbc1a5578802512d87bc592fe44",
+                "sha256:35bc0faa494b0f1d851fd29129b2575b2e26d41d177caacd4206d81502d4c6a6",
+                "sha256:3c11a48cf5e59026ad7cb0dc29e29a01b5a66a3e333dc11c04f7e991fc5510a9",
+                "sha256:449e57cc1ff18d3b444eb554e44613cffcccb32805d16726a5494038c3b93dab",
+                "sha256:462497af5fd4e0edbb1559c352ad84f6c577ffbbb708566a0abaaa84acd9f3ae",
+                "sha256:4733359808c56d5d7756628736061c432ded018e7a1dff2d35a02439043321aa",
+                "sha256:48f5d88c99f64c456413d74a975bd605a9b0526293218a3b77220a2c15458ba9",
+                "sha256:49565b0e3d7896d9ea71d9095df15b7f75a035c49be733051c34762ca95bbf7e",
+                "sha256:4ab251d229d10498e9a2f3b1e68ef64cb393394ec477e3370c457f9430ce9250",
+                "sha256:4d5834a2a48965a349da1c5a79760d94a1a0172fbb5ab6b5b33cbf8447e109ce",
+                "sha256:4dea20515f660aa6b7e964433b1808d098dcfcabbebeaaad240d11f909298075",
+                "sha256:545e3cf0cf74f3e48b470f68ed19551ae6f9722814ea969305794645da091236",
+                "sha256:63e29d6e8c9ca22b21846234913c3466b7e4ee6e422f205a2988083de3b08cae",
+                "sha256:6916c78f33602ecf0509cc40379271ba0f9ab572b066bd4bdafd7434dee4bc6e",
+                "sha256:6a4192b1ab40f8dca3f2877b70e63799d95c62c068c84dc028b40a6cb03ccd0f",
+                "sha256:6c9566f2c39ccced0a38d37c26cc3570983b97833c365a6044edef3574a00c08",
+                "sha256:76ee788122de3a68a02ed6f3a16bbcd97bc7c2e39bd4d94be2f1821e7c4a64e6",
+                "sha256:7760f85956c415578c17edb39eed99f9181a48375b0d4a94076d84148cf67b2d",
+                "sha256:77ccd2af37f3db0ea59fb280fa2165bf1b096510ba9fe0cc2bf8fa92a22fdb43",
+                "sha256:81fc7ba725464651190b196f3cd848e8553d4d510114a954681fd0b9c479d7e1",
+                "sha256:85f279d88d8e833ec015650fd15ae5eddce0791e1e8a59165318f371158efec6",
+                "sha256:9667bdfdf523c40d2511f0e98a6c9d3603be6b371ae9a238b7ef2dc4e7a427b0",
+                "sha256:a75dfb03f8b06f4ab093dafe3ddcc2d633259e6c3f74bb1b01996f5d8aa5868c",
+                "sha256:ac5bd7901487c4a1dd51a8c58f2632b15d838d07ceedaa5e4c080f7190925bff",
+                "sha256:aca0f1644d6b5a73eb3e74d4d64d5d8c6c3d577e753a04c9e9c87d07692c58db",
+                "sha256:b17be2478b622939e39b816e0aa8242611cc8d3583d1cd8ec31b249f04623243",
+                "sha256:c1683841cd4fa45ac427c18854c3ec3cd9b681694caf5bff04edb9387602d661",
+                "sha256:c23080fdeec4716aede32b4e0ef7e213c7b1093eede9ee010949f2a418ced6ba",
+                "sha256:d5b5b962221fa2c5d3a7f8133f9abffc114fe218eb4365e40f17732ade576c8e",
+                "sha256:d603de2b8d2ea3f3bcb2efe286849aa7a81531abc52d8454da12f46235092bcb",
+                "sha256:e83f80a7fec1a62cf4e6c9a660e39c7f878f603737a0cdac8c13131d11d97f52",
+                "sha256:eb514ad14edf07a1dbe63761fd30f89ae79b42625731e1ccf5e1f1092950eaa6",
+                "sha256:eba96145051ccec0ec86611fe9cf693ce55f2a3ce89c06ed307de0e085730ec1",
+                "sha256:ed6f7b854a823ea44cf94919ba3f727e230da29feb4a99711433f25800cf747f",
+                "sha256:f0029245c51fd9473dc1aede1160b0a29f4a912e6b1dd353fa6d317085b219da",
+                "sha256:f5d869c18f030202eb412f08b28d2afeea553d6613aee89e200d7aca7ef01f5f",
+                "sha256:fb62ea4b62bfcb0b380d5680f9a4b3f9a2d166d9394e9bbd9666c0ee09a3645c",
+                "sha256:fcb8a47f43acc113e24e910399376f7277cf8508b27e5b88499f053de6b115a8"
+            ],
+            "index": "pypi",
+            "version": "==1.0.4"
         },
         "multidict": {
             "hashes": [
@@ -463,11 +521,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:d1746e7fd520e83bbe210d02fff1aa1a425ad671c7a9da7d246ec2401a087198",
-                "sha256:e7d11f3db616cda0751372244c2ba798e8e56a28e096ec4529010b803485f3fe"
+                "sha256:990a4f7861b31532871ab72331e755b5f14efbe52d336ea7f6118144dd478741",
+                "sha256:c1848f654aea2e3526d17fc3ce6aeaa5e7e24e66e645b5be2171f3f6b4e5a178"
             ],
             "index": "pypi",
-            "version": "==62.3.3"
+            "version": "==62.6.0"
         },
         "six": {
             "hashes": [
@@ -603,32 +661,32 @@
         },
         "black": {
             "hashes": [
-                "sha256:06f9d8846f2340dfac80ceb20200ea5d1b3f181dd0556b47af4e8e0b24fa0a6b",
-                "sha256:10dbe6e6d2988049b4655b2b739f98785a884d4d6b85bc35133a8fb9a2233176",
-                "sha256:2497f9c2386572e28921fa8bec7be3e51de6801f7459dffd6e62492531c47e09",
-                "sha256:30d78ba6bf080eeaf0b7b875d924b15cd46fec5fd044ddfbad38c8ea9171043a",
-                "sha256:328efc0cc70ccb23429d6be184a15ce613f676bdfc85e5fe8ea2a9354b4e9015",
-                "sha256:35020b8886c022ced9282b51b5a875b6d1ab0c387b31a065b84db7c33085ca79",
-                "sha256:5795a0375eb87bfe902e80e0c8cfaedf8af4d49694d69161e5bd3206c18618bb",
-                "sha256:5891ef8abc06576985de8fa88e95ab70641de6c1fca97e2a15820a9b69e51b20",
-                "sha256:637a4014c63fbf42a692d22b55d8ad6968a946b4a6ebc385c5505d9625b6a464",
-                "sha256:67c8301ec94e3bcc8906740fe071391bce40a862b7be0b86fb5382beefecd968",
-                "sha256:6d2fc92002d44746d3e7db7cf9313cf4452f43e9ea77a2c939defce3b10b5c82",
-                "sha256:6ee227b696ca60dd1c507be80a6bc849a5a6ab57ac7352aad1ffec9e8b805f21",
-                "sha256:863714200ada56cbc366dc9ae5291ceb936573155f8bf8e9de92aef51f3ad0f0",
-                "sha256:9b542ced1ec0ceeff5b37d69838106a6348e60db7b8fdd245294dc1d26136265",
-                "sha256:a6342964b43a99dbc72f72812bf88cad8f0217ae9acb47c0d4f141a6416d2d7b",
-                "sha256:ad4efa5fad66b903b4a5f96d91461d90b9507a812b3c5de657d544215bb7877a",
-                "sha256:bc58025940a896d7e5356952228b68f793cf5fcb342be703c3a2669a1488cb72",
-                "sha256:cc1e1de68c8e5444e8f94c3670bb48a2beef0e91dddfd4fcc29595ebd90bb9ce",
-                "sha256:cee3e11161dde1b2a33a904b850b0899e0424cc331b7295f2a9698e79f9a69a0",
-                "sha256:e3556168e2e5c49629f7b0f377070240bd5511e45e25a4497bb0073d9dda776a",
-                "sha256:e8477ec6bbfe0312c128e74644ac8a02ca06bcdb8982d4ee06f209be28cdf163",
-                "sha256:ee8f1f7228cce7dffc2b464f07ce769f478968bfb3dd1254a4c2eeed84928aad",
-                "sha256:fd57160949179ec517d32ac2ac898b5f20d68ed1a9c977346efbac9c2f1e779d"
+                "sha256:074458dc2f6e0d3dab7928d4417bb6957bb834434516f21514138437accdbe90",
+                "sha256:187d96c5e713f441a5829e77120c269b6514418f4513a390b0499b0987f2ff1c",
+                "sha256:2ea29072e954a4d55a2ff58971b83365eba5d3d357352a07a7a4df0d95f51c78",
+                "sha256:4af5bc0e1f96be5ae9bd7aaec219c901a94d6caa2484c21983d043371c733fc4",
+                "sha256:560558527e52ce8afba936fcce93a7411ab40c7d5fe8c2463e279e843c0328ee",
+                "sha256:568ac3c465b1c8b34b61cd7a4e349e93f91abf0f9371eda1cf87194663ab684e",
+                "sha256:6797f58943fceb1c461fb572edbe828d811e719c24e03375fd25170ada53825e",
+                "sha256:6c1734ab264b8f7929cef8ae5f900b85d579e6cbfde09d7387da8f04771b51c6",
+                "sha256:6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9",
+                "sha256:7ba9be198ecca5031cd78745780d65a3f75a34b2ff9be5837045dce55db83d1c",
+                "sha256:94783f636bca89f11eb5d50437e8e17fbc6a929a628d82304c80fa9cd945f256",
+                "sha256:a218d7e5856f91d20f04e931b6f16d15356db1c846ee55f01bac297a705ca24f",
+                "sha256:a3db5b6409b96d9bd543323b23ef32a1a2b06416d525d27e0f67e74f1446c8f2",
+                "sha256:ac609cf8ef5e7115ddd07d85d988d074ed00e10fbc3445aee393e70164a2219c",
+                "sha256:b154e6bbde1e79ea3260c4b40c0b7b3109ffcdf7bc4ebf8859169a6af72cd70b",
+                "sha256:b270a168d69edb8b7ed32c193ef10fd27844e5c60852039599f9184460ce0807",
+                "sha256:b9fd45787ba8aa3f5e0a0a98920c1012c884622c6c920dbe98dbd05bc7c70fbf",
+                "sha256:c85928b9d5f83b23cee7d0efcb310172412fbf7cb9d9ce963bd67fd141781def",
+                "sha256:c9a3ac16efe9ec7d7381ddebcc022119794872abce99475345c5a61aa18c45ad",
+                "sha256:cfaf3895a9634e882bf9d2363fed5af8888802d670f58b279b0bece00e9a872d",
+                "sha256:e439798f819d49ba1c0bd9664427a05aab79bfba777a6db94fd4e56fae0cb849",
+                "sha256:f586c26118bc6e714ec58c09df0157fe2d9ee195c764f630eb0d8e7ccce72e69",
+                "sha256:f6fe02afde060bbeef044af7996f335fbe90b039ccf3f5eb8f16df8b20f77666"
             ],
             "index": "pypi",
-            "version": "==22.3.0"
+            "version": "==22.6.0"
         },
         "click": {
             "hashes": [
@@ -835,11 +893,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:d1746e7fd520e83bbe210d02fff1aa1a425ad671c7a9da7d246ec2401a087198",
-                "sha256:e7d11f3db616cda0751372244c2ba798e8e56a28e096ec4529010b803485f3fe"
+                "sha256:990a4f7861b31532871ab72331e755b5f14efbe52d336ea7f6118144dd478741",
+                "sha256:c1848f654aea2e3526d17fc3ce6aeaa5e7e24e66e645b5be2171f3f6b4e5a178"
             ],
             "index": "pypi",
-            "version": "==62.3.3"
+            "version": "==62.6.0"
         },
         "six": {
             "hashes": [
@@ -854,7 +912,7 @@
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_full_version < '3.11.0a7'",
             "version": "==2.0.1"
         },
         "traceback2": {

--- a/asadm.py
+++ b/asadm.py
@@ -25,6 +25,7 @@ import shlex
 import sys
 import asyncio
 import readline
+from lib.live_cluster.client.msgpack import ASPacker
 from lib.utils.async_object import AsyncObject
 
 
@@ -58,7 +59,7 @@ import yappi  # noqa F401
 # codec is registered well before it is used in getaddrinfo.
 # see https://bugs.python.org/issue29288, https://github.com/aws/aws-cli/blob/1.16.277/awscli/clidriver.py#L55,
 # and https://github.com/pyinstaller/pyinstaller/issues/1113 for more info :)
-u"".encode("idna")
+"".encode("idna")
 
 # Do not remove this line.  It mitigates a race condition that occurs when using
 # pyinstaller and socket.getaddrinfo.  For some reason the idna codec is not registered
@@ -77,6 +78,9 @@ MULTILEVEL_COMMANDS = ["show", "info", "manage"]
 
 DEFAULT_PROMPT = "Admin> "
 PRIVILEGED_PROMPT = "Admin+> "
+
+
+packer = ASPacker()
 
 
 class AerospikeShell(cmd.Cmd, AsyncObject):
@@ -270,7 +274,7 @@ class AerospikeShell(cmd.Cmd, AsyncObject):
 
         command = []
         build_token = ""
-        lexer.wordchars += ".*-:/_{}@"
+        lexer.wordchars += r"`~!@#$%^&*()_-+={}[]|\:''\"<>,./?"
         for token in lexer:
             build_token += token
             if token == "-":

--- a/asadm.py
+++ b/asadm.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from lib.utils.logger import logger
 import inspect
 import cmd
 import getpass
@@ -25,7 +26,7 @@ import shlex
 import sys
 import asyncio
 import readline
-from lib.live_cluster.client.msgpack import ASPacker
+
 from lib.utils.async_object import AsyncObject
 
 
@@ -37,7 +38,6 @@ else:
 
 # Setup logger before anything
 
-from lib.utils.logger import logger
 from lib.collectinfo_analyzer.collectinfo_root_controller import (
     CollectinfoRootController,
 )
@@ -78,9 +78,6 @@ MULTILEVEL_COMMANDS = ["show", "info", "manage"]
 
 DEFAULT_PROMPT = "Admin> "
 PRIVILEGED_PROMPT = "Admin+> "
-
-
-packer = ASPacker()
 
 
 class AerospikeShell(cmd.Cmd, AsyncObject):

--- a/asadm.py
+++ b/asadm.py
@@ -274,7 +274,7 @@ class AerospikeShell(cmd.Cmd, AsyncObject):
 
         command = []
         build_token = ""
-        lexer.wordchars += r"`~!@#$%^&*()_-+={}[]|\:''\"<>,./?"
+        lexer.wordchars += r"`~!@#$%^&*()_-+={}[]|:''\"<>,./?"
         for token in lexer:
             build_token += token
             if token == "-":

--- a/lib/base_controller.py
+++ b/lib/base_controller.py
@@ -317,7 +317,7 @@ class BaseController(object):
                 rv.append(result)
         return rv
 
-    async def execute(self, line) -> Union[None, str, list[None]]:
+    async def execute(self, line: list[str]) -> Union[None, str, list[None]]:
         # Init all command controller objects
         self._init()
 

--- a/lib/live_cluster/client/__init__.py
+++ b/lib/live_cluster/client/__init__.py
@@ -31,6 +31,8 @@ from .config_handler import (
 
 from .cluster import Cluster
 
+from .ctx import CTXItem, CTXItems, CDTContext, ASValue, ASValues
+
 __all__ = (
     Cluster,
     ASInfoError,
@@ -44,4 +46,9 @@ __all__ = (
     EnumConfigType,
     StringConfigType,
     IntConfigType,
+    CTXItem,
+    CTXItems,
+    CDTContext,
+    ASValue,
+    ASValues,
 )

--- a/lib/live_cluster/client/constants.py
+++ b/lib/live_cluster/client/constants.py
@@ -1,0 +1,5 @@
+import enum
+
+
+class BinType(enum.Enum):
+    blah = "blah"

--- a/lib/live_cluster/client/constants.py
+++ b/lib/live_cluster/client/constants.py
@@ -1,5 +1,0 @@
-import enum
-
-
-class BinType(enum.Enum):
-    blah = "blah"

--- a/lib/live_cluster/client/ctx.py
+++ b/lib/live_cluster/client/ctx.py
@@ -1,0 +1,106 @@
+from typing import Any, Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class ASValue(Generic[T]):
+    def __init__(self, value: T):
+        self.value = value
+
+
+class ASValues:
+    class ASBool(ASValue[bool]):
+        def __init__(self, value: bool):
+            super().__init__(value)
+
+    class ASInt(ASValue[int]):
+        def __init__(self, value: int):
+            super().__init__(value)
+
+    class ASString(ASValue[str]):
+        def __init__(self, value: str):
+            super().__init__(value)
+
+    class ASList(ASValue[list[ASValue]]):
+        def __init__(self, value: list[ASValue]):
+            super().__init__(value)
+
+    class ASMap(ASValue[dict[ASValue, ASValue]]):
+        def __init__(self, value: dict[ASValue, ASValue]):
+            super().__init__(value)
+
+    class ASPair(ASValue[tuple]):
+        def __init__(self, value: tuple):
+            super().__init__(value)
+
+    class ASBytes(ASValue[bytes]):
+        def __init__(self, value: bytes):
+            super().__init__(value)
+
+    class ASDouble(ASValue[float]):
+        def __init__(self, value: float):
+            super().__init__(value)
+
+    class ASGeoJson(ASValue[str]):
+        def __init__(self, value: str):
+            super().__init__(value)
+
+    class ASWildCard(ASValue[None]):
+        def __init__(self):  # maybe could be dict?
+            super().__init__(None)
+
+    # class ASUndef(ASValue):
+    #     def __init__(self):
+    #         super().__init__(None)
+
+    # class ASNil(ASValue):
+    #     def __init__(self):
+    #         super().__init__(None)
+
+    # class ASRec(ASValue):
+    #     def __init__(self, value):
+    #         super().__init__(value)
+
+
+class CTXItem(Generic[T]):
+    def __init__(self, val: T):
+        self.value = val
+
+
+class CTXIntItem(CTXItem[int]):
+    pass
+
+
+class CTXParticleItem(CTXItem[ASValue]):
+    pass
+
+
+class CTXItems:
+    class ListIndex(CTXIntItem):
+        pass
+
+    class ListRank(CTXIntItem):
+        pass
+
+    class MapIndex(CTXIntItem):
+        pass
+
+    class MapRank(CTXIntItem):
+        pass
+
+    class MapKey(CTXParticleItem):
+        pass
+
+    # Not needed. Here for reference
+    # class ListValue(CTXItem):
+    #     def __init__(self, pval: ASValue):
+    #         super().__init__(pval=pval)
+
+    # Not needed. Here for reference
+    # class MapValue(CTXItem):
+    #     def __init__(self, pval: ASValue):
+    #         super().__init__(pval=pval)
+
+
+class CDTContext(list[CTXItem]):
+    pass

--- a/lib/live_cluster/client/ctx.py
+++ b/lib/live_cluster/client/ctx.py
@@ -7,6 +7,12 @@ class ASValue(Generic[T]):
     def __init__(self, value: T):
         self.value = value
 
+    def __eq__(self, __o: object) -> bool:
+        return type(self) is type(__o) and self.__dict__ == __o.__dict__
+
+    def __str__(self) -> str:
+        return "{}({})".format(type(self), self.value)
+
 
 class ASValues:
     class ASBool(ASValue[bool]):
@@ -21,18 +27,6 @@ class ASValues:
         def __init__(self, value: str):
             super().__init__(value)
 
-    class ASList(ASValue[list[ASValue]]):
-        def __init__(self, value: list[ASValue]):
-            super().__init__(value)
-
-    class ASMap(ASValue[dict[ASValue, ASValue]]):
-        def __init__(self, value: dict[ASValue, ASValue]):
-            super().__init__(value)
-
-    class ASPair(ASValue[tuple]):
-        def __init__(self, value: tuple):
-            super().__init__(value)
-
     class ASBytes(ASValue[bytes]):
         def __init__(self, value: bytes):
             super().__init__(value)
@@ -41,13 +35,25 @@ class ASValues:
         def __init__(self, value: float):
             super().__init__(value)
 
-    class ASGeoJson(ASValue[str]):
-        def __init__(self, value: str):
-            super().__init__(value)
+    """
+    Not used.  Here for reference in case they become needed.
+    """
 
-    class ASWildCard(ASValue[None]):
-        def __init__(self):  # maybe could be dict?
-            super().__init__(None)
+    # class ASList(ASValue[list[ASValue]]):
+    #     def __init__(self, value: list[ASValue]):
+    #         super().__init__(value)
+
+    # class ASMap(ASValue[dict[ASValue, ASValue]]):
+    #     def __init__(self, value: dict[ASValue, ASValue]):
+    #         super().__init__(value)
+
+    # class ASGeoJson(ASValue[str]):
+    #     def __init__(self, value: str):
+    #         super().__init__(value)
+
+    # class ASWildCard(ASValue[None]):
+    #     def __init__(self):  # maybe could be dict?
+    #         super().__init__(None)
 
     # class ASUndef(ASValue):
     #     def __init__(self):
@@ -66,13 +72,27 @@ class CTXItem(Generic[T]):
     def __init__(self, val: T):
         self.value = val
 
+    def __eq__(self, __o: object) -> bool:
+        return type(__o) is type(self) and __o.__dict__ == self.__dict__
+
+    def __str__(self):
+        return "{}({})".format(type(self), self.value)
+
 
 class CTXIntItem(CTXItem[int]):
-    pass
+    def __init__(self, val: int):
+        if not isinstance(val, int):
+            raise TypeError("CTX value must of type int")
+
+        super().__init__(val)
 
 
 class CTXParticleItem(CTXItem[ASValue]):
-    pass
+    def __init__(self, val: ASValue):
+        if not isinstance(val, ASValue):
+            raise TypeError("CTX value must of type ASValue")
+
+        super().__init__(val)
 
 
 class CTXItems:
@@ -80,6 +100,9 @@ class CTXItems:
         pass
 
     class ListRank(CTXIntItem):
+        pass
+
+    class ListValue(CTXParticleItem):
         pass
 
     class MapIndex(CTXIntItem):
@@ -91,15 +114,8 @@ class CTXItems:
     class MapKey(CTXParticleItem):
         pass
 
-    # Not needed. Here for reference
-    # class ListValue(CTXItem):
-    #     def __init__(self, pval: ASValue):
-    #         super().__init__(pval=pval)
-
-    # Not needed. Here for reference
-    # class MapValue(CTXItem):
-    #     def __init__(self, pval: ASValue):
-    #         super().__init__(pval=pval)
+    class MapValue(CTXParticleItem):
+        pass
 
 
 class CDTContext(list[CTXItem]):

--- a/lib/live_cluster/client/info.py
+++ b/lib/live_cluster/client/info.py
@@ -64,7 +64,10 @@ logger = logging.getLogger("asadm")
 
 _STRUCT_PROTOCOL_HEADER = struct.Struct("! B B 3H")
 _STRUCT_UINT8 = struct.Struct("! B")
+_STRUCT_UINT16 = struct.Struct("! H")
 _STRUCT_UINT32 = struct.Struct("! I")
+_STRUCT_UINT64 = struct.Struct("! Q")
+_STRUCT_INT64 = struct.Struct("! q")
 _STRUCT_FIELD_HEADER = struct.Struct("! I B")
 _STRUCT_ADMIN_HEADER = struct.Struct("! B B B B 12x")
 
@@ -83,6 +86,12 @@ def _unpack_uint8(buf, offset):
     return val[0], offset
 
 
+def _pack_uint16(buf, offset, val):
+    _STRUCT_UINT16.pack_into(buf, offset, val)
+    offset += _STRUCT_UINT16.size
+    return offset
+
+
 def _pack_uint32(buf, offset, val):
     _STRUCT_UINT32.pack_into(buf, offset, val)
     offset += _STRUCT_UINT32.size
@@ -93,6 +102,18 @@ def _unpack_uint32(buf, offset):
     val = _STRUCT_UINT32.unpack_from(buf, offset)
     offset += _STRUCT_UINT32.size
     return val[0], offset
+
+
+def _pack_uint64(buf, offset, val):
+    _STRUCT_UINT64.pack_into(buf, offset, val)
+    offset += _STRUCT_UINT64.size
+    return offset
+
+
+def _pack_int64(buf, offset, val):
+    _STRUCT_INT64.pack_into(buf, offset, val)
+    offset += _STRUCT_INT64.size
+    return offset
 
 
 def _pack_string(buf, offset, string):

--- a/lib/live_cluster/client/info.py
+++ b/lib/live_cluster/client/info.py
@@ -86,12 +86,6 @@ def _unpack_uint8(buf, offset):
     return val[0], offset
 
 
-def _pack_uint16(buf, offset, val):
-    _STRUCT_UINT16.pack_into(buf, offset, val)
-    offset += _STRUCT_UINT16.size
-    return offset
-
-
 def _pack_uint32(buf, offset, val):
     _STRUCT_UINT32.pack_into(buf, offset, val)
     offset += _STRUCT_UINT32.size
@@ -102,18 +96,6 @@ def _unpack_uint32(buf, offset):
     val = _STRUCT_UINT32.unpack_from(buf, offset)
     offset += _STRUCT_UINT32.size
     return val[0], offset
-
-
-def _pack_uint64(buf, offset, val):
-    _STRUCT_UINT64.pack_into(buf, offset, val)
-    offset += _STRUCT_UINT64.size
-    return offset
-
-
-def _pack_int64(buf, offset, val):
-    _STRUCT_INT64.pack_into(buf, offset, val)
-    offset += _STRUCT_INT64.size
-    return offset
 
 
 def _pack_string(buf, offset, string):

--- a/lib/live_cluster/client/msgpack.py
+++ b/lib/live_cluster/client/msgpack.py
@@ -1,0 +1,113 @@
+import struct
+from typing import Union
+from msgpack.fallback import Packer
+from msgpack import ExtType
+
+from lib.live_cluster.client.ctx import ASValue, ASValues, CDTContext, CTXItem, CTXItems
+
+AS_BYTES_STRING = 3
+AS_BYTES_GEOJSON = 23
+ASVAL_CMP_EXT_TYPE = 0xFF
+ASVAL_CMP_WILDCARD = 0x00
+
+
+class CTXItemWireType:
+    AS_CDT_CTX_LIST_INDEX = 0x10
+    AS_CDT_CTX_LIST_RANK = 0x11
+    AS_CDT_CTX_LIST_VALUE = 0x13
+    AS_CDT_CTX_MAP_INDEX = 0x20
+    AS_CDT_CTX_MAP_RANK = 0x21
+    AS_CDT_CTX_MAP_KEY = 0x22
+    AS_CDT_CTX_MAP_VALUE = 0x23
+
+
+class ASPacker(Packer):
+    def __init__(self, autoreset=False):
+        super().__init__(autoreset=autoreset)
+
+    def pack(self, obj):
+        if isinstance(obj, ASValue):
+            self._pack_as_value(obj)
+            return
+        elif isinstance(obj, CDTContext):
+            self._pack_as_cdt_ctx(obj)
+            return
+
+        super().pack(obj)
+
+    def _pack_as_cdt_ctx(self, obj: CDTContext):
+        n = len(obj) * 2
+        self._pack_array_header(n)
+
+        tmp = self.bytes()
+
+        for item in obj:
+            self._pack_as_cdt_item(item)
+
+        return
+
+    def _pack_as_cdt_item(self, obj: CTXItem):
+        if isinstance(obj, CTXItems.ListIndex):
+            self.pack(CTXItemWireType.AS_CDT_CTX_LIST_INDEX)
+        elif isinstance(obj, CTXItems.ListRank):
+            self.pack(CTXItemWireType.AS_CDT_CTX_LIST_RANK)
+        elif isinstance(obj, CTXItems.MapIndex):
+            self.pack(CTXItemWireType.AS_CDT_CTX_MAP_INDEX)
+        elif isinstance(obj, CTXItems.MapRank):
+            self.pack(CTXItemWireType.AS_CDT_CTX_MAP_RANK)
+        elif isinstance(obj, CTXItems.MapKey):
+            self.pack(CTXItemWireType.AS_CDT_CTX_MAP_KEY)
+            tmp = self.bytes()
+        self.pack(obj.value)
+        return
+
+    def _pack_as_value(self, obj: ASValue):
+        if isinstance(obj, ASValues.ASString):
+            val = obj.value
+            val = val.encode("utf-8", self._unicode_errors)
+            n = len(val) + 1
+            if n >= 2**32:
+                raise ValueError("String is too large")
+            self._pack_raw_header(n)
+            self._pack_byte(AS_BYTES_STRING)
+            self._buffer.write(val)
+            tmp = self.bytes()
+            return
+
+        if isinstance(obj, ASValues.ASGeoJson):
+            val = obj.value
+            val = val.encode("utf-8", self._unicode_errors)
+            n = len(val) + 1
+            if n >= 2**32:
+                raise ValueError("String is too large")
+            self._pack_raw_header(n)
+            self._pack_byte(AS_BYTES_GEOJSON)
+            self._buffer.write(val)
+            return
+
+        if isinstance(obj, ASValues.ASPair):
+            val = obj.value
+            val1, val2 = val
+            self._pack_array_header(2)
+            self.pack(val1)
+            self.pack(val2)
+            return
+
+        if isinstance(obj, ASValues.ASList):
+            val = obj.value
+            n = len(val)
+            self._pack_array_header(n)
+            for i in range(n):
+                self._pack_as_value(val[i])
+            return
+
+        if isinstance(obj, ASValues.ASWildCard):
+            wildCardExt = ExtType(ASVAL_CMP_EXT_TYPE, ASVAL_CMP_WILDCARD)
+            super().pack(wildCardExt)
+            return
+
+        self.pack(obj.value)
+        return
+
+    def _pack_byte(self, byte):
+        self._buffer.write(struct.pack("B", byte))

--- a/lib/live_cluster/client/node.py
+++ b/lib/live_cluster/client/node.py
@@ -41,7 +41,6 @@ from .types import (
     ASProtocolError,
     ASResponse,
     Addr_Port_TLSName,
-    SIndexBinType,
 )
 
 logger = logger_debug.get_debug_logger(__name__, logging.CRITICAL)

--- a/lib/live_cluster/client/node.py
+++ b/lib/live_cluster/client/node.py
@@ -2225,7 +2225,7 @@ class Node(AsyncObject):
         index_name: str,
         namespace: str,
         bin_name: str,
-        bin_type: SIndexBinType,
+        bin_type: str,
         index_type: Optional[str] = None,
         set_: Optional[str] = None,
         ctx: Optional[CDTContext] = None,
@@ -2249,8 +2249,8 @@ class Node(AsyncObject):
             packer = ASPacker()
             packer.pack(ctx)
             ctx_bytes: bytes = packer.bytes()
-            ctx_b64 = base64.encodebytes(ctx_bytes)
-            ctx_b64 = util.bytes_to_str(ctx_b64).strip("\n")
+            ctx_b64 = base64.b64encode(ctx_bytes)
+            ctx_b64 = util.bytes_to_str(ctx_b64)
 
             command += "context={};".format(ctx_b64)
 

--- a/lib/live_cluster/client/types.py
+++ b/lib/live_cluster/client/types.py
@@ -1,5 +1,6 @@
 from enum import IntEnum, unique
 import logging
+from typing import Literal, Union
 
 Addr_Port_TLSName = tuple[str, int, str]
 
@@ -248,3 +249,6 @@ class ASInfoNotAuthenticatedError(ASInfoError):
 
 class ASInfoClusterStableError(ASInfoError):
     pass
+
+
+SIndexBinType = Union[Literal["NUMERIC"], Literal["GEO2DSPHERE"], Literal["STRING"]]

--- a/lib/live_cluster/client/types.py
+++ b/lib/live_cluster/client/types.py
@@ -158,26 +158,26 @@ ASINFO_RESPONSE_OK = "ok"
 class ASInfoError(Exception):
     generic_error = "Unknown error occurred"
 
-    def __init__(self, message, response):
+    def __init__(self, message: str, server_resp: str):
         self.message = message
-        self.raw_response = response
+        self.raw_response = server_resp
 
         # Success can either be "ok", "OK", or "" :(
-        if response.lower() in {ASINFO_RESPONSE_OK, ""}:
+        if server_resp.lower() in {ASINFO_RESPONSE_OK, ""}:
             raise ValueError('info() returned value "ok" which is not an error.')
 
         try:
             # sometimes there is a message with 'error' and sometimes not. i.e. set-config, udf-put
-            if response.startswith("error") or response.startswith("ERROR"):
+            if server_resp.startswith("error") or server_resp.startswith("ERROR"):
                 try:
-                    response = response.split("=")[1]
+                    server_resp = server_resp.split("=")[1]
                 except IndexError:
-                    response = response.split(":")[2]
+                    server_resp = server_resp.split(":")[2]
 
-            elif response.startswith("fail") or response.startswith("FAIL"):
-                response = response.split(":")[2]
+            elif server_resp.startswith("fail") or server_resp.startswith("FAIL"):
+                server_resp = server_resp.split(":")[2]
 
-            self.response = response.strip(" .")
+            self.response = server_resp.strip(" .")
 
         except IndexError:
             self.response = self.generic_error

--- a/lib/live_cluster/client/types.py
+++ b/lib/live_cluster/client/types.py
@@ -249,6 +249,3 @@ class ASInfoNotAuthenticatedError(ASInfoError):
 
 class ASInfoClusterStableError(ASInfoError):
     pass
-
-
-SIndexBinType = Union[Literal["NUMERIC"], Literal["GEO2DSPHERE"], Literal["STRING"]]

--- a/lib/live_cluster/live_cluster_command_controller.py
+++ b/lib/live_cluster/live_cluster_command_controller.py
@@ -3,7 +3,7 @@ from .client import Cluster
 
 
 class LiveClusterCommandController(CommandController):
-    cluster = None
+    cluster: Cluster = None
 
     def __init__(self, cluster: Cluster):
         LiveClusterCommandController.cluster = cluster

--- a/lib/live_cluster/manage_controller.py
+++ b/lib/live_cluster/manage_controller.py
@@ -1148,7 +1148,11 @@ class ManageSIndexCreateController(ManageLeafCommandController):
         if isinstance(resp, Exception):
             raise resp
 
-        self.view.print_result("Successfully created sindex {}.".format(index_name))
+        self.view.print_result(
+            "Use 'show sindex' to confirm {} was created successfully.".format(
+                index_name
+            )
+        )
 
     # Hack for auto-complete
     async def do_numeric(self, line):

--- a/lib/live_cluster/manage_controller.py
+++ b/lib/live_cluster/manage_controller.py
@@ -975,7 +975,6 @@ class ManageSIndexCreateController(ManageLeafCommandController):
             r"(?:[tT]{1}[Rr]{1}[Uu]{1}[Ee]{1})|(?:[Ff]{1}[Aa]{1}[Ll]{1}[Ss]{1}[Ee]{1})"
         )
         base64_pattern = r"(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})"
-        hex_pattern = r"0[xX][0-9a-fA-F]+"
 
         particle_pattern_with_names = (
             r"(?:"
@@ -997,10 +996,6 @@ class ManageSIndexCreateController(ManageLeafCommandController):
             + r"|"
             + r"(?P<bytes_base64>"
             + base64_pattern
-            + r")"
-            + r"|"
-            + r"(?P<bytes_hex>"
-            + hex_pattern
             + r")"
             + r")"
         )
@@ -1039,13 +1034,12 @@ class ManageSIndexCreateController(ManageLeafCommandController):
                     ):
                         groups = match.groupdict()
 
-                        double_, int_, str_, bool_, base_64, hex_ = (
+                        double_, int_, str_, bool_, base_64 = (
                             groups["double"],
                             groups["int"],
                             groups["str"],
                             groups["bool"],
                             groups["bytes_base64"],
-                            groups["bytes_hex"],
                         )
                         if double_ is not None:
                             double_ = float(double_)
@@ -1061,9 +1055,6 @@ class ManageSIndexCreateController(ManageLeafCommandController):
                         elif base_64 is not None:
                             base_64 = binascii.a2b_base64(bytes(base_64, "utf-8"))
                             as_val = ASValues.ASBytes(base_64)
-                        elif hex_ is not None:
-                            hex_ = bytes.fromhex(hex_[2:])  # remove 0x
-                            as_val = ASValues.ASBytes(hex_)
                         else:
                             raise Exception("All ctx args are None?")
                     else:

--- a/lib/utils/constants.py
+++ b/lib/utils/constants.py
@@ -119,6 +119,8 @@ class JobType:
 
 
 # server versions with critical changes
+# TODO: Change to functions on the node
+SERVER_SINDEX_ON_CDT_FIRST_VERSION = "6.1"
 SERVER_QUERIES_ABORT_ALL_FIRST_VERSION = "6.0"
 SERVER_39_BYTE_OVERHEAD_FIRST_VERSION = "6.0"
 SERVER_SINDEX_BUILDER_REMOVED_VERSION = "5.7"

--- a/lib/utils/util.py
+++ b/lib/utils/util.py
@@ -369,7 +369,7 @@ def get_value_from_dict(
     Returns value of first matching key from keys which is available in d else returns default_value
     """
 
-    if not isinstance(keys, Iterable):
+    if not isinstance(keys, tuple) and not isinstance(keys, list):
         keys = (keys,)
 
     for key in keys:

--- a/lib/utils/util.py
+++ b/lib/utils/util.py
@@ -369,7 +369,7 @@ def get_value_from_dict(
     Returns value of first matching key from keys which is available in d else returns default_value
     """
 
-    if not isinstance(keys, tuple):
+    if not isinstance(keys, Iterable):
         keys = (keys,)
 
     for key in keys:
@@ -530,7 +530,10 @@ def restructure_sys_data(content, cmd):
 
 
 def get_value_from_second_level_of_dict(
-    data, keys, default_value: DefaultType = None, return_type: Type[ReturnType] = str
+    data: dict[Any, str],
+    keys: list[str],
+    default_value: DefaultType = None,
+    return_type: Type[ReturnType] = str,
 ) -> dict[str, Union[ReturnType, DefaultType]]:
     """
     Function takes dictionary and subkeys to find values inside all keys of dictionary.

--- a/lib/view/sheet/decleration.py
+++ b/lib/view/sheet/decleration.py
@@ -587,12 +587,14 @@ class Projectors(object):
             """
             self.numerator_projector = numerator_projector
             self.denominator_projector = denominator_projector
-            self.sources = set(
-                (
-                    field_fn.source
-                    for field_fn in [numerator_projector, denominator_projector]
-                )
-            )
+            self.sources = set([])
+
+            for field_fn in [numerator_projector, denominator_projector]:
+                if field_fn.source is None:
+                    source = field_fn.sources
+                else:
+                    source = set([field_fn.source])
+                self.sources = self.sources.union(source)
 
         def do_project(self, sheet, sources):
             """
@@ -630,7 +632,7 @@ class Projectors(object):
             return result if not self.invert else 100 - result
 
     class Any(BaseProjector):
-        def __init__(self, field_type, *field_projectors):
+        def __init__(self, field_type: str, *field_projectors: BaseProjector):
             """
             Arguments:
             field_type -- The 'FieldType' for this field.
@@ -640,12 +642,10 @@ class Projectors(object):
             self.field_type = field_type
             self.sources = set()
             for field_fn in field_projectors:
-
                 if field_fn.source is None:
                     source = field_fn.sources
                 else:
                     source = set([field_fn.source])
-
                 self.sources = self.sources.union(source)
 
             self.field_projectors = field_projectors

--- a/lib/view/templates.py
+++ b/lib/view/templates.py
@@ -15,9 +15,6 @@
 from datetime import datetime
 import itertools
 from typing import Iterable, Union
-from unicodedata import numeric
-from lib.utils import file_size
-from lib.utils.common import SummaryStorageUsageDict
 from lib.view.sheet.decleration import ComplexAggregator, EntryData
 from lib.live_cluster.client.node import ASINFO_RESPONSE_OK, ASInfoError
 from lib.view.sheet import (
@@ -740,6 +737,20 @@ def sindex_state_converter(edata):
     return state
 
 
+def _ignore_zero(num: int):
+    if num == 0:
+        return None
+
+    return num
+
+
+def _ignore_null(s: str):
+    if s == "null":
+        return None
+
+    return s
+
+
 info_sindex_sheet = Sheet(
     (
         Field("Index Name", Projectors.String("sindex_stats", "indexname")),
@@ -747,7 +758,7 @@ info_sindex_sheet = Sheet(
         Field("Set", Projectors.String("sindex_stats", "set")),
         node_field,
         hidden_node_id_field,
-        Field("Bins", Projectors.String("sindex_stats", "bins", "bin")),
+        Field("Bin", Projectors.String("sindex_stats", "bins", "bin")),
         Field("Num Bins", Projectors.Number("sindex_stats", "num_bins")),
         Field("Bin Type", Projectors.String("sindex_stats", "type")),
         Field(
@@ -757,12 +768,45 @@ info_sindex_sheet = Sheet(
         ),  # new
         Field("Sync State", Projectors.String("sindex_stats", "sync_state")),  # old
         # removed 6.0
-        Field("Keys", Projectors.Number("sindex_stats", "keys")),
         Field(
-            "Entries",
-            Projectors.Number("sindex_stats", "entries", "objects"),
+            "Keys",
+            Projectors.Any(
+                FieldType.number,
+                Projectors.Div(
+                    Projectors.Number("sindex_stats", "entries", "objects"),
+                    Projectors.Func(
+                        FieldType.number,
+                        _ignore_zero,
+                        Projectors.Number("sindex_stats", "keys", "entries_per_bval"),
+                    ),
+                ),
+                Projectors.Number("sindex_stats", "keys"),
+            ),
             converter=Converters.scientific_units,
-            aggregator=Aggregators.sum(),
+        ),
+        # added 6.1
+        Subgroup(
+            "Entries",
+            (
+                Field(
+                    "Total",
+                    Projectors.Number("sindex_stats", "entries", "objects"),
+                    converter=Converters.scientific_units,
+                    aggregator=Aggregators.sum(),
+                ),
+                Field(
+                    "Avg Per Rec",
+                    Projectors.Number("sindex_stats", "keys", "entries_per_rec"),
+                    converter=Converters.scientific_units,
+                    aggregator=Aggregators.sum(),
+                ),
+                Field(
+                    "Avg Per Bin Val",
+                    Projectors.Number("sindex_stats", "keys", "entries_per_bval"),
+                    converter=Converters.scientific_units,
+                    aggregator=Aggregators.sum(),
+                ),
+            ),
         ),
         Field(
             "Memory Used",
@@ -778,7 +822,14 @@ info_sindex_sheet = Sheet(
             converter=Converters.byte,
             aggregator=Aggregators.sum(),
         ),
-        Field("Context", Projectors.String("sindex_stats", "context")),
+        Field(
+            "Context",
+            Projectors.Func(
+                FieldType.string,
+                _ignore_null,
+                Projectors.String("sindex_stats", "context"),
+            ),
+        ),
         Subgroup(
             "Queries",
             (

--- a/lib/view/templates.py
+++ b/lib/view/templates.py
@@ -778,6 +778,7 @@ info_sindex_sheet = Sheet(
             converter=Converters.byte,
             aggregator=Aggregators.sum(),
         ),
+        Field("Context", Projectors.String("sindex_stats", "context")),
         Subgroup(
             "Queries",
             (
@@ -1581,6 +1582,7 @@ show_sindex = Sheet(
         Field("Bin Type", Projectors.String("data", "type")),
         Field("Index Type", Projectors.String("data", "indextype")),
         Field("State", Projectors.String("data", "state")),
+        Field("Context", Projectors.String("data", "context")),
     ),
     from_source=("data"),
     group_by=("Namespace", "Set"),

--- a/test/unit/live_cluster/client/test_msgpack.py
+++ b/test/unit/live_cluster/client/test_msgpack.py
@@ -1,0 +1,85 @@
+import unittest
+from lib.live_cluster.client.ctx import ASValues, CDTContext, CTXItems
+
+from lib.live_cluster.client.msgpack import (
+    AS_BYTES_BLOB,
+    AS_BYTES_STRING,
+    ASPacker,
+    CTXItemWireType,
+)
+
+
+class MsgPackTest(unittest.TestCase):
+    def setUp(self):
+        self.packer = ASPacker()
+
+    def pack(self, val) -> bytes:
+        self.packer.pack(val)
+        return self.packer.bytes()
+
+    def test_pack_as_string_fixstr(self):
+        string = "abcd"
+        as_string = ASValues.ASString(string)
+        expected = bytes([0xA5, AS_BYTES_STRING]) + bytes(string, encoding="utf-8")
+
+        actual = self.pack(as_string)
+
+        self.assertEqual(expected, actual)
+
+    def test_pack_as_string_8(self):
+        string = "abcdefghijklmnopqrstuvwxyz123456"
+        as_string = ASValues.ASString(string)
+        expected = bytearray([0xD9, 33, AS_BYTES_STRING])
+        expected.extend(bytearray(string, encoding="ascii"))
+
+        actual = self.pack(as_string)
+
+        self.assertEqual(expected, actual)
+
+    def test_pack_as_bytes_fixstr(self):
+        string = b"abcd"
+        as_string = ASValues.ASBytes(string)
+        expected = bytearray([0xA5, AS_BYTES_BLOB])
+        expected.extend(bytearray(string))
+
+        actual = self.pack(as_string)
+
+        self.assertEqual(expected, actual)
+
+    def test_pack_as_bool_false(self):
+        actual = self.pack(ASValues.ASBool(False))
+        self.assertEqual(bytes([0xC2]), actual)
+
+    def test_pack_as_bool_true(self):
+        actual = self.pack(ASValues.ASBool(True))
+        self.assertEqual(bytes([0xC3]), actual)
+
+    def test_pack_cdt_ctx(self):
+        ctx = CDTContext(
+            [
+                CTXItems.ListIndex(1),
+                CTXItems.ListRank(2),
+                CTXItems.MapIndex(3),
+                CTXItems.MapRank(4),
+                CTXItems.MapKey(ASValues.ASString("abcd")),
+                CTXItems.ListValue(ASValues.ASBool(True)),
+                CTXItems.MapValue(ASValues.ASInt(5)),
+            ]
+        )
+
+        expected = (
+            bytes([0x9E])
+            + bytes([CTXItemWireType.AS_CDT_CTX_LIST_INDEX, 1])
+            + bytes([CTXItemWireType.AS_CDT_CTX_LIST_RANK, 2])
+            + bytes([CTXItemWireType.AS_CDT_CTX_MAP_INDEX, 3])
+            + bytes([CTXItemWireType.AS_CDT_CTX_MAP_RANK, 4])
+            + bytes([CTXItemWireType.AS_CDT_CTX_MAP_KEY])
+            + bytes([0xA5, AS_BYTES_STRING])
+            + bytes("abcd", encoding="utf-8")
+            + bytes([CTXItemWireType.AS_CDT_CTX_LIST_VALUE, 0xC3])
+            + bytes([CTXItemWireType.AS_CDT_CTX_MAP_VALUE, 5])
+        )
+
+        actual = self.pack(ctx)
+
+        self.assertEqual(expected, actual)

--- a/test/unit/live_cluster/client/test_node.py
+++ b/test/unit/live_cluster/client/test_node.py
@@ -24,6 +24,7 @@ import unittest
 from mock.mock import AsyncMock, Mock
 
 import lib
+from lib.live_cluster.client.ctx import CDTContext, CTXItem, CTXItems
 from lib.live_cluster.client.types import ASProtocolError, ASResponse
 from test.unit import util
 from lib.utils import constants
@@ -3195,8 +3196,8 @@ class NodeTest(asynctest.TestCase):
 
     async def test_info_sindex_create_success(self):
         self.info_mock.return_value = "OK"
-        expected_call = "sindex-create:indexname={};ns={};indexdata={},{}".format(
-            "iname", "ns", "data1", "data2"
+        expected_call = (
+            "sindex-create:indexname=iname;ns=ns;indexdata=data1,data2".format()
         )
 
         actual = await self.node.info_sindex_create("iname", "ns", "data1", "data2")
@@ -3205,12 +3206,16 @@ class NodeTest(asynctest.TestCase):
         self.assertEqual(actual, ASINFO_RESPONSE_OK)
 
         self.info_mock.return_value = "OK"
-        expected_call = "sindex-create:indexname={};indextype={};ns={};set={};indexdata={},{}".format(
-            "iname", "itype", "ns", "set", "data1", "data2"
-        )
+        expected_call = "sindex-create:indexname=iname;indextype=itype;ns=ns;set=set;context=khAB;indexdata=data1,data2"
 
         actual = await self.node.info_sindex_create(
-            "iname", "ns", "data1", "data2", index_type="itype", set_="set"
+            "iname",
+            "ns",
+            "data1",
+            "data2",
+            index_type="itype",
+            set_="set",
+            ctx=CDTContext([CTXItems.ListIndex(1)]),
         )
 
         self.info_mock.assert_called_with(expected_call, self.ip)

--- a/test/unit/live_cluster/test_manage_controller.py
+++ b/test/unit/live_cluster/test_manage_controller.py
@@ -1490,7 +1490,7 @@ class ManageSIndexCreateControllerTest(asynctest.TestCase):
             nodes="principal",
         )
         self.view_mock.print_result.assert_called_once_with(
-            "Successfully created sindex a-index."
+            "Use 'show sindex' to confirm a-index was created successfully."
         )
 
     async def test_create_fails_with_asinfo_error(self):

--- a/test/unit/live_cluster/test_manage_controller.py
+++ b/test/unit/live_cluster/test_manage_controller.py
@@ -1282,56 +1282,56 @@ class ManageConfigAutoCompleteTest(asynctest.TestCase):
 
 
 class ManageSIndexCreateStrToCTXTest(unittest.TestCase):
-    def test_str_to_cdt_ctx_with_list_by_index(self):
-        line = "[list_by_index(3)]"
+    def test_str_to_cdt_ctx_with_list_index(self):
+        line = "list_index(3)"
         expected = CDTContext([CTXItems.ListIndex(3)])
 
         actual = ManageSIndexCreateController._str_to_cdt_ctx(line)
 
         self.assertEqual(expected, actual)
 
-    def test_str_to_cdt_ctx_with_list_by_rank(self):
-        line = "[list_by_rank(2)]"
+    def test_str_to_cdt_ctx_with_list_rank(self):
+        line = "list_rank(2)"
         expected = CDTContext([CTXItems.ListRank(2)])
 
         actual = ManageSIndexCreateController._str_to_cdt_ctx(line)
 
         self.assertEqual(expected, actual)
 
-    def test_str_to_cdt_ctx_with_list_by_str_value(self):
-        line = "[list_by_value('str')]"
+    def test_str_to_cdt_ctx_with_list_str_value(self):
+        line = "list_value('str')"
         expected = CDTContext([CTXItems.ListValue(ASValues.ASString("str"))])
 
         actual = ManageSIndexCreateController._str_to_cdt_ctx(line)
 
         self.assertEqual(expected, actual)
 
-    def test_str_to_cdt_ctx_with_map_by_index(self):
-        line = "[map_by_index(3)]"
+    def test_str_to_cdt_ctx_with_map_index(self):
+        line = "map_index(3)"
         expected = CDTContext([CTXItems.MapIndex(3)])
 
         actual = ManageSIndexCreateController._str_to_cdt_ctx(line)
 
         self.assertEqual(expected, actual)
 
-    def test_str_to_cdt_ctx_with_map_by_rank(self):
-        line = "[map_by_rank(2)]"
+    def test_str_to_cdt_ctx_with_map_rank(self):
+        line = "map_rank(2)"
         expected = CDTContext([CTXItems.MapRank(2)])
 
         actual = ManageSIndexCreateController._str_to_cdt_ctx(line)
 
         self.assertEqual(expected, actual)
 
-    def test_str_to_cdt_ctx_with_map_by_str_key(self):
-        line = "[map_by_key('str')]"
+    def test_str_to_cdt_ctx_with_map_str_key(self):
+        line = "map_key('str')"
         expected = CDTContext([CTXItems.MapKey(ASValues.ASString("str"))])
 
         actual = ManageSIndexCreateController._str_to_cdt_ctx(line)
 
         self.assertEqual(expected, actual)
 
-    def test_str_to_cdt_ctx_with_map_by_str_value(self):
-        line = "[map_by_value('str')]"
+    def test_str_to_cdt_ctx_with_map_str_value(self):
+        line = "map_value('str')"
         expected = CDTContext([CTXItems.MapValue(ASValues.ASString("str"))])
 
         actual = ManageSIndexCreateController._str_to_cdt_ctx(line)
@@ -1339,7 +1339,7 @@ class ManageSIndexCreateStrToCTXTest(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_str_to_cdt_ctx_with_multiple_items(self):
-        line = "[list_by_index(3),list_by_rank(2), list_by_value(\"str\"), map_by_index(3), map_by_rank(2), map_by_key('str'), map_by_value('str')]"
+        line = "list_index(3)list_rank(2) list_value(\"str\") map_index(3) map_rank(2) map_key('str') map_value('str')"
         expected = CDTContext(
             [
                 CTXItems.ListIndex(3),
@@ -1357,7 +1357,7 @@ class ManageSIndexCreateStrToCTXTest(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_str_to_cdt_ctx_with_double(self):
-        line = "[map_by_key(3.14159), map_by_key(0.0),map_by_key(-3.14159)]"
+        line = "map_key(3.14159) map_key(0.0) map_key(-3.14159)"
         expected = CDTContext(
             [
                 CTXItems.MapKey(ASValues.ASDouble(3.14159)),
@@ -1371,7 +1371,7 @@ class ManageSIndexCreateStrToCTXTest(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_str_to_cdt_ctx_with_int(self):
-        line = "[map_by_key(3), map_by_key(0),map_by_key(-3)]"
+        line = "map_key(3) map_key(0) map_key(-3)"
         expected = CDTContext(
             [
                 CTXItems.MapKey(ASValues.ASInt(3)),
@@ -1385,7 +1385,7 @@ class ManageSIndexCreateStrToCTXTest(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_str_to_cdt_ctx_with_str(self):
-        line = '[map_by_key("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"-=!@#$%^&*()_+[]\\,.;/`~")]'
+        line = 'map_key("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"-=!@#$%^&*()_+[]\\,.;/`~")'
         expected = CDTContext(
             [
                 CTXItems.MapKey(
@@ -1401,7 +1401,7 @@ class ManageSIndexCreateStrToCTXTest(unittest.TestCase):
         self.assertListEqual(expected, actual)
 
     def test_str_to_cdt_ctx_with_bool(self):
-        line = "[map_by_key(FaLsE), map_by_key(TRUE)]"
+        line = "map_key(FaLsE) map_key(TRUE)"
         expected = CDTContext(
             [
                 CTXItems.MapKey(ASValues.ASBool(False)),
@@ -1414,7 +1414,7 @@ class ManageSIndexCreateStrToCTXTest(unittest.TestCase):
         self.assertListEqual(expected, actual)
 
     def test_str_to_cdt_ctx_with_bytes(self):
-        line = "[map_by_key(YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY3ODkwLT1gIUAjJV4mKigpXytbXXt9Oyc6IltdOiwu), map_by_key(YmxhaA==)]"
+        line = "map_key(YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY3ODkwLT1gIUAjJV4mKigpXytbXXt9Oyc6IltdOiwu) map_key(YmxhaA==)"
         expected = CDTContext(
             [
                 CTXItems.MapKey(
@@ -1433,11 +1433,11 @@ class ManageSIndexCreateStrToCTXTest(unittest.TestCase):
         self.assertListEqual(expected, actual)
 
     def test_incorrect_item_sytax_raises_shell_exception(self):
-        line = "[map_by_key(1.'5)]"
+        line = "map_key(1.'5)"
 
         self.assertRaisesRegex(
             ShellException,
-            r"Unable to parse ctx item map_by_key\(1.'5\)",
+            r"Unable to parse ctx item map_key\(1.'5\)",
             ManageSIndexCreateController._str_to_cdt_ctx,
             line,
         )
@@ -1461,7 +1461,7 @@ class ManageSIndexCreateControllerTest(asynctest.TestCase):
         self.addCleanup(patch.stopall)
 
     async def test_prompt_challenge_fails(self):
-        line = "numeric a-index ns test bin a ctx [list_by_value(1)]".split()
+        line = "numeric a-index ns test bin a ctx list_value(1)".split()
         self.controller.warn = True
         self.prompt_mock.return_value = False
 
@@ -1472,7 +1472,7 @@ class ManageSIndexCreateControllerTest(asynctest.TestCase):
         )
 
     async def test_create_successful(self):
-        line = "numeric a-index ns test set testset bin a in mapkeys ctx [list_by_value(1)]".split()
+        line = "numeric a-index ns test set testset bin a in mapkeys ctx list_value(1)".split()
         self.cluster_mock.info_sindex_create.return_value = {
             "1.1.1.1": ASINFO_RESPONSE_OK
         }
@@ -1494,7 +1494,7 @@ class ManageSIndexCreateControllerTest(asynctest.TestCase):
         )
 
     async def test_create_fails_with_asinfo_error(self):
-        line = "numeric a-index ns test bin a ctx [list_by_value(1)]".split()
+        line = "numeric a-index ns test bin a ctx list_value(1)".split()
         self.cluster_mock.info_sindex_create.return_value = {
             "1.1.1.1": ASInfoError("foo", "ERROR::bar")
         }
@@ -1504,7 +1504,7 @@ class ManageSIndexCreateControllerTest(asynctest.TestCase):
         )
 
     async def test_ctx_invalid_format(self):
-        line = "numeric a-index ns test bin a ctx [foo]".split()
+        line = "numeric a-index ns test bin a ctx foo".split()
         self.cluster_mock.info_build.return_value = {"principal": "6.1.0.0"}
 
         await self.assertAsyncRaisesRegex(
@@ -1520,16 +1520,6 @@ class ManageSIndexCreateControllerTest(asynctest.TestCase):
         await self.assertAsyncRaisesRegex(
             ShellException,
             "One or more servers does not support 'ctx'.",
-            self.controller.execute(line),
-        )
-
-    async def test_ctx_malformed_list(self):
-        line = "numeric a-index ns test bin a ctx foo".split()
-        self.cluster_mock.info_build.return_value = {"principal": "6.1.0.0"}
-
-        await self.assertAsyncRaisesRegex(
-            ShellException,
-            "Malformed ctx list",
             self.controller.execute(line),
         )
 

--- a/test/unit/live_cluster/test_manage_controller.py
+++ b/test/unit/live_cluster/test_manage_controller.py
@@ -1,3 +1,4 @@
+import unittest
 from pytest import PytestUnraisableExceptionWarning
 from lib.base_controller import ShellException
 from mock import MagicMock, patch
@@ -12,6 +13,7 @@ from lib.live_cluster.client import (
     Cluster,
 )
 from lib.live_cluster.client.config_handler import JsonDynamicConfigHandler
+from lib.live_cluster.client.ctx import ASValues, CDTContext, CTXItems
 from lib.live_cluster.client.node import Node
 from lib.live_cluster.live_cluster_command_controller import (
     LiveClusterCommandController,
@@ -33,6 +35,9 @@ from lib.live_cluster.manage_controller import (
     ManageRosterRemoveController,
     ManageRosterStageNodesController,
     ManageRosterStageObservedController,
+    ManageSIndexController,
+    ManageSIndexCreateController,
+    ManageSIndexDeleteController,
     ManageTruncateController,
 )
 from lib.utils import constants
@@ -1274,6 +1279,306 @@ class ManageConfigAutoCompleteTest(asynctest.TestCase):
 
         for tc in test_cases:
             run_test(tc)
+
+
+class ManageSIndexCreateStrToCTXTest(unittest.TestCase):
+    def test_str_to_cdt_ctx_with_list_by_index(self):
+        line = "[list_by_index(3)]"
+        expected = CDTContext([CTXItems.ListIndex(3)])
+
+        actual = ManageSIndexCreateController._str_to_cdt_ctx(line)
+
+        self.assertEqual(expected, actual)
+
+    def test_str_to_cdt_ctx_with_list_by_rank(self):
+        line = "[list_by_rank(2)]"
+        expected = CDTContext([CTXItems.ListRank(2)])
+
+        actual = ManageSIndexCreateController._str_to_cdt_ctx(line)
+
+        self.assertEqual(expected, actual)
+
+    def test_str_to_cdt_ctx_with_list_by_str_value(self):
+        line = "[list_by_value('str')]"
+        expected = CDTContext([CTXItems.ListValue(ASValues.ASString("str"))])
+
+        actual = ManageSIndexCreateController._str_to_cdt_ctx(line)
+
+        self.assertEqual(expected, actual)
+
+    def test_str_to_cdt_ctx_with_map_by_index(self):
+        line = "[map_by_index(3)]"
+        expected = CDTContext([CTXItems.MapIndex(3)])
+
+        actual = ManageSIndexCreateController._str_to_cdt_ctx(line)
+
+        self.assertEqual(expected, actual)
+
+    def test_str_to_cdt_ctx_with_map_by_rank(self):
+        line = "[map_by_rank(2)]"
+        expected = CDTContext([CTXItems.MapRank(2)])
+
+        actual = ManageSIndexCreateController._str_to_cdt_ctx(line)
+
+        self.assertEqual(expected, actual)
+
+    def test_str_to_cdt_ctx_with_map_by_str_key(self):
+        line = "[map_by_key('str')]"
+        expected = CDTContext([CTXItems.MapKey(ASValues.ASString("str"))])
+
+        actual = ManageSIndexCreateController._str_to_cdt_ctx(line)
+
+        self.assertEqual(expected, actual)
+
+    def test_str_to_cdt_ctx_with_map_by_str_value(self):
+        line = "[map_by_value('str')]"
+        expected = CDTContext([CTXItems.MapValue(ASValues.ASString("str"))])
+
+        actual = ManageSIndexCreateController._str_to_cdt_ctx(line)
+
+        self.assertEqual(expected, actual)
+
+    def test_str_to_cdt_ctx_with_multiple_items(self):
+        line = "[list_by_index(3),list_by_rank(2), list_by_value(\"str\"), map_by_index(3), map_by_rank(2), map_by_key('str'), map_by_value('str')]"
+        expected = CDTContext(
+            [
+                CTXItems.ListIndex(3),
+                CTXItems.ListRank(2),
+                CTXItems.ListValue(ASValues.ASString("str")),
+                CTXItems.MapIndex(3),
+                CTXItems.MapRank(2),
+                CTXItems.MapKey(ASValues.ASString("str")),
+                CTXItems.MapValue(ASValues.ASString("str")),
+            ]
+        )
+
+        actual = ManageSIndexCreateController._str_to_cdt_ctx(line)
+
+        self.assertEqual(expected, actual)
+
+    def test_str_to_cdt_ctx_with_double(self):
+        line = "[map_by_key(3.14159), map_by_key(0.0),map_by_key(-3.14159)]"
+        expected = CDTContext(
+            [
+                CTXItems.MapKey(ASValues.ASDouble(3.14159)),
+                CTXItems.MapKey(ASValues.ASDouble(0.0)),
+                CTXItems.MapKey(ASValues.ASDouble(-3.14159)),
+            ]
+        )
+
+        actual = ManageSIndexCreateController._str_to_cdt_ctx(line)
+
+        self.assertEqual(expected, actual)
+
+    def test_str_to_cdt_ctx_with_int(self):
+        line = "[map_by_key(3), map_by_key(0),map_by_key(-3)]"
+        expected = CDTContext(
+            [
+                CTXItems.MapKey(ASValues.ASInt(3)),
+                CTXItems.MapKey(ASValues.ASInt(0)),
+                CTXItems.MapKey(ASValues.ASInt(-3)),
+            ]
+        )
+
+        actual = ManageSIndexCreateController._str_to_cdt_ctx(line)
+
+        self.assertEqual(expected, actual)
+
+    def test_str_to_cdt_ctx_with_str(self):
+        line = '[map_by_key("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"-=!@#$%^&*()_+[]\\,.;/`~")]'
+        expected = CDTContext(
+            [
+                CTXItems.MapKey(
+                    ASValues.ASString(
+                        'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"-=!@#$%^&*()_+[]\\,.;/`~'
+                    )
+                ),
+            ]
+        )
+
+        actual = ManageSIndexCreateController._str_to_cdt_ctx(line)
+
+        self.assertListEqual(expected, actual)
+
+    def test_str_to_cdt_ctx_with_bool(self):
+        line = "[map_by_key(FaLsE), map_by_key(TRUE)]"
+        expected = CDTContext(
+            [
+                CTXItems.MapKey(ASValues.ASBool(False)),
+                CTXItems.MapKey(ASValues.ASBool(True)),
+            ]
+        )
+
+        actual = ManageSIndexCreateController._str_to_cdt_ctx(line)
+
+        self.assertListEqual(expected, actual)
+
+    def test_str_to_cdt_ctx_with_bytes(self):
+        line = "[map_by_key(YmxhaA==), map_by_key(0x626C6168)]"
+        expected = CDTContext(
+            [
+                CTXItems.MapKey(ASValues.ASBytes(bytes("blah", encoding="utf-8"))),
+                CTXItems.MapKey(ASValues.ASBytes(bytes("blah", encoding="utf-8"))),
+            ]
+        )
+
+        actual = ManageSIndexCreateController._str_to_cdt_ctx(line)
+        print(actual[1].value)
+
+        self.assertListEqual(expected, actual)
+
+    def test_incorrect_item_sytax_raises_shell_exception(self):
+        line = "[map_by_key(1.'5)]"
+
+        self.assertRaisesRegex(
+            ShellException,
+            r"Unable to parse ctx item map_by_key\(1.'5\)",
+            ManageSIndexCreateController._str_to_cdt_ctx,
+            line,
+        )
+
+
+class ManageSIndexCreateControllerTest(asynctest.TestCase):
+    def setUp(self) -> None:
+        self.cluster_mock = patch(
+            "lib.live_cluster.manage_controller.ManageLeafCommandController.cluster",
+            AsyncMock(),
+        ).start()
+        self.controller = ManageSIndexCreateController()
+        self.logger_mock = patch("lib.base_controller.BaseController.logger").start()
+        self.view_mock = patch("lib.base_controller.BaseController.view").start()
+        self.prompt_mock = patch(
+            "lib.live_cluster.manage_controller.ManageSIndexCreateController.prompt_challenge"
+        ).start()
+
+        self.cluster_mock.info_build.return_value = {"principal": "6.1.0.0"}
+
+        self.addCleanup(patch.stopall)
+
+    async def test_prompt_challenge_fails(self):
+        line = "numeric a-index ns test bin a ctx [list_by_value(1)]".split()
+        self.controller.warn = True
+        self.prompt_mock.return_value = False
+
+        await self.controller.execute(line)
+
+        self.prompt_mock.assert_called_once_with(
+            "Adding a secondary index will cause longer restart times."
+        )
+
+    async def test_create_successful(self):
+        line = "numeric a-index ns test set testset bin a in mapkeys ctx [list_by_value(1)]".split()
+        self.cluster_mock.info_sindex_create.return_value = {
+            "1.1.1.1": ASINFO_RESPONSE_OK
+        }
+
+        await self.controller.execute(line)
+
+        self.cluster_mock.info_sindex_create.assert_called_once_with(
+            "a-index",
+            "test",
+            "a",
+            "numeric",
+            "mapkeys",
+            "testset",
+            CDTContext([CTXItems.ListValue(ASValues.ASInt(1))]),
+            nodes="principal",
+        )
+        self.view_mock.print_result.assert_called_once_with(
+            "Successfully created sindex a-index."
+        )
+
+    async def test_create_fails_with_asinfo_error(self):
+        line = "numeric a-index ns test bin a ctx [list_by_value(1)]".split()
+        self.cluster_mock.info_sindex_create.return_value = {
+            "1.1.1.1": ASInfoError("foo", "ERROR::bar")
+        }
+
+        await self.assertAsyncRaisesRegex(
+            ASInfoError, "bar", self.controller.execute(line)
+        )
+
+    async def test_ctx_invalid_format(self):
+        line = "numeric a-index ns test bin a ctx foo".split()
+        self.cluster_mock.info_build.return_value = {"principal": "6.1.0.0"}
+
+        await self.assertAsyncRaisesRegex(
+            ShellException,
+            "Unable to parse ctx item foo",
+            self.controller.execute(line),
+        )
+
+    async def test_ctx_not_supported(self):
+        line = "numeric a-index ns test bin a ctx foo".split()
+        self.cluster_mock.info_build.return_value = {"principal": "6.0.0.0"}
+
+        await self.assertAsyncRaisesRegex(
+            ShellException,
+            "One or more servers does not support 'ctx'.",
+            self.controller.execute(line),
+        )
+
+
+class ManageSIndexDeleteControllerTest(asynctest.TestCase):
+    def setUp(self) -> None:
+        self.cluster_mock = patch(
+            "lib.live_cluster.manage_controller.ManageLeafCommandController.cluster",
+            AsyncMock(),
+        ).start()
+        self.controller = ManageSIndexDeleteController()
+        self.logger_mock = patch("lib.base_controller.BaseController.logger").start()
+        self.view_mock = patch("lib.base_controller.BaseController.view").start()
+        self.prompt_mock = patch(
+            "lib.live_cluster.manage_controller.ManageSIndexDeleteController.prompt_challenge"
+        ).start()
+
+        self.cluster_mock.info_build.return_value = {"principal": "6.1.0.0"}
+
+        self.addCleanup(patch.stopall)
+
+    async def test_prompt_challenge_fails(self):
+        line = "a-index ns test set testset".split()
+        self.controller.warn = True
+        self.prompt_mock.return_value = False
+        self.cluster_mock.info_sindex_statistics.return_value = {
+            "1.1.1.1": {"keys": 1111},
+            "2.2.2.2": {"keys": 2222},
+        }
+
+        await self.controller.execute(line)
+
+        self.prompt_mock.assert_called_once_with(
+            "The secondary index a-index has 3333 keys indexed."
+        )
+        self.cluster_mock.info_sindex_delete.assert_not_called()
+
+    async def test_delete_successful(self):
+        line = "a-index ns test set testset".split()
+        self.cluster_mock.info_sindex_delete.return_value = {
+            "1.1.1.1": ASINFO_RESPONSE_OK
+        }
+
+        await self.controller.execute(line)
+
+        self.cluster_mock.info_sindex_delete.assert_called_once_with(
+            "a-index",
+            "test",
+            "testset",
+            nodes="principal",
+        )
+        self.view_mock.print_result.assert_called_once_with(
+            "Successfully deleted sindex a-index."
+        )
+
+    async def test_create_fails_with_asinfo_error(self):
+        line = "a-index ns test set testset".split()
+        self.cluster_mock.info_sindex_delete.return_value = {
+            "1.1.1.1": ASInfoError("foo", "ERROR::bar")
+        }
+
+        await self.assertAsyncRaisesRegex(
+            ASInfoError, "bar", self.controller.execute(line)
+        )
 
 
 @asynctest.fail_on(active_handles=True)


### PR DESCRIPTION
[TOOLS-2066](https://aerospike.atlassian.net/browse/TOOLS-2066) (ASADM) Add sindex cardinality to `show sindex` and `info sindex` commands

[TOOLS-2063](https://aerospike.atlassian.net/browse/TOOLS-2063) (ASADM) Add the ability to create sindexs on CDTs by providing a context to the `manage sindex create` command.

[TOOLS-2061](https://aerospike.atlassian.net/browse/TOOLS-2061) (ASADM) Accept all characters for passwords except `;` and whitespace.