### PR TITLE
fix: Tools 2512 incorrect enable compression

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a11c07acdef3b38faf5d18f251647849cf69229d5b3b93bd6ed47ad08c773571"
+            "sha256": "fc7dfa152a87c3cf2a1f5eb053fb643568c8345be9f7f6c5828f3646ef8cf06c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -114,7 +114,7 @@
                 "sha256:54cd96e15e1649b75d6c87526a6ff0b6c1b0dd3459f43d9ca11d48c339b68cfc",
                 "sha256:f8376fb07dd1e86a584e4fcdec80b36b7f81aac666ebc724e2c090300dd83b17"
             ],
-            "markers": "python_full_version >= '3.7.0'",
+            "markers": "python_version >= '3.7'",
             "version": "==1.3.1"
         },
         "async-timeout": {
@@ -424,7 +424,7 @@
                 "sha256:f470c92737afa7d4c3aacc001e335062d582053d4dbe73cda126f2d7031068dd",
                 "sha256:ff8bf625fe85e119553b5383ba0fb6aa3d0ec2ae980295aaefa552374926b3f4"
             ],
-            "markers": "python_full_version >= '3.7.0'",
+            "markers": "python_version >= '3.7'",
             "version": "==1.3.3"
         },
         "idna": {
@@ -589,7 +589,7 @@
                 "sha256:fc35cb4676846ef752816d5be2193a1e8367b4c1397b74a565a9d0389c433a1d",
                 "sha256:ff959bee35038c4624250473988b24f846cbeb2c6639de3602c073f10410ceba"
             ],
