### PR TITLE
Bugfix 2.8.1

### DIFF
--- a/.github/workflows/mac-artifact.yml
+++ b/.github/workflows/mac-artifact.yml
@@ -4,7 +4,7 @@ on:
   repository_dispatch:
     types: mac-build
   push:
-    branches: [actionsHub, master, test-ready, TOOLS-1993-mac-build]
+    branches: [actionsHub, master, test-ready, bugfix-2.8.1]
   pull_request:
     branches: [actionsHub]
   workflow_call:

--- a/lib/live_cluster/collectinfo_controller.py
+++ b/lib/live_cluster/collectinfo_controller.py
@@ -863,17 +863,15 @@ class CollectinfoController(LiveClusterCommandController):
             self._dump_collectinfo_sysinfo(as_logfile_prefix, file_header),
             self._dump_collectinfo_aerospike_conf(as_logfile_prefix, config_path),
         ]
-        tasks: list[asyncio.Task] = list(map(asyncio.create_task, coroutines))  # type: ignore
 
-        for t in tasks:
+        for c in coroutines:
             try:
-                await t
+                await c
             except:
                 # close remaining coroutines.  An error will be raised if they are not
                 # awaited.
-                for t in tasks:
-                    if not t.done():
-                        t.cancel()
+                for c in coroutines:
+                    c.close()
 
                 if not ignore_errors:
                     self.logger.error(ignore_errors_msg)

--- a/lib/log_analyzer/log_handler/log_handler.py
+++ b/lib/log_analyzer/log_handler/log_handler.py
@@ -468,7 +468,7 @@ class LogHandler(object):
         file_key = self.reader.get_server_node_id(log_file)
 
         if not file_key:
-            file_key = "MD5_" + str(hashlib.md5(log_file).hexdigest())
+            file_key = "MD5_" + str(hashlib.md5(log_file.encode("utf-8")).hexdigest())
             file_key = file_key[:15] + " "
 
         log = ServerLog(file_key, log_file, self.reader)


### PR DESCRIPTION
[TOOLS-2097](https://aerospike.atlassian.net/browse/TOOLS-2097) (ASADM) LogAnalyzer fails when trying to hash logfile before it is converted to bytes.

Collectinfo cmd does not correctly restore prompt when finished.