### PR TITLE
Tools 2380 rhel9

### DIFF
--- a/asadm-asinfo-one-dir.spec
+++ b/asadm-asinfo-one-dir.spec
@@ -13,11 +13,11 @@ from PyInstaller.utils.hooks import collect_all
 #
 
 datas = []
-binaries = [('/usr/bin/less','.')]
+binaries = [('/usr/bin/less','.'), ('/usr/lib64/libcrypt.so.1', '.')]
 hiddenimports = []
 tmp_ret = collect_all('lib')
 datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
-
+print(datas)
 added_files = [
 ]
 

--- a/asadm-asinfo-one-dir.spec
+++ b/asadm-asinfo-one-dir.spec
@@ -1,5 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 from PyInstaller.utils.hooks import collect_all
+import platform
 
 #
 # Creates a bundled directory as apposed to a single executable file. This allows for
@@ -12,14 +13,18 @@ from PyInstaller.utils.hooks import collect_all
 # TLDR; Use onedir for MacOS.
 #
 
-datas = []
-binaries = [('/usr/bin/less','.'), ('/usr/lib64/libcrypt.so.1', '.')]
+datas = [('lib/live_cluster/client/config-schemas', './lib/live_cluster/client/config-schemas')]
+binaries = [('/usr/bin/less','.')]
 hiddenimports = []
-tmp_ret = collect_all('lib')
-datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
-print(datas)
-added_files = [
-]
+
+'''
+RHEL9 removed libcrypt (different from libcrypto) from its default distribution.
+It is possible to build Python without libcrypt but we would need to move away from
+using pyenv on our build machine since pyenv relies on libcrypt to run `pyenv install`.
+'''
+
+if "darwin" not in platform.system().lower():
+    binaries.append(('/usr/lib64/libcrypt.so.1', '.'))
 
 block_cipher = None
 


### PR DESCRIPTION
These spec files are really just python files.  I did two things. The most important is that I now bundle `/usr/lib64/libcrypt.so.1` with asadm. The location of that file is system dependent and is only needed for rhel9 so I only add it if we are linux.  We build our Linux bundles on centos7 and that is where the file is located. The second thing I did was remove the entire `lib` directory from the distribution.  When I first created the files I could not figure out how to only include the schemas and excluded the all the source files while still keeping the paths as asadm expects them.  Anyway, I figured it out hence the addition to the array `datas`.