### PR TITLE
Tools 2325 keyboard interrupt except

### DIFF
--- a/asadm.py
+++ b/asadm.py
@@ -624,18 +624,16 @@ async def execute_asinfo_commands(
 
 async def main():
     loop = asyncio.get_event_loop()
+    admin_version = get_version()
 
-    if get_version == "development":
-        loop.set_debug(True)
-    else:
+    if admin_version != "development":
         # Do nothing in production. It is likely that another error occurred too that will be displayed.
         loop.set_exception_handler(lambda loop, context: None)
 
     cli_args = conf.get_cli_args()
 
-    admin_version = get_version()
-
     if cli_args.debug:
+        loop.set_debug(True)
         logger.setLevel(logging.DEBUG)
 
     if cli_args.help:
@@ -809,10 +807,7 @@ async def main():
             cleanup()
             logger.critical("Not able to connect any cluster with " + str(seeds) + ".")
 
-    try:
-        await cmdloop(shell, func, args, use_yappi, single_command)
-    except (KeyboardInterrupt, SystemExit):
-        pass
+    await cmdloop(shell, func, args, use_yappi, single_command)
     await shell.close()
 
     try:
@@ -882,5 +877,7 @@ def get_version():
 if __name__ == "__main__":
     try:
         asyncio.run(main())
+    except (KeyboardInterrupt, SystemExit):
+        sys.exit(130)
     except Exception:
         pass

--- a/asadm.py
+++ b/asadm.py
@@ -21,6 +21,7 @@ try:
 except:
     pass
 
+from signal import SIGINT, SIGTERM
 from lib.utils.logger import logger  # THIS MUST BE THE FIRST IMPORT
 from lib.base_controller import ShellException
 import inspect
@@ -308,7 +309,6 @@ class AerospikeShell(cmd.Cmd, AsyncObject):
         """Repeatedly issue a prompt, accept input, parse an initial prefix
         off the received input, and dispatch to action methods, passing them
         the remainder of the line as argument.
-
         """
 
         self.preloop()
@@ -384,9 +384,23 @@ class AerospikeShell(cmd.Cmd, AsyncObject):
                 )
 
             sys.stdout.write(terminal.reset())
+            signals = [SIGINT, SIGTERM]
+            loop = asyncio.get_event_loop()
 
             try:
-                response = await self.ctrl.execute(line)
+                task = asyncio.create_task(self.ctrl.execute(line))
+
+                if task:
+                    """
+                    Keyboard interrupts behave differently in asyncio.
+                    We need ctrl-c to propagate up through the caller rather then event loop. This
+                    is important for the 'watch' command where sometimes ctrl-c will propagate to
+                    asyncio.run() which will terminate asadm rather than return to prompt.
+                    """
+                    for signal in signals:
+                        loop.add_signal_handler(signal, task.cancel)
+
+                response = await task
 
                 if response == "EXIT":
                     return "exit"
@@ -397,8 +411,16 @@ class AerospikeShell(cmd.Cmd, AsyncObject):
                 elif response == "DISABLE":
                     self.set_default_prompt()
 
+            except asyncio.CancelledError:
+                """
+                Interrupt in the middle of executing a command.
+                """
+                pass
             except Exception as e:
                 logger.error(e)
+            finally:
+                for signal in signals:
+                    loop.remove_signal_handler(signal)
         return ""  # line was handled by execute
 
     # overloaded to support async
@@ -715,7 +737,8 @@ async def main():
 
     if not execute_only_mode:
         readline.set_completer_delims(" \t\n;")