-            "markers": "python_full_version >= '3.7.0'",
+            "markers": "python_version >= '3.7'",
             "version": "==6.0.4"
         },
         "parameterized": {
@@ -943,11 +943,84 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
-                "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
+                "sha256:04afa6387e2b282cf78ff3dbce20f0cc071c12dc8f685bd40960cc68644cfea6",
+                "sha256:04eefcee095f58eaabe6dc3cc2262f3bcd776d2c67005880894f447b3f2cb9c1",
+                "sha256:0be65ccf618c1e7ac9b849c315cc2e8a8751d9cfdaa43027d4f6624bd587ab7e",
+                "sha256:0c95f12b74681e9ae127728f7e5409cbbef9cd914d5896ef238cc779b8152373",
+                "sha256:0ca564606d2caafb0abe6d1b5311c2649e8071eb241b2d64e75a0d0065107e62",
+                "sha256:10c93628d7497c81686e8e5e557aafa78f230cd9e77dd0c40032ef90c18f2230",
+                "sha256:11d117e6c63e8f495412d37e7dc2e2fff09c34b2d09dbe2bee3c6229577818be",
+                "sha256:11d3bcb7be35e7b1bba2c23beedac81ee893ac9871d0ba79effc7fc01167db6c",
+                "sha256:12a2b561af122e3d94cdb97fe6fb2bb2b82cef0cdca131646fdb940a1eda04f0",
+                "sha256:12d1a39aa6b8c6f6248bb54550efcc1c38ce0d8096a146638fd4738e42284448",
+                "sha256:1435ae15108b1cb6fffbcea2af3d468683b7afed0169ad718451f8db5d1aff6f",
+                "sha256:1c60b9c202d00052183c9be85e5eaf18a4ada0a47d188a83c8f5c5b23252f649",
+                "sha256:1e8fcdd8f672a1c4fc8d0bd3a2b576b152d2a349782d1eb0f6b8e52e9954731d",
+                "sha256:20064ead0717cf9a73a6d1e779b23d149b53daf971169289ed2ed43a71e8d3b0",
+                "sha256:21fa558996782fc226b529fdd2ed7866c2c6ec91cee82735c98a197fae39f706",
+                "sha256:22908891a380d50738e1f978667536f6c6b526a2064156203d418f4856d6e86a",
+                "sha256:3160a0fd9754aab7d47f95a6b63ab355388d890163eb03b2d2b87ab0a30cfa59",
+                "sha256:322102cdf1ab682ecc7d9b1c5eed4ec59657a65e1c146a0da342b78f4112db23",
+                "sha256:34e0a2f9c370eb95597aae63bf85eb5e96826d81e3dcf88b8886012906f509b5",
+                "sha256:3573d376454d956553c356df45bb824262c397c6e26ce43e8203c4c540ee0acb",
+                "sha256:3747443b6a904001473370d7810aa19c3a180ccd52a7157aacc264a5ac79265e",
+                "sha256:38e812a197bf8e71a59fe55b757a84c1f946d0ac114acafaafaf21667a7e169e",
+                "sha256:3a06f32c9634a8705f4ca9946d667609f52cf130d5548881401f1eb2c39b1e2c",
+                "sha256:3a5fc78f9e3f501a1614a98f7c54d3969f3ad9bba8ba3d9b438c3bc5d047dd28",
+                "sha256:3d9098b479e78c85080c98e1e35ff40b4a31d8953102bb0fd7d1b6f8a2111a3d",
+                "sha256:3dc5b6a8ecfdc5748a7e429782598e4f17ef378e3e272eeb1340ea57c9109f41",
+                "sha256:4155b51ae05ed47199dc5b2a4e62abccb274cee6b01da5b895099b61b1982974",
+                "sha256:49919f8400b5e49e961f320c735388ee686a62327e773fa5b3ce6721f7e785ce",
+                "sha256:53d0a3fa5f8af98a1e261de6a3943ca631c526635eb5817a87a59d9a57ebf48f",
+                "sha256:5f008525e02908b20e04707a4f704cd286d94718f48bb33edddc7d7b584dddc1",
+                "sha256:628c985afb2c7d27a4800bfb609e03985aaecb42f955049957814e0491d4006d",
+                "sha256:65ed923f84a6844de5fd29726b888e58c62820e0769b76565480e1fdc3d062f8",
+                "sha256:6734e606355834f13445b6adc38b53c0fd45f1a56a9ba06c2058f86893ae8017",
+                "sha256:6baf0baf0d5d265fa7944feb9f7451cc316bfe30e8df1a61b1bb08577c554f31",
+                "sha256:6f4f4668e1831850ebcc2fd0b1cd11721947b6dc7c00bf1c6bd3c929ae14f2c7",
+                "sha256:6f5c2e7bc8a4bf7c426599765b1bd33217ec84023033672c1e9a8b35eaeaaaf8",
+                "sha256:6f6c7a8a57e9405cad7485f4c9d3172ae486cfef1344b5ddd8e5239582d7355e",
+                "sha256:7381c66e0561c5757ffe616af869b916c8b4e42b367ab29fedc98481d1e74e14",
+                "sha256:73dc03a6a7e30b7edc5b01b601e53e7fc924b04e1835e8e407c12c037e81adbd",
+                "sha256:74db0052d985cf37fa111828d0dd230776ac99c740e1a758ad99094be4f1803d",
+                "sha256:75f2568b4189dda1c567339b48cba4ac7384accb9c2a7ed655cd86b04055c795",
+                "sha256:78cacd03e79d009d95635e7d6ff12c21eb89b894c354bd2b2ed0b4763373693b",
+                "sha256:80d1543d58bd3d6c271b66abf454d437a438dff01c3e62fdbcd68f2a11310d4b",
+                "sha256:830d2948a5ec37c386d3170c483063798d7879037492540f10a475e3fd6f244b",
+                "sha256:891cf9b48776b5c61c700b55a598621fdb7b1e301a550365571e9624f270c203",
+                "sha256:8f25e17ab3039b05f762b0a55ae0b3632b2e073d9c8fc88e89aca31a6198e88f",
+                "sha256:9a3267620866c9d17b959a84dd0bd2d45719b817245e49371ead79ed4f710d19",
+                "sha256:a04f86f41a8916fe45ac5024ec477f41f886b3c435da2d4e3d2709b22ab02af1",
+                "sha256:aaf53a6cebad0eae578f062c7d462155eada9c172bd8c4d250b8c1d8eb7f916a",
+                "sha256:abc1185d79f47c0a7aaf7e2412a0eb2c03b724581139193d2d82b3ad8cbb00ac",
+                "sha256:ac0aa6cd53ab9a31d397f8303f92c42f534693528fafbdb997c82bae6e477ad9",
+                "sha256:ac3775e3311661d4adace3697a52ac0bab17edd166087d493b52d4f4f553f9f0",
+                "sha256:b06f0d3bf045158d2fb8837c5785fe9ff9b8c93358be64461a1089f5da983137",
+                "sha256:b116502087ce8a6b7a5f1814568ccbd0e9f6cfd99948aa59b0e241dc57cf739f",
+                "sha256:b82fab78e0b1329e183a65260581de4375f619167478dddab510c6c6fb04d9b6",
+                "sha256:bd7163182133c0c7701b25e604cf1611c0d87712e56e88e7ee5d72deab3e76b5",
+                "sha256:c36bcbc0d5174a80d6cccf43a0ecaca44e81d25be4b7f90f0ed7bcfbb5a00909",
+                "sha256:c3af8e0f07399d3176b179f2e2634c3ce9c1301379a6b8c9c9aeecd481da494f",
+                "sha256:c84132a54c750fda57729d1e2599bb598f5fa0344085dbde5003ba429a4798c0",
+                "sha256:cb7b2ab0188829593b9de646545175547a70d9a6e2b63bf2cd87a0a391599324",
+                "sha256:cca4def576f47a09a943666b8f829606bcb17e2bc2d5911a46c8f8da45f56755",
+                "sha256:cf6511efa4801b9b38dc5546d7547d5b5c6ef4b081c60b23e4d941d0eba9cbeb",
+                "sha256:d16fd5252f883eb074ca55cb622bc0bee49b979ae4e8639fff6ca3ff44f9f854",
+                "sha256:d2686f91611f9e17f4548dbf050e75b079bbc2a82be565832bc8ea9047b61c8c",
+                "sha256:d7fc3fca01da18fbabe4625d64bb612b533533ed10045a2ac3dd194bfa656b60",
+                "sha256:dd5653e67b149503c68c4018bf07e42eeed6b4e956b24c00ccdf93ac79cdff84",
+                "sha256:de5695a6f1d8340b12a5d6d4484290ee74d61e467c39ff03b39e30df62cf83a0",
+                "sha256:e0ac8959c929593fee38da1c2b64ee9778733cdf03c482c9ff1d508b6b593b2b",
+                "sha256:e1b25e3ad6c909f398df8921780d6a3d120d8c09466720226fc621605b6f92b1",
+                "sha256:e633940f28c1e913615fd624fcdd72fdba807bf53ea6925d6a588e84e1151531",
+                "sha256:e89df2958e5159b811af9ff0f92614dabf4ff617c03a4c1c6ff53bf1c399e0e1",
+                "sha256:ea9f9c6034ea2d93d9147818f17c2a0860d41b71c38b9ce4d55f21b6f9165a11",
+                "sha256:f645caaf0008bacf349875a974220f1f1da349c5dbe7c4ec93048cdc785a3326",
+                "sha256:f8303414c7b03f794347ad062c0516cee0e15f7a612abd0ce1e25caf6ceb47df",
+                "sha256:fca62a8301b605b954ad2e9c3666f9d97f63872aa4efcae5492baca2056b74ab"
             ],
