### PR TITLE
TOOLS-2220 Bug in the `with` modifier logic causes ip to not match

### DIFF
--- a/lib/live_cluster/client/cluster.py
+++ b/lib/live_cluster/client/cluster.py
@@ -445,9 +445,10 @@ class Cluster(AsyncObject):
                     return []
 
         if match is None:
+            # no match
             return []
         else:
-            # more than one match
+            # exactly one match
             return [match]
 
     def get_nodes(
@@ -520,7 +521,7 @@ class Cluster(AsyncObject):
             pass
         return None
 
-    async def _create_node(self, addr_port_tls, force=False):
+    async def _create_node(self, addr_port_tls: Addr_Port_TLSName, force=False):
         """
         Instantiate and return a new node
 
@@ -535,7 +536,7 @@ class Cluster(AsyncObject):
             try:
                 # tuple of length 2 for server version < 3.10.0 ( without tls
                 # name)
-                addr, port = addr_port_tls
+                addr, port = addr_port_tls  # type: ignore
                 tls_name = None
             except Exception:
                 print(

--- a/lib/live_cluster/client/node.py
+++ b/lib/live_cluster/client/node.py
@@ -20,7 +20,7 @@ import socket
 import threading
 import time
 import base64
-from typing import Optional
+from typing import Optional, Union
 from lib.live_cluster.client.ctx import CDTContext
 from lib.live_cluster.client.msgpack import ASPacker
 
@@ -140,7 +140,7 @@ class Node(AsyncObject):
         self.user = user
         self.password = password
         self.auth_mode = auth_mode
-        self.tls_name = tls_name
+        self.tls_name: Union[str, None] = tls_name
         self.ssl_context = ssl_context
         if ssl_context:
             self.enable_tls = True

--- a/lib/live_cluster/client/node.py
+++ b/lib/live_cluster/client/node.py
@@ -134,8 +134,8 @@ class Node(AsyncObject):
         """
         self.logger = logging.getLogger("asadm")
         self.remote_system_command_prompt = "[#$] "
-        self.ip = address
-        self.port = port
+        self.ip: str = address
+        self.port: int = port
         self._timeout = timeout
         self.user = user
         self.password = password

--- a/lib/utils/lookup_dict.py
+++ b/lib/utils/lookup_dict.py
@@ -12,25 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any, Generic, TypeVar
 
-class LookupDict:
+
+ValueType = TypeVar("ValueType")
+
+
+class LookupDict(Generic[ValueType]):
 
     LOOKUP_MODE = 0
     PREFIX_MODE = 1
     SUFFIX_MODE = 2
 
     def __init__(self, mode=None):
-        self._kv = {}
+        self._kv: dict[Any, ValueType] = {}
 
         if mode is None:
             mode = self.LOOKUP_MODE
 
         self.mode = mode
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key, value: ValueType):
         return self.add(key, value)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key) -> list[ValueType]:
         return self.get(key)
 
     def __delitem__(self, key):
@@ -141,7 +146,7 @@ class LookupDict:
     def keys(self):
         return list(self._kv.keys())
 
-    def get(self, k):
+    def get(self, k) -> list[ValueType]:
         keys = self.get_key(k)
         return [self._kv[key] for key in keys]
 

--- a/test/unit/live_cluster/client/test_cluster.py
+++ b/test/unit/live_cluster/client/test_cluster.py
@@ -192,6 +192,8 @@ class ClusterTest(asynctest.TestCase):
             ("192.169.0.1", 3000),
             ("192.168.0.1", 3001),
             ("192.168.0.1", 3002),
+            ("183.168.0.1", 3000),
+            ("183.168.0.11", 3000),
         ]
         for i, (ip, port) in enumerate(ip_ports):
             n = await self.get_info_mock("A0000000000000" + str(i), ip=ip, port=port)
@@ -258,9 +260,20 @@ class ClusterTest(asynctest.TestCase):
             "192.169.0.1:3000",
             "192.168.0.1:3001",
             "192.168.0.1:3002",
+            "183.168.0.1:3000",
+            "183.168.0.11:3000",
         ]
 
         actual = cl.get_node("A0*")
+        actual = map(lambda x: x.key, actual)
+
+        self.assertCountEqual(expected, actual)
+
+        expected = [
+            "183.168.0.1:3000",
+        ]
+
+        actual = cl.get_node("183.168.0.1")
         actual = map(lambda x: x.key, actual)
 
         self.assertCountEqual(expected, actual)


### PR DESCRIPTION
When the exact ip of a node is provided to the with modifier and there exists another node with an almost identical ip except for the last octet where the provided ip is a prefix of the other then an error will occur indicating that no matching nodes could be found.

Example:
User provides `with 1.1.1.1` and the list of available nodes is (1.1.1.11:3000, 1.1.1.1:3000) the correct response is  [1.1.1.1:3000] but with this bug an empty list would be returned.