-    shell = await AerospikeShell(
+
+    shell: AerospikeShell = await AerospikeShell(
         admin_version,
         seeds,
         user=cli_args.user,
@@ -830,7 +853,7 @@ async def cmdloop(shell, func, args, use_yappi, single_command):
     try:
         if use_yappi:
             yappi.start()
-            func(*args)
+            await func(*args)
             yappi.get_func_stats().print_all()
         else:
             await func(*args)

--- a/lib/live_cluster/live_cluster_root_controller.py
+++ b/lib/live_cluster/live_cluster_root_controller.py
@@ -121,7 +121,6 @@ class LiveClusterRootController(BaseController, AsyncObject):
         "           interrupted",
         "           watch 5 info namespace",
     )
-    @DisableAutoComplete()
     async def do_watch(self, line):
         await self.view.watch(self, line)
 

--- a/test/e2e/lib.py
+++ b/test/e2e/lib.py
@@ -463,7 +463,7 @@ def populate_db(set_name: str):
                 "int-str-mix": str(idx % 5) if idx >= 80 else idx % 10,
             }
             keys.append(key)
-            CLIENT.put(key, bins, policy=write_policy)
+            CLIENT.put(key, bins, {"ttl": 3600 * (idx + 1)}, policy=write_policy)
     except:
         print("Failed to fully populate the DB")
         raise

--- a/test/e2e/live_cluster/test_all.py
+++ b/test/e2e/live_cluster/test_all.py
@@ -119,11 +119,6 @@ class TableRenderTests(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        """
-        TODO: enable micro-benchmarks like
-        asinfo -v 'set-config:context=namespace;id=test;enable-benchmarks-write=true' -Uadmin -Padmin
-        asinfo -v 'set-config:context=namespace;id=test;enable-benchmarks-read=true' -Uadmin -Padmin
-        """
         lib.start()
         lib.populate_db("no-error-test")
         lib.create_sindex("a-index", "numeric", lib.NAMESPACE, "a", "no-error-test")
@@ -135,7 +130,7 @@ class TableRenderTests(unittest.TestCase):
                 "manage config namespace test param nsup-hist-period to 10; manage config namespace test param enable-benchmarks-write to true; manage config namespace test param enable-benchmarks-read to true",
             )
         )
-        time.sleep(60)
+        time.sleep(60000)
         cls.collectinfo_cp = util.run_asadm(
             "-h {} -e '{}' -Uadmin -Padmin".format(
                 lib.SERVER_IP, "collectinfo --output-prefix asadm_test_"

--- a/test/e2e/live_cluster/test_all.py
+++ b/test/e2e/live_cluster/test_all.py
@@ -179,6 +179,9 @@ class TableRenderTests(unittest.TestCase):
                 "This command returned no tables. There should be exactly 1 for this test."
             )
 
+        if "traceback" in cp.stderr:
+            self.fail("Traceback found in stderr")
+
         for group in stdout_dicts[0]["groups"]:
             for record in group["records"]:
                 self.assertRecordNotError(self, record)

--- a/test/e2e/live_cluster/test_all.py
+++ b/test/e2e/live_cluster/test_all.py
@@ -130,7 +130,7 @@ class TableRenderTests(unittest.TestCase):
                 "manage config namespace test param nsup-hist-period to 10; manage config namespace test param enable-benchmarks-write to true; manage config namespace test param enable-benchmarks-read to true",
             )
         )
-        time.sleep(60000)
+        time.sleep(60)
         cls.collectinfo_cp = util.run_asadm(
             "-h {} -e '{}' -Uadmin -Padmin".format(
                 lib.SERVER_IP, "collectinfo --output-prefix asadm_test_"


### PR DESCRIPTION
The main change involves configuring a signal handler on the event loop to cancel tasks when a keyboard interrupt is received. In the original code it wasn't easy to guarantee the KeyboardInterrupt exception would propagate up as you would expect a normal exception to in a sync environment. Setting a CancelError exception makes the exception propagate as you'd expect rather than boil up to the event loop. We can play with this more in a code review if you'd like.

The last change is a small refactor of the watch controller and view logic. I moved stripped out some of the execution code from the view.watch method and put it in the controller to match the rest of the code design. Now the view code only displays, and the controller loops and executes the desired function. There is also a slight refactor of the arg/flag parsing. You might want to choose the split view when diffing.

If you would like to test out the watch function just run asadm -e 'watch 1 info net'