-            "markers": "python_full_version >= '3.6.0'",
-            "version": "==2.1.1"
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==3.1.0"
         },
         "click": {
             "hashes": [

--- a/lib/live_cluster/manage_controller.py
+++ b/lib/live_cluster/manage_controller.py
@@ -1771,7 +1771,6 @@ class ManageConfigNamespaceController(ManageConfigLeafController):
 
         # Config params that require another to be set.
         self.param_pairs = {
-            "compression-level": "enable-compression",
             "ship-sets": "ship-only-specified-sets",
         }
 
@@ -1804,7 +1803,7 @@ class ManageConfigNamespaceController(ManageConfigLeafController):
                 )
             )
 
-        if param in self.param_pairs.keys():
+        if param in self.param_pairs:
             self.view.print_result(
                 'The parameter "{}" must also be set.'.format(self.param_pairs[param])
             )
@@ -1970,7 +1969,7 @@ class ManageConfigXDRDCController(ManageConfigLeafController):
         title = "Set XDR DC param {} to {}".format(param, value)
         self.view.print_info_responses(title, resp, self.cluster, **self.mods)
 
-        if param in self.param_pairs.keys():
+        if param in self.param_pairs:
             self.view.print_result(
                 'The parameter "{}" must also be set.'.format(self.param_pairs[param])
             )
