### PR TITLE
fix: TOOLS-2538 not able to parse collectinfo files

### DIFF
--- a/lib/collectinfo_analyzer/collectinfo_handler/collectinfo_log.py
+++ b/lib/collectinfo_analyzer/collectinfo_handler/collectinfo_log.py
@@ -163,12 +163,10 @@ class _CollectinfoSnapshot:
                 )
 
                 # "node_name" was stored in collectinfo file in asadm 2.15.0
-                if not node_names_dict:
-                    node_names = self.cinfo_data.keys()
-                    for node_name in node_names:
-                        self.node_names[node_name] = node_name
-                else:
-                    for node_ips in node_names_dict:
+                for node_ips in node_names_dict:
+                    if not node_names_dict[node_ips]:
+                        self.node_names[node_ips] = node_ips
+                    else:
                         self.node_names[node_ips] = node_names_dict[node_ips]
             else:
                 return {}

--- a/test/e2e/live_cluster/test_all.py
+++ b/test/e2e/live_cluster/test_all.py
@@ -97,8 +97,8 @@ class TableRenderTests(unittest.TestCase):
         ("show statistics xdr dc"),
         ("show statistics xdr namespace"),
         ("show latencies -v"),
-        # ("show distribution time_to_live"), # TODO: Causing issues on github actions
-        # ("show distribution object_size"),
+        ("show distribution time_to_live"),  # TODO: Causing issues on github actions
+        ("show distribution object_size"),
         ("show mapping ip"),
         ("show mapping node"),
         ("show pmap"),
@@ -129,6 +129,12 @@ class TableRenderTests(unittest.TestCase):
         lib.create_sindex("a-index", "numeric", lib.NAMESPACE, "a", "no-error-test")
         lib.create_xdr_filter(lib.NAMESPACE, lib.DC, "kxGRSJMEk1ECo2FnZRU=")
         lib.upload_udf("metadata.lua", TEST_UDF)
+        util.run_asadm(
+            "-h {} --enable -e '{}' -Uadmin -Padmin".format(
+                lib.SERVER_IP,
+                "manage config namespace test param nsup-hist-period to 10; manage config namespace test param enable-benchmarks-write to true; manage config namespace test param enable-benchmarks-read to true",
+            )
+        )
         time.sleep(60)
         cls.collectinfo_cp = util.run_asadm(
             "-h {} -e '{}' -Uadmin -Padmin".format(


### PR DESCRIPTION
Asadm 2.15.0 can't run commands that print a 'Node' column if the collectinfo file was not created with 2.15.0