### PR TITLE
fix: `info sindex` formatting

### DIFF
--- a/lib/collectinfo_analyzer/info_controller.py
+++ b/lib/collectinfo_analyzer/info_controller.py
@@ -189,9 +189,7 @@ class InfoController(CollectinfoCommandController):
 
     @CommandHelp("Displays secondary index (SIndex) summary information).")
     def do_sindex(self, line):
-        sindex_stats = self.log_handler.info_statistics(
-            stanza=constants.STAT_SINDEX, flip=True
-        )
+        sindex_stats = self.log_handler.info_statistics(stanza=constants.STAT_SINDEX)
         for timestamp in sorted(sindex_stats.keys()):
             if not sindex_stats[timestamp]:
                 continue

--- a/lib/live_cluster/collectinfo_controller.py
+++ b/lib/live_cluster/collectinfo_controller.py
@@ -662,7 +662,7 @@ class CollectinfoController(LiveClusterCommandController):
                 util.write_to_file(complete_filename, str(e))
         except Exception as e:
             util.write_to_file(complete_filename, str(e))
-            self.logger.warning("Failed to generate {} file.", complete_filename)
+            self.logger.warning("Failed to generate %s file.", complete_filename)
             self.logger.debug(traceback.format_exc())
             raise
 
@@ -707,7 +707,7 @@ class CollectinfoController(LiveClusterCommandController):
 
         except Exception as e:
             util.write_to_file(complete_filename, str(e))
-            self.logger.warning("Failed to generate {} file.", complete_filename)
+            self.logger.warning("Failed to generate %s file.", complete_filename)
             self.logger.debug(traceback.format_exc())
             raise
 
@@ -731,7 +731,7 @@ class CollectinfoController(LiveClusterCommandController):
                 )
         except Exception as e:
             util.write_to_file(complete_filename, str(e))
-            self.logger.warning("Failed to generate {} file.", complete_filename)
+            self.logger.warning("Failed to generate %s file.", complete_filename)
             self.logger.debug(traceback.format_exc())
             raise
 
@@ -751,7 +751,7 @@ class CollectinfoController(LiveClusterCommandController):
             )
         except Exception as e:
             util.write_to_file(complete_filename, str(e))
-            self.logger.warning("Failed to generate {} file.", complete_filename)
+            self.logger.warning("Failed to generate %s file.", complete_filename)
             self.logger.debug(traceback.format_exc())
             raise
 
@@ -767,7 +767,7 @@ class CollectinfoController(LiveClusterCommandController):
             self._collect_local_file(conf_path, complete_filename)
         except Exception as e:
             self.logger.debug(traceback.format_exc())
-            self.logger.warning("Failed to generate {} file.", complete_filename)
+            self.logger.warning("Failed to generate %s file.", complete_filename)
             self.logger.warning(str(e))
             util.write_to_file(complete_filename, str(e))
 

--- a/lib/view/view.py
+++ b/lib/view/view.py
@@ -304,14 +304,6 @@ class CliView(object):
         if not stats:
             return
 
-        # stats comes in {index:{node:{k:v}}}, needs to be {node:{index:{k:v}}}
-        sindex_stats = {}
-
-        for iname, nodes in stats.items():
-            for node, values in nodes.items():
-                sindex_stats[node] = node_stats = sindex_stats.get(node, {})
-                node_stats[iname] = values
-
         node_names = cluster.get_node_names(with_)
         node_ids = cluster.get_node_ids(with_)
         title_suffix = CliView._get_timestamp_suffix(timestamp)
@@ -319,7 +311,7 @@ class CliView(object):
         sources = dict(
             node_ids=node_ids,
             node_names=node_names,
-            sindex_stats=sindex_stats,
+            sindex_stats=stats,
         )
         common = dict(principal=cluster.get_expected_principal())
 


### PR DESCRIPTION
The stats need to be flipped one more time for them to be correctly displayed.  Instead of adding another flip I removed a previous flip in live and collectinfo modes which had the same effect.