@@ -2138,6 +2137,11 @@ class ManageConfigXDRDCNamespaceController(ManageConfigLeafController):
         self.modifiers = set(["with"])
         self.controller_arg = "ns"
 
+        # Config params that require another to be set.
+        self.param_pairs = {
+            "compression-level": "enable-compression",
+        }
+
     async def _do_default(self, line):
         param, value = self.extract_param_value(line)
         dc = self.mods["dc"][0]
@@ -2156,6 +2160,11 @@ class ManageConfigXDRDCNamespaceController(ManageConfigLeafController):
 
         title = "Set XDR Namespace Param {} to {}".format(param, value)
         self.view.print_info_responses(title, resp, self.cluster, **self.mods)
+
+        if param in self.param_pairs:
+            self.view.print_result(
+                'The parameter "{}" must also be set.'.format(self.param_pairs[param])
+            )
 
 
 @CommandHelp(

--- a/lib/live_cluster/manage_controller.py
+++ b/lib/live_cluster/manage_controller.py
@@ -1769,11 +1769,6 @@ class ManageConfigNamespaceController(ManageConfigLeafController):
         }
         self.require_recluster = set(["prefer-uniform-balance", "rack-id"])
 
-        # Config params that require another to be set.
-        self.param_pairs = {
-            "ship-sets": "ship-only-specified-sets",
-        }
-
     async def _do_default(self, line):
         param, value = self.extract_param_value(line)
         namespace = self.mods["namespace"][0]
@@ -1801,11 +1796,6 @@ class ManageConfigNamespaceController(ManageConfigLeafController):
                 'Run "manage recluster" for your changes to {} to take affect.'.format(
                     param
                 )
-            )
-
-        if param in self.param_pairs:
-            self.view.print_result(
-                'The parameter "{}" must also be set.'.format(self.param_pairs[param])
             )
 
 
@@ -1943,10 +1933,6 @@ class ManageConfigXDRDCController(ManageConfigLeafController):
             "add": ManageConfigXDRDCAddController,
             "remove": ManageConfigXDRDCRemoveController,
         }
-        self.param_pairs = {
-            "auth-user": "auth-password-file",
-            "auth-password-file": "auth-user",
-        }
 
     def execute_help(self, line, indent=0, method=None):
         return super().execute_help(
@@ -1968,11 +1954,6 @@ class ManageConfigXDRDCController(ManageConfigLeafController):
 
         title = "Set XDR DC param {} to {}".format(param, value)
         self.view.print_info_responses(title, resp, self.cluster, **self.mods)
-
-        if param in self.param_pairs:
-            self.view.print_result(
-                'The parameter "{}" must also be set.'.format(self.param_pairs[param])
-            )
 
 
 @CommandHelp("")
@@ -2137,11 +2118,6 @@ class ManageConfigXDRDCNamespaceController(ManageConfigLeafController):
         self.modifiers = set(["with"])
         self.controller_arg = "ns"
 
-        # Config params that require another to be set.
-        self.param_pairs = {
-            "compression-level": "enable-compression",
-        }
-
     async def _do_default(self, line):
         param, value = self.extract_param_value(line)
         dc = self.mods["dc"][0]
@@ -2160,11 +2136,6 @@ class ManageConfigXDRDCNamespaceController(ManageConfigLeafController):
 
         title = "Set XDR Namespace Param {} to {}".format(param, value)
         self.view.print_info_responses(title, resp, self.cluster, **self.mods)
-
-        if param in self.param_pairs:
-            self.view.print_result(
-                'The parameter "{}" must also be set.'.format(self.param_pairs[param])
-            )
 
 
 @CommandHelp(

--- a/test/unit/live_cluster/test_manage_controller.py
+++ b/test/unit/live_cluster/test_manage_controller.py
@@ -882,10 +882,6 @@ class ManageConfigControllerTest(asynctest.TestCase):
 
         await self.controller.execute(line.split())
 
-        self.view_mock.print_result.assert_called_once_with(
-            'The parameter "enable-compression" must also be set.'
-        )
-
     async def test_set_prompt(self):
         line = "namespace test-ns set test-set param test-param to test-value with 1.1.1.1 2.2.2.2"
         self.prompt_mock.return_value = False
@@ -1197,25 +1193,28 @@ class ManageConfigControllerTest(asynctest.TestCase):
         self.cluster_mock.info_set_config_xdr.assert_not_called()
 
     async def test_XDR_dc_namespace_success(self):
-        line = "xdr dc test-dc namespace test-ns param test-param to test-value with 1.1.1.1 2.2.2.2"
+        line = "xdr dc test-dc namespace test-ns param compression-level to test-value with 1.1.1.1 2.2.2.2"
         resp = {"1.1.1.1": ASINFO_RESPONSE_OK, "2.2.2.2": "ASInfoConfigError"}
         self.cluster_mock.info_set_config_xdr.return_value = resp
 
         await self.controller.execute(line.split())
 
         self.cluster_mock.info_set_config_xdr.assert_called_once_with(
-            "test-param",
+            "compression-level",
             "test-value",
             dc="test-dc",
             namespace="test-ns",
             nodes=["1.1.1.1", "2.2.2.2"],
         )
-        title = "Set XDR Namespace Param test-param to test-value"
+        title = "Set XDR Namespace Param compression-level to test-value"
         self.view_mock.print_info_responses.assert_called_once_with(
             title,
             resp,
             self.cluster_mock,
             **self._get_controller_mods(self.controller, ["xdr", "dc", "namespace"]),
+        )
+        self.view_mock.print_result.assert_called_once_with(
+            'The parameter "enable-compression" must also be set.'
         )
 
 

--- a/test/unit/live_cluster/test_manage_controller.py
+++ b/test/unit/live_cluster/test_manage_controller.py
@@ -1035,9 +1035,6 @@ class ManageConfigControllerTest(asynctest.TestCase):
         self.view_mock.print_info_responses(
             title, resp, self.cluster_mock, **self.controller.mods
         )
-        self.view_mock.print_result.assert_called_once_with(
-            'The parameter "auth-password-file" must also be set.'
-        )
 
     async def test_XDR_dc_add_node_prompt(self):
         line = "xdr dc test-dc add node 3.3.3.3 with 1.1.1.1 2.2.2.2"
@@ -1212,9 +1209,6 @@ class ManageConfigControllerTest(asynctest.TestCase):
             resp,
             self.cluster_mock,
             **self._get_controller_mods(self.controller, ["xdr", "dc", "namespace"]),
-        )
-        self.view_mock.print_result.assert_called_once_with(
-            'The parameter "enable-compression" must also be set.'
         )
 
 


### PR DESCRIPTION
We were displaying the message for the namespace context when it should have been for the xdr/dc/namespace context