### PR TITLE
feat: TOOLS-2543 improve asadm help output

### DIFF
--- a/lib/base_controller.py
+++ b/lib/base_controller.py
@@ -676,9 +676,9 @@ class CommandController(BaseController):
             if not self.mods[mod]:
                 self.execute_help(line)
                 if mod == "line":
-                    raise IOError("Missing required argument")
+                    raise ShellException("Missing required argument")
 
-                raise IOError("{} is required".format(mod))
+                raise ShellException("{} is required".format(mod))
 
     def pre_command(self, line):
         mods = self.modifiers | self.required_modifiers

--- a/lib/base_controller.py
+++ b/lib/base_controller.py
@@ -617,7 +617,7 @@ class BaseController(object):
     async def _do_default(self, line):
         # Override method to provide default command behavior
         self.execute_help(line)
-        self.logger.error("%s: command not found." % (" ".join(line)))
+        raise ShellException("%s: command not found." % (" ".join(line)))
 
     def pre_command(self, line):
         """

--- a/lib/base_controller.py
+++ b/lib/base_controller.py
@@ -277,16 +277,10 @@ class BaseController(object):
             else:
                 self.commands.add(command[1], func)
 
-        try:
-            if self.mods:
-                pass
-        except Exception:
-            self.mods = {}
-
         for command, controller in self.controller_map.items():
             self.commands.add(command, controller())
 
-    def _set_controller_context(self):
+    def _set_command_contexts(self):
         for command in self.controller_map:
             controller: BaseController = self.commands[command][0]
             context_cpy = list(self._context)
@@ -381,7 +375,7 @@ class BaseController(object):
         self._init_controller_map()
         self._init_context()
         self._init_commands()
-        self._set_controller_context()
+        self._set_command_contexts()
 
     def _find_method(self, line):
         method = None

--- a/lib/collectinfo_analyzer/collectinfo_root_controller.py
+++ b/lib/collectinfo_analyzer/collectinfo_root_controller.py
@@ -62,9 +62,11 @@ class CollectinfoRootController(BaseController):
         return "EXIT"
 
     @CommandHelp(
-        "Returns documentation related to a command.",
-        'for example, to retrieve documentation for the "info"',
-        'command use "help info".',
+        "Displays the documentation for the specified command.",
+        "For example, to see the documentation for the 'info' command,",
+        "use the command 'help info'.",
+        short_msg="Displays the documentation for the specified command",
+        hide=True,
     )
     def do_help(self, line):
         self.execute_help(line)

--- a/lib/collectinfo_analyzer/collectinfo_root_controller.py
+++ b/lib/collectinfo_analyzer/collectinfo_root_controller.py
@@ -69,4 +69,4 @@ class CollectinfoRootController(BaseController):
         hide=True,
     )
     def do_help(self, line):
-        self.execute_help(line)
+        self.view.print_result(self.execute_help(line))

--- a/lib/collectinfo_analyzer/features_controller.py
+++ b/lib/collectinfo_analyzer/features_controller.py
@@ -15,11 +15,17 @@
 from lib.collectinfo_analyzer.collectinfo_command_controller import (
     CollectinfoCommandController,
 )
-from lib.base_controller import CommandHelp
+from lib.base_controller import CommandHelp, ModifierHelp
 from lib.utils import constants, common
 
 
-@CommandHelp("Displays features used in Aerospike cluster.")
+@CommandHelp(
+    "Lists the features in use in a running Aerospike cluster.",
+    usage=f"[{constants.Modifiers.LIKE} <feature-substring>]",
+    modifiers=(
+        ModifierHelp(constants.Modifiers.LIKE, "Filter features by substring match"),
+    ),
+)
 class FeaturesController(CollectinfoCommandController):
     def __init__(self):
         self.modifiers = set(["like"])
@@ -78,5 +84,5 @@ class FeaturesController(CollectinfoCommandController):
                 features,
                 self.log_handler.get_cinfo_log_at(timestamp=timestamp),
                 timestamp=timestamp,
-                **self.mods
+                **self.mods,
             )

--- a/lib/collectinfo_analyzer/health_check_controller.py
+++ b/lib/collectinfo_analyzer/health_check_controller.py
@@ -14,7 +14,7 @@
 
 import copy
 
-from lib.base_controller import CommandHelp
+from lib.base_controller import CommandHelp, ModifierHelp
 import lib.health as health
 from lib.utils import util
 
@@ -22,8 +22,28 @@ from .collectinfo_command_controller import CollectinfoCommandController
 
 
 @CommandHelp(
-    "Checks for common inconsistencies and print if there is any.",
-    "This command is still in beta and its output should not be directly acted upon without further analysis.",
+    "Displays all lines from cluster logs (collectinfos) matched with input strings.",
+    short_msg="Displays health summary",
+    usage="[-dv] [-f <query_file>] [-o <output_file>] [-oc <output_filter_category>] [-wl <output_filter_warn_level>]",
+    modifiers=(
+        ModifierHelp(
+            "-f <string>", "Query file path. Default: inbuilt health queries."
+        ),
+        ModifierHelp(
+            "-o <string>",
+            "Output file path. This parameter works if Query file path provided, otherwise health command will work in interactive mode.",
+        ),
+        ModifierHelp("-v", "Enable to display extra details of assert errors."),
+        ModifierHelp("-d", "Enable to display extra details of exceptions."),
+        ModifierHelp(
+            "-oc <string>",
+            "Output filter Category. This parameter works if Query file path provided, otherwise health command will work in interactive mode. Format: string of dot (.) separated category levels",
+        ),
+        ModifierHelp(
+            "-wl <string>",
+            "Output filter Warning level. Expected value CRITICAL or WARNING or INFO. This parameter works if Query file path provided, otherwise health command will work in interactive mode.",
+        ),
+    ),
 )
 class HealthCheckController(CollectinfoCommandController):
     health_check_input_created = False
@@ -31,20 +51,6 @@ class HealthCheckController(CollectinfoCommandController):
     def __init__(self):
         self.modifiers = set()
 
-    @CommandHelp(
-        "Displays all lines from cluster logs (collectinfos) matched with input strings.",
-        "  Options:",
-        "    -f <string>     - Query file path. Default: inbuilt health queries.",
-        "    -o <string>     - Output file path. ",
-        "                      This parameter works if Query file path provided, otherwise health command will work in interactive mode.",
-        "    -v              - Enable to display extra details of assert errors.",
-        "    -d              - Enable to display extra details of exceptions.",
-        "    -oc <string>    - Output filter Category. ",
-        "                      This parameter works if Query file path provided, otherwise health command will work in interactive mode.",
-        "                      Format : string of dot (.) separated category levels",
-        "    -wl <string>    - Output filter Warning level. Expected value CRITICAL or WARNING or INFO ",
-        "                      This parameter works if Query file path provided, otherwise health command will work in interactive mode.",
-    )
     def _do_default(self, line):
         output_file = util.get_arg_and_delete_from_mods(
             line=line,

--- a/lib/collectinfo_analyzer/info_controller.py
+++ b/lib/collectinfo_analyzer/info_controller.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from lib.base_controller import CommandHelp
+from lib.base_controller import CommandHelp, ModifierHelp
 from lib.collectinfo_analyzer.get_controller import (
     GetConfigController,
     GetStatisticsController,
@@ -21,10 +21,13 @@ from lib.utils import constants, util, version
 
 from .collectinfo_command_controller import CollectinfoCommandController
 
+Modifiers = constants.Modifiers
+ModifierUsageHelp = constants.ModifierUsage
+
 
 @CommandHelp(
-    'The "info" command provides summary tables for various aspects',
-    "of Aerospike functionality.",
+    "Commands that display summary tables for various aspects of Aerospike functionality.",
+    short_msg="Provides summary tables for various aspects of Aerospike functionality",
 )
 class InfoController(CollectinfoCommandController):
     def __init__(self):
@@ -40,7 +43,9 @@ class InfoController(CollectinfoCommandController):
         await self.controller_map["namespace"]()(line[:])
         self.do_xdr(line)
 
-    @CommandHelp("Displays network summary information.")
+    @CommandHelp(
+        "Displays network information for the cluster",
+    )
     def do_network(self, line):
         service_stats = self.log_handler.info_statistics(stanza=constants.STAT_SERVICE)
         for timestamp in sorted(service_stats.keys()):
@@ -58,7 +63,7 @@ class InfoController(CollectinfoCommandController):
                 builds,
                 cluster=cinfo_log,
                 timestamp=timestamp,
-                **self.mods
+                **self.mods,
             )
 
     def _convert_key_to_tuple(self, stats):
@@ -67,7 +72,7 @@ class InfoController(CollectinfoCommandController):
             stats[key_tuple] = stats[key]
             del stats[key]
 
-    @CommandHelp("Displays set summary information.")
+    @CommandHelp("Displays summary information for each set")
     def do_set(self, line):
         set_stats = self.stats_getter.get_sets()
 
@@ -79,10 +84,16 @@ class InfoController(CollectinfoCommandController):
                 set_stats[timestamp],
                 self.log_handler.get_cinfo_log_at(timestamp=timestamp),
                 timestamp=timestamp,
-                **self.mods
+                **self.mods,
             )
 
-    @CommandHelp("Displays Cross Datacenter Replication (XDR) summary information.")
+    @CommandHelp(
+        "Displays summary information for each datacenter",
+        usage=f"[for <dc-substring>]",
+        modifiers=(
+            ModifierHelp(Modifiers.FOR, "Filter datacenters using a substring match"),
+        ),
+    )
     def do_xdr(self, line):
         old_stats = self.stats_getter.get_xdr()
         new_stats = self.stats_getter.get_xdr_dcs(for_mods=self.mods["for"])
@@ -112,7 +123,7 @@ class InfoController(CollectinfoCommandController):
                     xdr_enable,
                     cluster=cinfo_log,
                     timestamp=timestamp,
-                    **self.mods
+                    **self.mods,
                 )
 
             if old_xdr_stats:
@@ -122,13 +133,13 @@ class InfoController(CollectinfoCommandController):
                     xdr_enable,
                     cluster=cinfo_log,
                     timestamp=timestamp,
-                    **self.mods
+                    **self.mods,
                 )
 
     # pre 5.0
     @CommandHelp(
-        "Displays datacenter summary information.",
-        'Replaced by "info xdr" for server >= 5.0.',
+        'Displays summary information for each datacenter. Replaced by "info xdr" for server >= 5.0.',
+        hide=True,
     )
     def do_dc(self, line):
         dc_stats = self.log_handler.info_statistics(stanza=constants.STAT_DC, flip=True)
@@ -190,7 +201,7 @@ class InfoController(CollectinfoCommandController):
                     util.flip_keys(dc_stats[timestamp]),
                     self.log_handler.get_cinfo_log_at(timestamp=timestamp),
                     timestamp=timestamp,
-                    **self.mods
+                    **self.mods,
                 )
 
             if nodes_running_v5_or_higher:
@@ -200,7 +211,9 @@ class InfoController(CollectinfoCommandController):
                     + "Use 'info xdr' instead."
                 )
 
-    @CommandHelp("Displays secondary index (SIndex) summary information).")
+    @CommandHelp(
+        "Displays summary information for Secondary Indexes",
+    )
     def do_sindex(self, line):
         sindex_stats = self.stats_getter.get_sindex()
         ns_configs = self.config_getter.get_namespace()
@@ -214,13 +227,13 @@ class InfoController(CollectinfoCommandController):
                 ns_configs[timestamp],
                 self.log_handler.get_cinfo_log_at(timestamp=timestamp),
                 timestamp=timestamp,
-                **self.mods
+                **self.mods,
             )
 
 
 @CommandHelp(
-    'The "namespace" command provides summary tables for various aspects',
-    "of Aerospike namespaces.",
+    "A collection of commands that display summary tables for various aspects of Aerospike namespaces",
+    short_msg="Provides summary tables for various aspects of Aerospike functionality",
 )
 class InfoNamespaceController(CollectinfoCommandController):
     def __init__(self):
@@ -228,12 +241,12 @@ class InfoNamespaceController(CollectinfoCommandController):
         self.config_getter = GetConfigController(self.log_handler)
         self.stat_getter = GetStatisticsController(self.log_handler)
 
-    @CommandHelp("Displays usage and objects information for namespaces")
+    @CommandHelp("Displays usage and objects information for each namespace")
     def _do_default(self, line):
         self.do_usage(line)
         self.do_object(line)
 
-    @CommandHelp("Displays usage information for each namespace.")
+    @CommandHelp("Displays usage information for each namespace")
     def do_usage(self, line):
         ns_stats = self.stat_getter.get_namespace()
 
@@ -245,7 +258,7 @@ class InfoNamespaceController(CollectinfoCommandController):
                 ns_stats[timestamp],
                 self.log_handler.get_cinfo_log_at(timestamp=timestamp),
                 timestamp=timestamp,
-                **self.mods
+                **self.mods,
             )
 
     @CommandHelp("Displays object information for each namespace.")
@@ -263,5 +276,5 @@ class InfoNamespaceController(CollectinfoCommandController):
                 rack_ids.get(timestamp, {}),
                 self.log_handler.get_cinfo_log_at(timestamp=timestamp),
                 timestamp=timestamp,
-                **self.mods
+                **self.mods,
             )

--- a/lib/collectinfo_analyzer/list_controller.py
+++ b/lib/collectinfo_analyzer/list_controller.py
@@ -18,16 +18,13 @@ from lib.base_controller import CommandHelp
 from .collectinfo_command_controller import CollectinfoCommandController
 
 
+@CommandHelp("Displays all added collectinfos files.")
 class ListController(CollectinfoCommandController):
     def __init__(self):
         self.controller_map = {}
         self.modifiers = set()
 
-    def _do_default(self, line):
-        self.do_all(line)
-
-    @CommandHelp("Displays list of all added collectinfos files.")
-    def do_all(self, line):
+    def _do_all(self, line):
         cinfo_logs = self.log_handler.all_cinfo_logs
         for timestamp, snapshot in cinfo_logs.items():
             print(
@@ -37,3 +34,6 @@ class ListController(CollectinfoCommandController):
                 + ": "
                 + str(snapshot.cinfo_file)
             )
+
+    def _do_default(self, line):
+        self._do_all(line)

--- a/lib/collectinfo_analyzer/page_controller.py
+++ b/lib/collectinfo_analyzer/page_controller.py
@@ -23,9 +23,6 @@ class PagerController(CollectinfoCommandController):
     def __init__(self):
         self.modifiers = set()
 
-    def _do_default(self, line):
-        self.execute_help(line)
-
     @CommandHelp(
         "Displays output with vertical and horizontal paging for each output table same as linux 'less' command. Use arrow keys to scroll output and 'q' to end page for table. All linux less commands can work in this pager option.",
         short_msg="Enables output paging. Similar to linux 'less'",

--- a/lib/collectinfo_analyzer/page_controller.py
+++ b/lib/collectinfo_analyzer/page_controller.py
@@ -18,7 +18,7 @@ from lib.view.view import CliView
 from .collectinfo_command_controller import CollectinfoCommandController
 
 
-@CommandHelp("Set pager for output")
+@CommandHelp("Turn terminal pager on or off")
 class PagerController(CollectinfoCommandController):
     def __init__(self):
         self.modifiers = set()
@@ -27,14 +27,13 @@ class PagerController(CollectinfoCommandController):
         self.execute_help(line)
 
     @CommandHelp(
-        "Displays output with vertical and horizontal paging for each output table same as linux 'less' command.",
-        "Use arrow keys to scroll output and 'q' to end page for table.",
-        "All linux less commands can work in this pager option.",
+        "Displays output with vertical and horizontal paging for each output table same as linux 'less' command. Use arrow keys to scroll output and 'q' to end page for table. All linux less commands can work in this pager option.",
+        short_msg="Enables output paging. Similar to linux 'less'",
     )
     def do_on(self, line):
         CliView.pager = CliView.LESS
 
-    @CommandHelp("Removes pager and prints output normally")
+    @CommandHelp("Disables paging and prints output normally")
     def do_off(self, line):
         CliView.pager = CliView.NO_PAGER
 

--- a/lib/collectinfo_analyzer/show_controller.py
+++ b/lib/collectinfo_analyzer/show_controller.py
@@ -18,12 +18,40 @@ from lib.collectinfo_analyzer.get_controller import (
     GetStatisticsController,
 )
 from lib.utils import common, constants, util
-from lib.base_controller import CommandHelp, CommandName
+from lib.base_controller import CommandHelp, CommandName, ModifierHelp
 
 from .collectinfo_command_controller import CollectinfoCommandController
 
+Modifiers = constants.Modifiers
+ModifierUsage = constants.ModifierUsage
 
-@CommandHelp('"show" is used to display Aerospike Statistics and', "configuration.")
+for_ns_modifier_help = ModifierHelp(
+    Modifiers.FOR,
+    "Filter by namespace using a substring match",
+)
+
+diff_row_modifier_help = ModifierHelp(
+    Modifiers.DIFF,
+    "Only display rows and values that differ between nodes.",
+)
+diff_col_modifier_help = ModifierHelp(
+    Modifiers.DIFF,
+    "Only display columns and values that differ between nodes.",
+)
+
+like_stat_modifier_help = ModifierHelp(
+    Modifiers.LIKE, "Filter by statistic substring match"
+)
+like_config_modifier_help = ModifierHelp(
+    Modifiers.LIKE, "Filter by configuration parameter substring match"
+)
+like_stat_usage = f"{Modifiers.LIKE} <stat-substring>"
+like_config_usage = f"{Modifiers.LIKE} <config-substring>"
+
+
+@CommandHelp(
+    "A collection of commands used to display information about the Aerospike cluster"
+)
 class ShowController(CollectinfoCommandController):
     def __init__(self):
         self.controller_map = {
@@ -48,19 +76,35 @@ class ShowController(CollectinfoCommandController):
         self.execute_help(line)
 
 
-@CommandHelp('"show config" is used to display Aerospike configuration settings')
+repeat_modifier_help = ModifierHelp(
+    "-r",
+    "Repeat output table title and row header after every <terminal width> columns.",
+    default="False",
+)
+flip_config_modifier = ModifierHelp(
+    "--flip",
+    "Flip output table to show Nodes on Y axis and config on X axis.",
+)
+
+
+@CommandHelp(
+    "A collection of commands that display configuration settings",
+    usage=f"[-r] [--flip] [{Modifiers.DIFF}] [{like_config_usage}]",
+    modifiers=(
+        repeat_modifier_help,
+        flip_config_modifier,
+        diff_row_modifier_help,
+        like_config_modifier_help,
+    ),
+)
 class ShowConfigController(CollectinfoCommandController):
     def __init__(self):
-        self.modifiers = set(["like", "diff", "for"])
+        self.modifiers = set([Modifiers.LIKE, Modifiers.DIFF, Modifiers.FOR])
         self.controller_map = {"xdr": ShowConfigXDRController}
         self.getter = GetConfigController(self.log_handler)
 
     @CommandHelp(
         "Displays security, service, network, and namespace configuration",
-        "  Options:",
-        "    -r           - Repeat output table title and row header after every <terminal width> columns.",
-        "                   default: False, no repetition.",
-        "    --flip       - Flip output table to show Nodes on Y axis and config on X axis.",
     )
     def _do_default(self, line):
         self.do_security(line[:])
@@ -69,11 +113,14 @@ class ShowConfigController(CollectinfoCommandController):
         self.do_namespace(line[:])
 
     @CommandHelp(
-        "Displays service configuration",
-        "  Options:",
-        "    -r           - Repeat output table title and row header after every <terminal width> columns.",
-        "                   default: False, no repetition.",
-        "    --flip       - Flip output table to show Nodes on Y axis and config on X axis.",
+        "Displays security configuration",
+        usage=f"[-r] [--flip] [{Modifiers.DIFF}] [{like_config_usage}]",
+        modifiers=(
+            repeat_modifier_help,
+            flip_config_modifier,
+            diff_row_modifier_help,
+            like_config_modifier_help,
+        ),
     )
     def do_security(self, line):
         title_every_nth = util.get_arg_and_delete_from_mods(
@@ -116,10 +163,13 @@ class ShowConfigController(CollectinfoCommandController):
 
     @CommandHelp(
         "Displays service configuration",
-        "  Options:",
-        "    -r           - Repeat output table title and row header after every <terminal width> columns.",
-        "                   default: False, no repetition.",
-        "    --flip       - Flip output table to show Nodes on Y axis and config on X axis.",
+        usage=f"[-r] [--flip] [{Modifiers.DIFF}] [{like_config_usage}]",
+        modifiers=(
+            repeat_modifier_help,
+            flip_config_modifier,
+            diff_row_modifier_help,
+            like_config_modifier_help,
+        ),
     )
     def do_service(self, line):
         title_every_nth = util.get_arg_and_delete_from_mods(
@@ -162,10 +212,13 @@ class ShowConfigController(CollectinfoCommandController):
 
     @CommandHelp(
         "Displays network configuration",
-        "  Options:",
-        "    -r           - Repeat output table title and row header after every <terminal width> columns.",
-        "                   default: False, no repetition.",
-        "    --flip       - Flip output table to show Nodes on Y axis and config on X axis.",
+        usage=f"[-r] [--flip] [{Modifiers.DIFF}] [{like_config_usage}]",
+        modifiers=(
+            repeat_modifier_help,
+            flip_config_modifier,
+            diff_row_modifier_help,
+            like_config_modifier_help,
+        ),
     )
     def do_network(self, line):
         title_every_nth = util.get_arg_and_delete_from_mods(
@@ -208,10 +261,14 @@ class ShowConfigController(CollectinfoCommandController):
 
     @CommandHelp(
         "Displays namespace configuration.",
-        "  Options:",
-        "    -r           - Repeat output table title and row header after every <terminal width> columns.",
-        "                   default: False, no repetition.",
-        "    --flip       - Flip output table to show Nodes on Y axis and config on X axis.",
+        usage=f"[-r] [--flip] [{Modifiers.DIFF}] [{Modifiers.FOR} <ns-substring>] [{like_config_usage}]",
+        modifiers=(
+            repeat_modifier_help,
+            flip_config_modifier,
+            diff_row_modifier_help,
+            for_ns_modifier_help,
+            like_config_modifier_help,
+        ),
     )
     def do_namespace(self, line):
         title_every_nth = util.get_arg_and_delete_from_mods(
@@ -255,12 +312,15 @@ class ShowConfigController(CollectinfoCommandController):
 
     # pre 5.0
     @CommandHelp(
-        "DEPRECATED: Replaced by 'show config xdr dc'",
-        "Displays datacenter configuration",
-        "  Options:",
-        "    -r           - Repeat output table title and row header after every <terminal width> columns.",
-        "                   default: False, no repetition.",
-        "    --flip       - Flip output table to show Nodes on Y axis and config on X axis.",
+        "DEPRECATED: Replaced by 'show config xdr' Displays datacenter configuration.",
+        usage=f"[-r] [--flip] [{Modifiers.DIFF}] [{like_config_usage}]",
+        modifiers=(
+            repeat_modifier_help,
+            flip_config_modifier,
+            diff_row_modifier_help,
+            like_config_modifier_help,
+        ),
+        hide=True,
     )
     def do_dc(self, line):
         title_every_nth = util.get_arg_and_delete_from_mods(
@@ -304,11 +364,22 @@ class ShowConfigController(CollectinfoCommandController):
 
 
 @CommandHelp(
-    "'show config xdr' is used to display Aerospike XDR configuration settings."
+    "A collection of commands that display xdr configuration",
+    modifiers=(
+        repeat_modifier_help,
+        flip_config_modifier,
+        diff_row_modifier_help,
+        ModifierHelp(
+            Modifiers.FOR,
+            "Filter by datacenter or namespace substring match",
+        ),
+        like_config_modifier_help,
+    ),
+    usage=f"[-r] [-flip] [{Modifiers.DIFF}] [{Modifiers.FOR} <dc-substring>|<ns-substring>] [{like_config_usage}]",
 )
 class ShowConfigXDRController(CollectinfoCommandController):
     def __init__(self):
-        self.modifiers = set(["with", "like", "diff", "for"])
+        self.modifiers = set(["like", "diff", "for"])
         self.getter = GetConfigController(self.log_handler)
 
     def _check_ns_stats_and_warn(self, xdr_ns_stats):
@@ -321,12 +392,7 @@ class ShowConfigXDRController(CollectinfoCommandController):
                     return
 
     @CommandHelp(
-        "Displays xdr, xdr datacenter, and xdr namespace configuration. Use the 'for' modifier to filter",
-        "by dc or by namespace. Use the available sub-commands for more granularity.",
-        "  Options:",
-        "    -r           - Repeat output table title and row header after every <terminal width> columns.",
-        "                   [default: False, no repetition]",
-        "    --flip      - Flip output table to show Nodes on Y axis and config on X axis.",
+        "Displays xdr, xdr datacenter, and xdr namespace configuration",
     )
     def _do_default(self, line):
         self._do_xdr(line[:])
@@ -373,11 +439,16 @@ class ShowConfigXDRController(CollectinfoCommandController):
             )
 
     @CommandHelp(
-        "Displays xdr datacenter configuration. Use the 'for' modifier to filter by dc.",
-        "  Options:",
-        "    -r           - Repeat output table title and row header after every <terminal width> columns.",
-        "                   [default: False, no repetition]",
-        "    --flip      - Flip output table to show Nodes on Y axis and config on X axis.",
+        "Displays xdr datacenter configuration",
+        short_msg="Displays xdr datacenter configuration",
+        modifiers=(
+            repeat_modifier_help,
+            flip_config_modifier,
+            diff_row_modifier_help,
+            ModifierHelp(Modifiers.FOR, "Filter by datacenter substring match"),
+            like_config_modifier_help,
+        ),
+        usage=f"[-r] [-flip] [{Modifiers.DIFF}] [{Modifiers.FOR} <dc-substring>] [{like_config_usage}]",
     )
     def do_dc(self, line):
         title_every_nth = util.get_arg_and_delete_from_mods(
@@ -417,11 +488,18 @@ class ShowConfigXDRController(CollectinfoCommandController):
             )
 
     @CommandHelp(
-        "Displays xdr namespace configuration. Use the 'for' modifier to filter by namespace and then by dc.",
-        "  Options:",
-        "    -r           - Repeat output table title and row header after every <terminal width> columns.",
-        "                   [default: False, no repetition]",
-        "    --flip      - Flip output table to show Nodes on Y axis and config on X axis.",
+        "Displays xdr namespace configuration",
+        modifiers=(
+            repeat_modifier_help,
+            flip_config_modifier,
+            diff_row_modifier_help,
+            ModifierHelp(
+                Modifiers.FOR,
+                "Filter by namespace substring match then by datacenter substring match",
+            ),
+            like_config_modifier_help,
+        ),
+        usage=f"[-r] [-flip] [{Modifiers.DIFF}] [{Modifiers.FOR} <ns-substring> [<dc-substring>]] [{like_config_usage}]",
     )
     def do_namespace(self, line):
         title_every_nth = util.get_arg_and_delete_from_mods(
@@ -461,11 +539,17 @@ class ShowConfigXDRController(CollectinfoCommandController):
             )
 
     @CommandHelp(
-        "Displays xdr filter information. Use the 'for' modifier to filter by dc and then by namespace.",
-        "  Options:",
-        "    -r           - Repeat output table title and row header after every <terminal width> columns.",
-        "                   [default: False, no repetition]",
-        "    --flip      - Flip output table to show Nodes on Y axis and config on X axis.",
+        "Displays configured xdr filters",
+        modifiers=(
+            repeat_modifier_help,
+            flip_config_modifier,
+            diff_col_modifier_help,
+            ModifierHelp(
+                Modifiers.FOR,
+                "Filter by datacenter substring match then by namespace substring match",
+            ),
+        ),
+        usage=f"[-r] [-flip] [{Modifiers.DIFF}] [{Modifiers.FOR} <dc-substring> [<ns-substring>]]",
     )
     def do_filter(self, line):
         title_every_nth = util.get_arg_and_delete_from_mods(
@@ -504,8 +588,11 @@ class ShowConfigXDRController(CollectinfoCommandController):
 
 
 @CommandHelp(
-    "Displays distribution of object sizes",
+    "A collection of commands that display the distribution of object sizes",
     "and time to live for node and a namespace.",
+    short_msg="A collection of commands that display the distribution of object sizes and time to live",
+    usage=f"[{Modifiers.FOR} <ns-substring>]",
+    modifiers=(for_ns_modifier_help,),
 )
 class ShowDistributionController(CollectinfoCommandController):
     def __init__(self):
@@ -534,14 +621,32 @@ class ShowDistributionController(CollectinfoCommandController):
                 like=self.mods["for"],
             )
 
-    @CommandHelp("Shows the distribution of TTLs for namespaces")
+    @CommandHelp(
+        "Shows the distribution of TTLs for namespaces",
+        modifiers=(for_ns_modifier_help,),
+        short_msg="Displays the distribution of Object sizes for namespace",
+        usage=f"[{Modifiers.FOR} <ns-substring>]",
+    )
     def do_time_to_live(self, line):
         return self._do_distribution("ttl", "TTL Distribution", "Seconds")
 
     @CommandHelp(
-        "Shows the distribution of Object sizes for namespaces",
-        "  Options:",
-        "    -b   - Displays byte wise distribution of Object Sizes if it is collected in collectinfo.",
+        "Displays the distribution of Object sizes for namespaces",
+        modifiers=(
+            ModifierHelp(
+                "-b",
+                "Force to show byte-wise distribution of Object Sizes.",
+                default="Record block wise distribution in percentage",
+            ),
+            ModifierHelp(
+                "-k",
+                "Maximum number of buckets to show if -b is set. It distributes objects in the same size k buckets and displays only buckets that have objects in them.",
+                default="5",
+            ),
+            for_ns_modifier_help,
+        ),
+        short_msg="Displays the distribution of Object sizes for namespace",
+        usage=f"[-b] [-k <num-buckets>] [{Modifiers.FOR} <ns-substring>]",
     )
     def do_object_size(self, line):
         byte_distribution = util.check_arg_and_delete_from_mods(
@@ -587,13 +692,16 @@ class ShowDistributionController(CollectinfoCommandController):
                 like=self.mods["for"],
             )
 
-    @CommandHelp(
-        "Shows the distribution of namespace Eviction TTLs for server version 3.7.5 and below"
-    )
-    def do_eviction(self, line):
-        return self._do_distribution("evict", "Eviction Distribution", "Seconds")
 
-
+@CommandHelp(
+    "Displays latency information for the Aerospike cluster.",
+    modifiers=(
+        for_ns_modifier_help,
+        ModifierHelp(Modifiers.LIKE, "Filter by histogram name substring match"),
+    ),
+    short_msg="Displays the server latency histograms",
+    usage=f"[{Modifiers.FOR} <ns-substring>] [like <histogram-substring>]",
+)
 class ShowLatenciesController(CollectinfoCommandController):
     def __init__(self):
         self.modifiers = set(["like", "for"])
@@ -652,7 +760,27 @@ class ShowLatenciesController(CollectinfoCommandController):
             )
 
 
-@CommandHelp("Displays statistics for Aerospike components.")
+total_modifier_help = ModifierHelp(
+    "-t",
+    "Set to show total column at the end. It contains node wise sum for statistics.",
+)
+
+flip_stats_modifier_help = flip_config_modifier
+flip_stats_modifier_help.msg = (
+    "Flip output table to show Nodes on Y axis and config on X axis."
+)
+
+
+@CommandHelp(
+    "A collection of commands that displays runtime statistics",
+    usage=f"[-rt] [--flip] [{ModifierUsage.LIKE}]",
+    modifiers=(
+        total_modifier_help,
+        repeat_modifier_help,
+        flip_stats_modifier_help,
+        like_stat_modifier_help,
+    ),
+)
 class ShowStatisticsController(CollectinfoCommandController):
     def __init__(self):
         self.modifiers = set(["like", "for"])
@@ -663,11 +791,6 @@ class ShowStatisticsController(CollectinfoCommandController):
 
     @CommandHelp(
         "Displays bin, set, service, and namespace statistics",
-        "  Options:",
-        "    -t           - Set to show total column at the end. It contains node wise sum for statistics.",
-        "    -r           - Repeat output table title and row header after every <terminal width> columns.",
-        "                   default: False, no repetition.",
-        "    --flip      - Flip output table to show Nodes on Y axis and stats on X axis.",
     )
     def _do_default(self, line):
         self.do_bins(line[:])
@@ -677,11 +800,13 @@ class ShowStatisticsController(CollectinfoCommandController):
 
     @CommandHelp(
         "Displays service statistics",
-        "  Options:",
-        "    -t           - Set to show total column at the end. It contains node wise sum for statistics.",
-        "    -r           - Repeat output table title and row header after every <terminal width> columns.",
-        "                   default: False, no repetition.",
-        "    --flip      - Flip output table to show Nodes on Y axis and stats on X axis.",
+        usage=f"[-rt] [--flip] [{ModifierUsage.LIKE}]",
+        modifiers=(
+            total_modifier_help,
+            repeat_modifier_help,
+            flip_stats_modifier_help,
+            like_stat_modifier_help,
+        ),
     )
     def do_service(self, line):
         show_total = util.check_arg_and_delete_from_mods(
@@ -726,12 +851,15 @@ class ShowStatisticsController(CollectinfoCommandController):
             )
 
     @CommandHelp(
-        "Displays namespace statistics. Use the 'for' modifier to filter by namespace.",
-        "  Options:",
-        "    -t           - Set to show total column at the end. It contains node wise sum for statistics.",
-        "    -r           - Repeat output table title and row header after every <terminal width> columns.",
-        "                   default: False, no repetition.",
-        "    --flip      - Flip output table to show Nodes on Y axis and stats on X axis.",
+        "Displays namespace statistics",
+        usage=f"[-rt] [--flip] [{Modifiers.FOR} <ns-substring>] [{ModifierUsage.LIKE}]",
+        modifiers=(
+            total_modifier_help,
+            repeat_modifier_help,
+            flip_stats_modifier_help,
+            for_ns_modifier_help,
+            like_stat_modifier_help,
+        ),
     )
     def do_namespace(self, line):
         show_total = util.check_arg_and_delete_from_mods(
@@ -783,12 +911,18 @@ class ShowStatisticsController(CollectinfoCommandController):
                 )
 
     @CommandHelp(
-        "Displays set statistics. Use the 'for' modifier to filter by namespace and then by set.",
-        "  Options:",
-        "    -t           - Set to show total column at the end. It contains node wise sum for statistics.",
-        "    -r           - Repeat output table title and row header after every <terminal width> columns.",
-        "                   default: False, no repetition.",
-        "    --flip      - Flip output table to show Nodes on Y axis and stats on X axis.",
+        "Displays set statistics",
+        usage=f"[-rt] [--flip] [{Modifiers.FOR} <ns-substring> [<set-substring>]] [{ModifierUsage.LIKE}]",
+        modifiers=(
+            total_modifier_help,
+            repeat_modifier_help,
+            flip_stats_modifier_help,
+            ModifierHelp(
+                Modifiers.FOR,
+                "Filter first by namespace substring match and then by set substring match",
+            ),
+            like_stat_modifier_help,
+        ),
     )
     def do_sets(self, line):
         show_total = util.check_arg_and_delete_from_mods(
@@ -835,12 +969,15 @@ class ShowStatisticsController(CollectinfoCommandController):
                 )
 
     @CommandHelp(
-        "Displays bin statistics. Use the 'for' modifier to filter by namespace.",
-        "  Options:",
-        "    -t           - Set to show total column at the end. It contains node wise sum for statistics.",
-        "    -r           - Repeat output table title and row header after every <terminal width> columns.",
-        "                   default: False, no repetition.",
-        "    --flip      - Flip output table to show Nodes on Y axis and stats on X axis.",
+        "Displays bin statistics",
+        usage=f"[-rt] [--flip] [{Modifiers.FOR} <ns-substring>] [{ModifierUsage.LIKE}]",
+        modifiers=(
+            total_modifier_help,
+            repeat_modifier_help,
+            flip_stats_modifier_help,
+            for_ns_modifier_help,
+            like_stat_modifier_help,
+        ),
     )
     def do_bins(self, line):
         show_total = util.check_arg_and_delete_from_mods(
@@ -901,13 +1038,15 @@ class ShowStatisticsController(CollectinfoCommandController):
 
     # pre 5.0
     @CommandHelp(
-        "DEPRECATED: Replaced by 'show statistics xdr dc'",
-        "Displays datacenter statistics",
-        "  Options:",
-        "    -t           - Set to show total column at the end. It contains node wise sum for statistics.",
-        "    -r           - Repeat output table title and row header after every <terminal width> columns.",
-        "                   default: False, no repetition.",
-        "    --flip      - Flip output table to show Nodes on Y axis and stats on X axis.",
+        "DEPRECATED: Replaced by 'show statistics xdr dc.' Displays datacenter statistics.",
+        usage=f"[-rt] [--flip] [{ModifierUsage.LIKE}]",
+        modifiers=(
+            total_modifier_help,
+            repeat_modifier_help,
+            flip_stats_modifier_help,
+            like_stat_modifier_help,
+        ),
+        hide=True,
     )
     def do_dc(self, line):
         show_total = util.check_arg_and_delete_from_mods(
@@ -957,12 +1096,18 @@ class ShowStatisticsController(CollectinfoCommandController):
         )
 
     @CommandHelp(
-        "Displays sindex statistics. Use the 'for' modifier to filter by namespace and then by sindex.",
-        "  Options:",
-        "    -t           - Set to show total column at the end. It contains node wise sum for statistics.",
-        "    -r           - Repeat output table title and row header after every <terminal width> columns.",
-        "                   default: False, no repetition.",
-        "    --flip       - Flip output table to show Nodes on Y axis and stats on X axis.",
+        "Displays sindex statistics",
+        usage=f"[-rt] [--flip] [{Modifiers.FOR} <ns-substring> [<sindex-substring>]] [{ModifierUsage.LIKE}]",
+        modifiers=(
+            total_modifier_help,
+            repeat_modifier_help,
+            flip_stats_modifier_help,
+            ModifierHelp(
+                Modifiers.FOR,
+                "Filter first by namespace substring and then by sindex substring",
+            ),
+            like_stat_modifier_help,
+        ),
     )
     def do_sindex(self, line):
         show_total = util.check_arg_and_delete_from_mods(
@@ -1040,7 +1185,18 @@ class ShowStatisticsController(CollectinfoCommandController):
 
 
 @CommandHelp(
-    '"show statistics xdr" is used to display xdr statistics for Aerospike components.'
+    "A collection of commands that display xdr statistics for different contexts",
+    usage=f"[-rt] [--flip] [{Modifiers.DIFF}] [{Modifiers.FOR} <dc>|<ns>]] [{ModifierUsage.LIKE}]",
+    modifiers=(
+        total_modifier_help,
+        repeat_modifier_help,
+        flip_stats_modifier_help,
+        diff_row_modifier_help,
+        like_stat_modifier_help,
+        ModifierHelp(
+            Modifiers.FOR, "Filter by datacenter or namespace substring match"
+        ),
+    ),
 )
 class ShowStatisticsXDRController(CollectinfoCommandController):
     def __init__(self):
@@ -1057,13 +1213,7 @@ class ShowStatisticsXDRController(CollectinfoCommandController):
                     return
 
     @CommandHelp(
-        "Displays xdr, xdr datacenter, and xdr namespace statistics. Use the 'for' modifier to filter by dc",
-        "or by namespace. Use the available sub-commands for more granularity.",
-        "  Options:",
-        "    -t           - Set to show total column at the end. It contains node wise sum for statistics.",
-        "    -r           - Repeat output table title and row header after every <terminal width> columns.",
-        "                   [default: False, no repetition]",
-        "    --flip       - Flip output table to show Nodes on Y axis and stats on X axis.",
+        "Displays xdr, xdr datacenter, and xdr namespace statistics",
     )
     def _do_default(self, line):
         self._do_xdr(line[:])
@@ -1116,12 +1266,16 @@ class ShowStatisticsXDRController(CollectinfoCommandController):
             )
 
     @CommandHelp(
-        "Displays xdr datacenter statistics. Use the 'for' modifier to filter by dc.",
-        "  Options:",
-        "    -t           - Set to show total column at the end. It contains node wise sum for statistics.",
-        "    -r           - Repeat output table title and row header after every <terminal width> columns.",
-        "                   [default: False, no repetition]",
-        "    --flip       - Flip output table to show Nodes on Y axis and stats on X axis.",
+        "Displays xdr datacenter statistics",
+        usage=f"[-rt] [--flip] [{Modifiers.DIFF}] [{Modifiers.FOR} <dc-substring>]] [{ModifierUsage.LIKE}]",
+        modifiers=(
+            total_modifier_help,
+            repeat_modifier_help,
+            flip_stats_modifier_help,
+            diff_row_modifier_help,
+            like_stat_modifier_help,
+            ModifierHelp(Modifiers.FOR, "Filter by datacenter substring match"),
+        ),
     )
     def do_dc(self, line):
         show_total = util.check_arg_and_delete_from_mods(
@@ -1166,15 +1320,24 @@ class ShowStatisticsXDRController(CollectinfoCommandController):
             )
 
     @CommandHelp(
-        "Displays xdr namespace statistics. Use the 'for' modifier to filter by namespace and then by dc.",
-        "  Options:",
-        "    -t           - Set to show total column at the end. It contains node wise sum for statistics.",
-        "    -r           - Repeat output table title and row header after every <terminal width> columns.",
-        "                   [default: False, no repetition]",
-        "    --flip       - Flip output table to show Nodes on Y axis and stats on X axis.",
-        "    --by-dc      - Display each datacenter as a new table rather than each namespace. Makes it easier",
-        "                   to identify issues belonging to a particular namespace",
-        "                   [default: False, by namespace]",
+        "Displays xdr namespace statistics",
+        usage=f"[-rt] [--flip] [--by-dc] [{Modifiers.DIFF}] [{Modifiers.FOR} <dc-substring> [<ns-substring>]] [{ModifierUsage.LIKE}]",
+        modifiers=(
+            total_modifier_help,
+            repeat_modifier_help,
+            flip_stats_modifier_help,
+            ModifierHelp(
+                "--by-dc",
+                "Display each datacenter as a new table rather than each namespace. This makes it easier to identify issues belonging to a particular namespace.",
+                default="False",
+            ),
+            diff_row_modifier_help,
+            like_stat_modifier_help,
+            ModifierHelp(
+                Modifiers.FOR,
+                "Filter first by datacenter and then by namespace substring match",
+            ),
+        ),
     )
     def do_namespace(self, line):
         show_total = util.check_arg_and_delete_from_mods(
@@ -1249,13 +1412,20 @@ class ShowPmapController(CollectinfoCommandController):
             )
 
 
-@CommandHelp("Displays users and their assigned roles for Aerospike cluster.")
+@CommandHelp(
+    "A collection of commands that display user configuration and statistics",
+    usage=f"[user]",
+    modifiers=(ModifierHelp("user", "Display output for a single user."),),
+)
 class ShowUsersController(CollectinfoCommandController):
     def __init__(self):
         self.modifiers = set(["like"])
         self.controller_map = {"statistics": ShowUsersStatsController}
         self.getter = GetAclController(self.log_handler)
 
+    @CommandHelp(
+        "Displays users and their assigned roles and quotas",
+    )
     def _do_default(self, line):
         user = None
 
@@ -1278,10 +1448,10 @@ class ShowUsersController(CollectinfoCommandController):
 
 
 @CommandHelp(
-    "Displays users, open connections, and quota usage",
-    "for the Aerospike cluster.",
-    "Usage: users [user]",
-    "  user          - Display output for a single user.",
+    "Displays users, open connections, and quota usage for the Aerospike cluster.",
+    modifiers=(ModifierHelp("user", "Display output for a single user."),),
+    short_msg="Displays users, open connections, and quota usage",
+    usage=f"[user]",
 )
 class ShowUsersStatsController(CollectinfoCommandController):
     def __init__(self):
@@ -1313,7 +1483,10 @@ class ShowUsersStatsController(CollectinfoCommandController):
 
 
 @CommandHelp(
-    "Displays roles and their assigned privileges and allowlist for Aerospike cluster."
+    "Displays roles and their assigned privileges, allowlist, and quotas for the Aerospike cluster.",
+    modifiers=(ModifierHelp("role", "Display output for a single role"),),
+    short_msg="Displays roles and their assigned privileges, allowlist, and quotas",
+    usage="[role]",
 )
 class ShowRolesController(CollectinfoCommandController):
     def __init__(self):
@@ -1330,7 +1503,13 @@ class ShowRolesController(CollectinfoCommandController):
             self.view.show_roles(data, timestamp=timestamp, **self.mods)
 
 
-@CommandHelp("Displays UDF modules along with metadata.")
+@CommandHelp(
+    "Displays UDF modules along with metadata.",
+    modifiers=(
+        ModifierHelp(Modifiers.LIKE, "Filter UDFs by name using a substring match"),
+    ),
+    usage=f"[{ModifierUsage.LIKE}]",
+)
 class ShowUdfsController(CollectinfoCommandController):
     def __init__(self):
         self.modifiers = set(["like"])
@@ -1349,7 +1528,13 @@ class ShowUdfsController(CollectinfoCommandController):
             self.view.show_udfs(data, timestamp=timestamp, **self.mods)
 
 
-@CommandHelp("Displays secondary indexes and static metadata.")
+@CommandHelp(
+    "Displays secondary indexes and static metadata.",
+    modifiers=(
+        ModifierHelp(Modifiers.LIKE, "Filter indexes by name using a substring match"),
+    ),
+    usage=f"[{ModifierUsage.LIKE}]",
+)
 class ShowSIndexController(CollectinfoCommandController):
     def __init__(self):
         self.modifiers = set(["like"])
@@ -1372,10 +1557,21 @@ class ShowSIndexController(CollectinfoCommandController):
             self.view.show_sindex(formatted_data, timestamp=timestamp, **self.mods)
 
 
-@CommandHelp("Displays roster information a node its namespaces.")
+@CommandHelp(
+    'Displays roster information per node. For easier viewing run "page on" first.',
+    modifiers=(
+        ModifierHelp(
+            "--flip", "Flip output table to show nodes on X axis and roster on Y axis."
+        ),
+        diff_col_modifier_help,
+        for_ns_modifier_help,
+    ),
+    usage=f"[--flip] [{Modifiers.DIFF}] [{Modifiers.FOR} <ns-substring>]",
+    short_msg="Displays roster information per node",
+)
 class ShowRosterController(CollectinfoCommandController):
     def __init__(self):
-        self.modifiers = set(["like", "diff"])
+        self.modifiers = set(["like", "diff", "for"])
 
     def _do_default(self, line):
         flip_output = util.check_arg_and_delete_from_mods(
@@ -1403,10 +1599,12 @@ class ShowRosterController(CollectinfoCommandController):
             )
 
 
-@CommandHelp('Displays any of Aerospike\'s violated "best-practices".')
+@CommandHelp(
+    'Displays any of Aerospike\'s violated "best-practices".',
+)
 class ShowBestPracticesController(CollectinfoCommandController):
     def __init__(self):
-        self.modifiers = set(["with"])
+        pass
 
     def _do_default(self, line):
         best_practices = self.log_handler.info_meta_data(
@@ -1425,11 +1623,11 @@ class ShowBestPracticesController(CollectinfoCommandController):
 
 
 @CommandHelp(
-    "Displays jobs and associated metadata.",
+    "A collection of commands that display jobs and associated metadata",
 )
 class ShowJobsController(CollectinfoCommandController):
     def __init__(self):
-        self.modifiers = set(["like", "trid"])
+        self.modifiers = set(["trid"])
 
     @CommandHelp(
         "Displays scans, queries, and sindex-builder jobs.",
@@ -1453,17 +1651,19 @@ class ShowJobsController(CollectinfoCommandController):
             self.view.show_jobs(title, cinfo_log, scan_data, **self.mods)
 
     @CommandHelp(
-        "Displays scan jobs.",
-        "Usage: scans [trid <trid1> [<trid2>]]",
-        "  trid          - List of transaction ids to filter for.",
+        f'Displays scan jobs. For easier viewing run "page on" first. Removed in server v. {constants.SERVER_QUERIES_ABORT_ALL_FIRST_VERSION} and later.',
+        modifiers=(ModifierHelp("trid", "List of transaction IDs to filter for."),),
+        usage=f"[trid <trid1> [<trid2>]]",
+        short_msg=f"Displays scan jobs. Removed in server v. {constants.SERVER_QUERIES_ABORT_ALL_FIRST_VERSION} and later",
     )
     def do_scans(self, line):
         self._job_helper(constants.JobType.SCAN, "Scan Jobs")
 
     @CommandHelp(
-        "Displays query jobs.",
-        "Usage: queries [trid <trid1> [<trid2>]]",
-        "  trid          - List of transaction ids to filter for.",
+        'Displays query jobs. For easier viewing run "page on" first.',
+        modifiers=(ModifierHelp("trid", "List of transaction IDs to filter for."),),
+        usage=f"[trid <trid1> [<trid2>]]",
+        short_msg="Displays query jobs",
     )
     def do_queries(self, line):
         self._job_helper(constants.JobType.QUERY, "Query Jobs")
@@ -1471,19 +1671,26 @@ class ShowJobsController(CollectinfoCommandController):
     # TODO: Should be removed eventually. "sindex-builder" was removed in server 5.7.
     # So should probably be removed when server 7.0 is supported.
     @CommandHelp(
-        "Displays sindex-builder jobs. Removed in server v. 5.7 and later.",
-        "Usage: sindex-builder [trid <trid1> [<trid2>]]",
-        "  trid          - List of transaction ids to filter for.",
+        "Displays sindex-builder jobs. Removed in server v. {} and later.".format(
+            constants.SERVER_SINDEX_BUILDER_REMOVED_VERSION
+        ),
+        modifiers=(ModifierHelp("trid", "List of transaction IDs to filter for."),),
+        usage=f"[trid <trid1> [<trid2>]]",
+        short_msg="Displays sindex-builder jobs. Removed in server v. {} and later".format(
+            constants.SERVER_SINDEX_BUILDER_REMOVED_VERSION
+        ),
     )
     @CommandName("sindex-builder")
     def do_sindex_builder(self, line):
         self._job_helper(constants.JobType.SINDEX_BUILDER, "SIndex Builder Jobs")
 
 
-@CommandHelp('Displays rack information for a rack-aware cluster".')
+@CommandHelp(
+    "Displays rack information for a rack-aware cluster",
+)
 class ShowRacksController(CollectinfoCommandController):
     def __init__(self):
-        self.modifiers = set(["with"])
+        pass
 
     def _do_default(self, line):
         racks_data = self.log_handler.info_getconfig(stanza=constants.CONFIG_RACKS)
@@ -1497,10 +1704,14 @@ class ShowRacksController(CollectinfoCommandController):
             self.view.show_racks(data, timestamp=timestamp, **self.mods)
 
 
-@CommandHelp("Displays all metrics that could trigger stop-writes.")
+@CommandHelp(
+    "Displays all metrics that could trigger stop-writes",
+    modifiers=(for_ns_modifier_help,),
+    usage=f"[{Modifiers.FOR} <ns-substring>]",
+)
 class ShowStopWritesController(CollectinfoCommandController):
     def __init__(self):
-        self.modifiers = set(["with", "for"])
+        self.modifiers = set(["for"])
         self.config_getter = GetConfigController(self.log_handler)
         self.stat_getter = GetStatisticsController(self.log_handler)
 

--- a/lib/collectinfo_analyzer/show_controller.py
+++ b/lib/collectinfo_analyzer/show_controller.py
@@ -72,9 +72,6 @@ class ShowController(CollectinfoCommandController):
         }
         self.modifiers = set()
 
-    def _do_default(self, line):
-        self.execute_help(line)
-
 
 repeat_modifier_help = ModifierHelp(
     "-r",

--- a/lib/collectinfo_analyzer/summary_controller.py
+++ b/lib/collectinfo_analyzer/summary_controller.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from lib.base_controller import CommandHelp
+from lib.base_controller import CommandHelp, ModifierHelp
 from lib.utils import common, constants, util
 
 from .collectinfo_command_controller import CollectinfoCommandController
@@ -20,9 +20,18 @@ from .collectinfo_command_controller import CollectinfoCommandController
 
 @CommandHelp(
     "Displays summary of Aerospike cluster.",
-    "  Options:",
-    "    -l                  - Enable to display namespace output in List view. Default: Table view",
-    "    --agent-unstable    - When processing UDA entries allow instances where the cluster is unstable.",
+    usage=f"[-l] [--agent-unstable]",
+    modifiers=(
+        ModifierHelp(
+            "-l",
+            "Enable to display namespace output in list view.",
+            default="table view",
+        ),
+        ModifierHelp(
+            "--agent-unstable",
+            "When processing UDA entries allow instances where the cluster is unstable.",
+        ),
+    ),
 )
 class SummaryController(CollectinfoCommandController):
     def __init__(self):

--- a/lib/live_cluster/asinfo_controller.py
+++ b/lib/live_cluster/asinfo_controller.py
@@ -12,19 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from lib.utils import util
-from lib.base_controller import CommandHelp, ShellException
+from lib.base_controller import CommandHelp, ModifierHelp, ShellException
 
 from .live_cluster_command_controller import LiveClusterCommandController
 
 
 @CommandHelp(
-    '"asinfo" provides raw access to the info protocol.',
-    "  Options:",
-    "    -v <command>   - The command to execute",
-    '    -l             - Replace semicolons ";" with newlines. If output does',
-    '                     not contain semicolons "-l" will attempt to use',
-    '                     colons ":" followed by commas ",".',
-    "    --no_node_name - Force to display output without printing node names.",
+    "Provides raw access to the info protocol.",
+    usage="[-v <command>] [-l] [--no_node_name]",
+    modifiers=(
+        ModifierHelp(
+            "-v",
+            'The command to execute, e.g. "get-stats:context=xdr;dc=dataCenterName"',
+        ),
+        ModifierHelp(
+            "-l",
+            'Replace semicolons ";" with newlines. If output does not contain semicolons "-l" will attempt to use colons ":" followed by commas ",".',
+        ),
+        ModifierHelp(
+            "--no_node_name", "Force to display output without printing node names."
+        ),
+    ),
 )
 class ASInfoController(LiveClusterCommandController):
     def __init__(self):

--- a/lib/live_cluster/features_controller.py
+++ b/lib/live_cluster/features_controller.py
@@ -12,13 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from lib.live_cluster.get_controller import GetFeaturesController
-from lib.utils import util
-from lib.base_controller import CommandHelp
+from lib.utils import constants
+from lib.base_controller import CommandHelp, ModifierHelp
 
 from .live_cluster_command_controller import LiveClusterCommandController
 
+with_modifier_help = ModifierHelp(constants.Modifiers.WITH, constants.ModifierHelp.WITH)
 
-@CommandHelp("Lists the features in use in a running Aerospike cluster.")
+
+@CommandHelp(
+    "Lists the features in use in a running Aerospike cluster.",
+    usage=f"[{constants.Modifiers.LIKE} <feature-substring>] [{constants.ModifierUsage.WITH}]",
+    modifiers=(
+        ModifierHelp(constants.Modifiers.LIKE, "Filter features by substring match"),
+        with_modifier_help,
+    ),
+)
 class FeaturesController(LiveClusterCommandController):
     def __init__(self):
         self.modifiers = set(["with", "like"])

--- a/lib/live_cluster/live_cluster_root_controller.py
+++ b/lib/live_cluster/live_cluster_root_controller.py
@@ -108,7 +108,7 @@ class LiveClusterRootController(BaseController, AsyncObject):
         hide=True,
     )
     def do_help(self, line):
-        self.execute_help(line)
+        self.view.print_result(self.execute_help(line))
 
     @CommandHelp(
         "Runs a command for a specified pause and iterations.",

--- a/lib/live_cluster/live_cluster_root_controller.py
+++ b/lib/live_cluster/live_cluster_root_controller.py
@@ -96,7 +96,7 @@ class LiveClusterRootController(BaseController, AsyncObject):
             pass
 
     # This function is a hack for autocomplete
-    @CommandHelp("Terminate session", usage="exit")
+    @CommandHelp("Terminate session")
     def do_exit(self, line):
         return "EXIT"
 

--- a/lib/live_cluster/live_cluster_root_controller.py
+++ b/lib/live_cluster/live_cluster_root_controller.py
@@ -21,6 +21,7 @@ from lib.base_controller import (
     DisableAutoComplete,
     BaseController,
     CommandHelp,
+    ModifierHelp,
     ShellException,
     create_disabled_controller,
 )
@@ -41,7 +42,7 @@ from .manage_controller import (
 )
 
 
-@CommandHelp("Aerospike Admin")
+@CommandHelp("A tool for interacting with your Aerospike cluster")
 class LiveClusterRootController(BaseController, AsyncObject):
     cluster: Cluster
 
@@ -94,11 +95,8 @@ class LiveClusterRootController(BaseController, AsyncObject):
         except Exception:
             pass
 
-    def _do_default(self, line):
-        self.execute_help(line)
-
     # This function is a hack for autocomplete
-    @CommandHelp("Terminate session")
+    @CommandHelp("Terminate session", usage="exit")
     def do_exit(self, line):
         return "EXIT"
 
@@ -106,24 +104,28 @@ class LiveClusterRootController(BaseController, AsyncObject):
         "Displays the documentation for the specified command.",
         "For example, to see the documentation for the 'info' command,",
         "use the command 'help info'.",
+        short_msg="Displays the documentation for the specified command",
+        hide=True,
     )
     def do_help(self, line):
         self.execute_help(line)
 
     @CommandHelp(
         "Runs a command for a specified pause and iterations.",
-        "Usage: watch [pause] [iterations] [--no-diff] command",
-        "   pause:      The duration between executions.",
-        "               [default: 2 seconds]",
-        "   iterations: Number of iterations to execute command.",
-        "               [default: until keyboard interrupt]",
-        "  Options:",
-        "   --no-diff:  Do not highlight differences",
-        "Example 1: Show 'info network' 3 times and pause for 1 second each time.",
-        "           watch 1 3 info network",
-        'Example 2: Show "info namespace" with 5 seconds pause until',
-        "           interrupted",
-        "           watch 5 info namespace",
+        short_msg="Runs a command for a specified pause and iterations",
+        usage="[--no-diff] [pause [iterations]] <command>",
+        modifiers=(
+            ModifierHelp(
+                "pause", "The duration between executions", default="2 seconds"
+            ),
+            ModifierHelp(
+                "iterations",
+                "Number of iterations to execute command",
+                default="until keyboard interrupt",
+            ),
+            ModifierHelp("command", "The command to execute e.g. 'info network'"),
+            ModifierHelp("--no-diff", "Do not highlight differences"),
+        ),
     )
     async def do_watch(self, line):
         sleep = 2.0
@@ -184,6 +186,8 @@ class LiveClusterRootController(BaseController, AsyncObject):
         "  Options:",
         "    --warn:    Use this option to receive a prompt to confirm",
         "               that you want to run the command.",
+        short_msg="Enters privileged mode",
+        usage="[--warn]",
     )
     def do_enable(self, line):
         warn = util.check_arg_and_delete_from_mods(
@@ -195,6 +199,10 @@ class LiveClusterRootController(BaseController, AsyncObject):
         )
         return "ENABLE"
 
+    @CommandHelp(
+        "Exits privileged mode, which protects you from issuing manage and asinfo commands.",
+        short_msg="Exits privileged mode",
+    )
     def do_disable(self, line):
         self.controller_map.update(
             {

--- a/lib/live_cluster/manage_controller.py
+++ b/lib/live_cluster/manage_controller.py
@@ -57,7 +57,8 @@ class LiveClusterManageCommandController(LiveClusterCommandController):
     def _init(self):
         self._init_controller_arg()
         self._init_controller_arg_context()
-        return super()._init()
+        super()._init()
+        self._set_controller_arg_context()
 
     def pre_controller(self, line):
         """
@@ -113,9 +114,9 @@ class LiveClusterManageCommandController(LiveClusterCommandController):
     def _print_help(self):
         return super()._print_help_helper(self, self.controller_arg_context, False)
 
-    def _init_commands(self):
-        super()._init_commands()
-        for command in self.commands.keys():
+    def _set_controller_arg_context(self):
+        # Use controller_map to only get commands that are controllers i.e. not methods
+        for command in self.controller_map:
             controller: LiveClusterManageCommandController = self.commands[command][0]
             context_cpy = list(self.controller_arg_context)
             context_cpy.append(command)
@@ -141,7 +142,10 @@ class LiveClusterManageCommandController(LiveClusterCommandController):
             if self.controller_arg_context:
                 pass
         except Exception:
-            self.controller_arg_context = self._context[:]
+            try:
+                self.controller_arg_context = self._context[:]
+            except Exception:
+                self.controller_arg_context = []
 
 
 class ManageLeafCommandController(LiveClusterManageCommandController):

--- a/lib/live_cluster/manage_controller.py
+++ b/lib/live_cluster/manage_controller.py
@@ -111,8 +111,8 @@ class LiveClusterManageCommandController(LiveClusterCommandController):
         """
         self.controller_arg_context = context
 
-    def _print_help(self):
-        return super()._print_help_helper(self, self.controller_arg_context, False)
+    def _format_help(self):
+        return super()._format_help_helper(self, self.controller_arg_context, False)
 
     def _set_controller_arg_context(self):
         # Use controller_map to only get commands that are controllers i.e. not methods

--- a/lib/live_cluster/manage_controller.py
+++ b/lib/live_cluster/manage_controller.py
@@ -110,10 +110,8 @@ class LiveClusterManageCommandController(LiveClusterCommandController):
         """
         self.controller_arg_context = context
 
-    def _print_help(self, method, context, is_method):
-        return super()._print_help(
-            method, " ".join(self.controller_arg_context), is_method
-        )
+    def _print_help(self):
+        return super()._print_help_helper(self, self.controller_arg_context, False)
 
     def _init_commands(self):
         super()._init_commands()

--- a/lib/live_cluster/pager_controller.py
+++ b/lib/live_cluster/pager_controller.py
@@ -22,9 +22,6 @@ class PagerController(LiveClusterCommandController):
     def __init__(self):
         self.modifiers = set()
 
-    def _do_default(self, line):
-        self.execute_help(line)
-
     @CommandHelp(
         "Displays output with vertical and horizontal paging for each output table same as linux 'less' command. Use arrow keys to scroll output and 'q' to end page for table. All linux less commands can work in this pager option.",
         short_msg="Enables output paging. Similar to linux 'less'",

--- a/lib/live_cluster/pager_controller.py
+++ b/lib/live_cluster/pager_controller.py
@@ -17,7 +17,7 @@ from lib.base_controller import CommandHelp
 from .live_cluster_command_controller import LiveClusterCommandController
 
 
-@CommandHelp("Set pager for output")
+@CommandHelp("Turn terminal pager on or off")
 class PagerController(LiveClusterCommandController):
     def __init__(self):
         self.modifiers = set()
@@ -26,15 +26,13 @@ class PagerController(LiveClusterCommandController):
         self.execute_help(line)
 
     @CommandHelp(
-        "Displays output with vertical and horizontal paging for each output table same as linux 'less'",
-        "command.",
-        "Use arrow keys to scroll output and 'q' to end page for table.",
-        "All linux less commands can work in this pager option.",
+        "Displays output with vertical and horizontal paging for each output table same as linux 'less' command. Use arrow keys to scroll output and 'q' to end page for table. All linux less commands can work in this pager option.",
+        short_msg="Enables output paging. Similar to linux 'less'",
     )
     def do_on(self, line):
         CliView.pager = CliView.LESS
 
-    @CommandHelp("Removes pager and prints output normally")
+    @CommandHelp("Disables paging and prints output normally")
     def do_off(self, line):
         CliView.pager = CliView.NO_PAGER
 

--- a/lib/live_cluster/show_controller.py
+++ b/lib/live_cluster/show_controller.py
@@ -221,11 +221,13 @@ class ShowDistributionController(LiveClusterCommandController):
             "-v", "Set to display verbose output of optionally configured histograms."
         ),
         for_ns_modifier_help,
-        ModifierHelp(Modifiers.LIKE, "Filter by histogram name substring match"),
+        ModifierHelp(
+            Modifiers.LIKE, "Filter by histogram name substring match", default="test"
+        ),
         with_modifier_help,
     ),
     short_msg="Displays the server latency histograms",
-    usage=f"[-e <increment>] [-b <num-buckets>] [-v] [{Modifiers.FOR} <ns-substring>] [like <histogram-substring>] {ModifierUsage.WITH}",
+    usage=f"[-e <increment>] [-b <num-buckets>] [-v] [{Modifiers.FOR} <ns-substring>] [like <histogram-substring>] [{ModifierUsage.WITH}",
 )
 class ShowLatenciesController(LiveClusterCommandController):
     def __init__(self):

--- a/lib/live_cluster/summary_controller.py
+++ b/lib/live_cluster/summary_controller.py
@@ -14,7 +14,7 @@
 import asyncio
 from typing import Union
 from lib.utils import common, util
-from lib.base_controller import CommandHelp
+from lib.base_controller import CommandHelp, ModifierHelp
 from lib.utils import constants
 
 from .live_cluster_command_controller import LiveClusterCommandController
@@ -22,30 +22,43 @@ from .live_cluster_command_controller import LiveClusterCommandController
 
 @CommandHelp(
     "Displays summary of Aerospike cluster.",
-    "  Options:",
-    "    -l                        - Enable to display namespace output in List view. Default: Table view",
-    "    --enable-ssh              - Enables the collection of system statistics from a remote server.",
-    "    --ssh-user   <string>     - Default user ID for remote servers. This is the ID of a user of the",
-    "                                system, not the ID of an Aerospike user.",
-    "    --ssh-pwd    <string>     - Default password or passphrase for key for remote servers. This is the",
-    "                                user's password for logging into the system, not a password for logging",
-    "                                into Aerospike.",
-    "    --ssh-port   <int>        - Default SSH port for remote servers. Default: 22",
-    "    --ssh-key    <string>     - Default SSH key (file path) for remote servers.",
-    "    --ssh-cf     <string>     - Remote System Credentials file path.",
-    "                                If the server credentials are not in the credentials file, then",
-    "                                authentication is attempted with the default credentials.",
-    "                                File format : each line should contain <IP[:PORT]>,<USER_ID>,",
-    "                                <PASSWORD or PASSPHRASE>,<SSH_KEY>",
-    "                                Example:  1.2.3.4,uid,pwd",
-    "                                          1.2.3.4:3232,uid,pwd",
-    "                                          1.2.3.4:3232,uid,,key_path",
-    "                                          1.2.3.4:3232,uid,passphrase,key_path",
-    "                                          [2001::1234:10],uid,pwd",
-    "                                          [2001::1234:10]:3232,uid,,key_path",
-    "    --agent-host    <host>    - Host IP of the Unique-Data-Agent (UDA) to collect license data usage.",
-    "    --agent-port    <int>     - Port of the UDA. Default: 8080",
-    "    --agent-unstable          - When processing UDA entries allow instances where the cluster is unstable.",
+    usage=f"[-l] [--enable-ssh --ssh-user <user> --ssh-pwd <pwd> [--ssh-port <port>] [--ssh-key <key_path>] [--ssh-cf <credentials_file_path>]] [--agent-host <host> --agent-port <port> [--agent-unstable]]",
+    modifiers=(
+        ModifierHelp(
+            "-l",
+            "Enable to display namespace output in list view.",
+            default="table view",
+        ),
+        ModifierHelp(
+            "--enable-ssh",
+            "Enables the collection of system statistics from a remote server.",
+        ),
+        ModifierHelp(
+            "--ssh-user",
+            "Default user ID for remote servers. This is the ID of a user of the system, not the ID of an Aerospike user.",
+        ),
+        ModifierHelp(
+            "--ssh-pwd",
+            "Default password or passphrase for key for remote servers. This is the user's password for logging into the system, not a password for logging into Aerospike.",
+        ),
+        ModifierHelp(
+            "--ssh-port", "Default SSH port for remote servers.", default="22"
+        ),
+        ModifierHelp("--ssh-key", "Default SSH key (file path) for remote servers."),
+        ModifierHelp(
+            "--ssh-cf",
+            "Remote System Credentials file path. If the server credentials are not in the credentials file, then authentication is attempted with the default credentials. File format: each line should contain <IP[:PORT]>,<USER_ID>,<PASSWORD-or-PASSPHRASE>,<SSH_KEY>. Example: 1.2.3.4,uid,pwd; 1.2.3.4:3232,uid,pwd; 1.2.3.4:3232,uid,,key_path; 1.2.3.4:3232,uid,passphrase,key_path; [2001::1234:10],uid,pwd; [2001::1234:10]:3232,uid,,key_path",
+        ),
+        ModifierHelp(
+            "--agent-host",
+            "Host IP of the Unique-Data-Agent (UDA) to collect license data usage.",
+        ),
+        ModifierHelp("--agent-port", "Port of the UDA.", default="8080"),
+        ModifierHelp(
+            "--agent-unstable",
+            "When processing UDA entries allow instances where the cluster is unstable.",
+        ),
+    ),
 )
 class SummaryController(LiveClusterCommandController):
     def __init__(self):

--- a/lib/log_analyzer/log_analyzer_root_controller.py
+++ b/lib/log_analyzer/log_analyzer_root_controller.py
@@ -61,7 +61,7 @@ class LogAnalyzerRootController(BaseController):
         hide=True,
     )
     def do_help(self, line):
-        self.execute_help(line)
+        self.view.print_result(self.execute_help(line))
 
 
 @CommandHelp(

--- a/lib/log_analyzer/log_analyzer_root_controller.py
+++ b/lib/log_analyzer/log_analyzer_root_controller.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from lib.base_controller import BaseController, CommandHelp
+from lib.base_controller import BaseController, CommandHelp, ModifierHelp
 from lib.utils import util
 from lib.view import terminal
 from lib.view.view import CliView
@@ -54,9 +54,11 @@ class LogAnalyzerRootController(BaseController):
         return "EXIT"
 
     @CommandHelp(
-        "Returns documentation related to a command",
-        'for example, to retrieve documentation for the "info"',
-        'command use "help info".',
+        "Displays the documentation for the specified command.",
+        "For example, to see the documentation for the 'count' command,",
+        "use the command 'help count'.",
+        short_msg="Displays the documentation for the specified command",
+        hide=True,
     )
     def do_help(self, line):
         self.execute_help(line)
@@ -64,23 +66,38 @@ class LogAnalyzerRootController(BaseController):
 
 @CommandHelp(
     "Displays all lines from server logs matched with input strings.",
-    "  Options:",
-    "    -s <string>  - Space seprated Strings to search in log files, MANDATORY - NO DEFAULT",
-    "                   Format -s 'string1' 'string2'... 'stringn'",
-    "    -a           - Set 'AND'ing of search strings (provided with -s): Finding lines with all search strings in it.",
-    "                   Default is 'OR'ing: Finding lines with atleast one search string in it.",
-    "    -v <string>  - Non-matching strings (space separated).",
-    "    -i           - Perform case insensitive matching of search strings (-s) and non-matching strings (-v).",
-    "                   By default it is case sensitive.",
-    "    -u           - Set to find unique lines.",
-    "    -f <string>  - Log time from which to analyze.",
-    "                   May use the following formats:  'Sep 22 2011 22:40:14', -3600, or '-1:00:00'.",
-    "                   Default: head",
-    "    -d <string>  - Maximum time period to analyze.",
-    "                   May use the following formats: 3600 or 1:00:00.",
-    "    -n <string>  - Comma separated node numbers. You can get these numbers by list command. Ex. : -n '1,2,5'.",
-    "                   If not set then runs on all server logs in selected list.",
-    "    -p <int>     - Showing output in pages with p entries per page. default: 10.",
+    modifiers=(
+        ModifierHelp(
+            "-s",
+            "Space-separated strings to search in log files. Format: -s 'string1' 'string2' ... 'stringn'",
+        ),
+        ModifierHelp(
+            "-a",
+            "Set 'AND'ing of search strings (provided with -s): Finding lines with all search strings in it. Default is 'OR'ing: Finding lines with at least one search string in it.",
+        ),
+        ModifierHelp("-v", "Non-matching strings (space separated)."),
+        ModifierHelp(
+            "-i",
+            "Perform case-insensitive matching of search strings (-s) and non-matching strings (-v)",
+        ),
+        ModifierHelp("-u", "Set to find unique lines."),
+        ModifierHelp(
+            "-f",
+            "Log time from which to analyze. May use the following formats: 'Sep 22 2011 22:40:14', -3600, or '-1:00:00'",
+            default="head",
+        ),
+        ModifierHelp(
+            "-d",
+            "Maximum time period to analyze. May use the following formats: 3600 or 1:00:00.",
+        ),
+        ModifierHelp(
+            "-n",
+            "Comma-separated node numbers. You can get these numbers by the list command. Example: -n '1,2,5'. If not set, then runs on all server logs in the selected list.",
+        ),
+        ModifierHelp(
+            "-p", "Showing output in pages with p entries per page", default="10"
+        ),
+    ),
 )
 class GrepController(LogAnalyzerCommandController):
     def __init__(self):
@@ -94,27 +111,48 @@ class GrepController(LogAnalyzerCommandController):
 
 @CommandHelp(
     "Displays count of lines from server logs matched with input strings.",
-    "  Options:",
-    "    -s <string>  - Space seprated Strings to search in log files, MANDATORY - NO DEFAULT",
-    "                   Format -s 'string1' 'string2'... 'stringn'",
-    "    -a           - Set 'AND'ing of search strings (provided with -s): Finding lines with all serach strings in it.",
-    "                   Default is 'OR'ing: Finding lines with atleast one search string in it.",
-    "    -v <string>  - Non-matching strings (space separated).",
-    "    -i           - Perform case insensitive matching of search strings (-s) and non-matching strings (-v).",
-    "                   By default it is case sensitive.",
-    "    -u           - Set to find unique lines.",
-    "    -f <string>  - Log time from which to analyze.",
-    "                   May use the following formats:  'Sep 22 2011 22:40:14', -3600, or '-1:00:00'.",
-    "                   default: head",
-    "    -d <string>  - Maximum time period to analyze.",
-    "                   May use the following formats: 3600 or 1:00:00.",
-    "    -t <string>  - Counting matched lines per interval of t.",
-    "                   May use the following formats: 60 or 1:00:00. default: 600 seconds.",
-    "    -n <string>  - Comma separated node numbers. You can get these numbers by list command. Ex. : -n '1,2,5'.",
-    "                   If not set then runs on all server logs in selected list.",
-    "    -p <int>     - Showing output in pages with p entries per page. default: 10.",
-    "    -r           - Repeat output table title and row header after every <terminal width> columns.",
-    "                   default: False, no repetition.",
+    modifiers=(
+        ModifierHelp(
+            "-s",
+            "Space separated strings to search in log files. Format: -s 'string-1' 'string-2' ... 'string-n'",
+        ),
+        ModifierHelp(
+            "-a",
+            "Set 'AND'ing of search strings (provided with -s): Finding lines with all search strings in it. Default is 'OR'ing: Finding lines with at least one search string in it.",
+        ),
+        ModifierHelp("-v", "Non-matching strings (space separated)."),
+        ModifierHelp(
+            "-i",
+            "Perform case insensitive matching of search strings (-s) and non-matching strings (-v)",
+        ),
+        ModifierHelp("-u", "Set to find unique lines."),
+        ModifierHelp(
+            "-f",
+            "Log time from which to analyze. May use the following formats: 'Sep 22 2011 22:40:14', -3600, or '-1:00:00'.",
+            default="head",
+        ),
+        ModifierHelp(
+            "-d",
+            "Maximum time period to analyze. May use the following formats: 3600 or 1:00:00.",
+        ),
+        ModifierHelp(
+            "-t",
+            "Counting matched lines per interval of t. May use the following formats: 60 or 1:00:00",
+            default="600 seconds",
+        ),
+        ModifierHelp(
+            "-n",
+            "Comma separated node numbers. You can get these numbers by the list command. Example: -n '1,2,5'. If not set, then runs on all server logs in the selected list.",
+        ),
+        ModifierHelp(
+            "-p", "Showing output in pages with p entries per page.", default="10"
+        ),
+        ModifierHelp(
+            "-r",
+            "Repeat output table title and row header after every <terminal width> columns",
+            default="False, no repetition.",
+        ),
+    ),
 )
 class CountController(LogAnalyzerCommandController):
     def __init__(self):
@@ -128,32 +166,45 @@ class CountController(LogAnalyzerCommandController):
 
 @CommandHelp(
     "Displays set of values and difference between consecutive values for input string in server logs.",
-    "Currently it is working for following KEY and VALUE patterns:",
-    "        1) KEY<space>VALUE",
-    "        2) KEY<space>(VALUE)",
-    "        3) KEY<space>(Comma separated VALUE list)",
-    "        4) KEY<space>(VALUE",
-    "        5) VALUE1(VALUE2)<space>KEY",
-    "  Options:",
-    "    -s <string>  - The Key to search in log files, MANDATORY - NO DEFAULT",
-    "                   Multiple strings can be given to analyse actual context, but these multiple search strings should",
-    "                   present in same line and in same order as they mentioned here.",
-    '                   Ex. to analyse key "avail pct" across all namespace : -s "avail pct" ',
-    '                       to analyse key "avail pct" for namespace test : -s test "avail pct"',
-    "    -i           - Perform case insensitive matching. By default it is case sensitive.",
-    "    -f <string>  - Log time from which to analyze.",
-    "                   May use the following formats:  'Sep 22 2011 22:40:14', -3600, or '-1:00:00'.",
-    "                   default: head",
-    "    -d <string>  - Maximum time period to analyze.",
-    "                   May use the following formats: 3600 or 1:00:00.",
-    "    -t <string>  - Analysis slice interval in seconds or time format (hh:mm:ss). default: 10 seconds.",
-    "    -l <string>  - Show results with at least one diff value greater than or equal to limit.",
-    "    -k <string>  - Show 0-th then every k-th result. default: 1.",
-    "    -n <string>  - Comma separated node numbers. You can get these numbers by list command. Ex. : -n '1,2,5'.",
-    "                   If not set then runs on all server logs in selected list.",
-    "    -p <int>     - Showing output in pages with p entries per page. default: 10.",
-    "    -r <int>     - Repeating output table title and row header after every r node columns.",
-    "                   default: 0, no repetition.",
+    usage="-s <string> [-i] [-f <string>] [-d <string>] [-t <string>] [-l <int>] [-k <int>] [-n <string>] [-p <int>] [-r <int>]",
+    modifiers=(
+        ModifierHelp(
+            "-s",
+            "The Key to search in log files. Multiple strings can be given to analyze actual context, but these multiple search strings should be present in the same line and in the same order as they are mentioned here. Example: to analyze key 'avail pct' across all namespaces: -s 'avail pct', to analyze key 'avail pct' for namespace test: -s test 'avail pct'. Currently it is working for the following KEY and VALUE patterns: 'KEY<space>VALUE', 'KEY<space>(VALUE)', 'KEY<space>(Comma separated VALUE list)', 'KEY<space>(VALUE', and 'VALUE1(VALUE2)<space>KEY'",
+        ),
+        ModifierHelp("-i", "Perform case insensitive matching"),
+        ModifierHelp(
+            "-f",
+            "Log time from which to analyze. May use the following formats: 'Sep 22 2011 22:40:14', -3600, or '-1:00:00'",
+            default="head",
+        ),
+        ModifierHelp(
+            "-d",
+            "Maximum time period to analyze. May use the following formats: 3600 or 1:00:00.",
+        ),
+        ModifierHelp(
+            "-t",
+            "Analysis slice interval in seconds or time format (hh:mm:ss)",
+            default="10",
+        ),
+        ModifierHelp(
+            "-l",
+            "Show results with at least one diff value greater than or equal to the limit.",
+        ),
+        ModifierHelp("-k", "Show 0-th then every k-th result", default="1"),
+        ModifierHelp(
+            "-n",
+            "Comma separated node numbers. You can get these numbers by the list command. Example: -n '1,2,5'. If not set, then runs on all server logs in the selected list.",
+        ),
+        ModifierHelp(
+            "-p", "Showing output in pages with p entries per page", default="10."
+        ),
+        ModifierHelp(
+            "-r",
+            "Repeating output table title and row header after every r node columns",
+            default="0, no repetition.",
+        ),
+    ),
 )
 class DiffController(LogAnalyzerCommandController):
     def __init__(self):
@@ -167,22 +218,44 @@ class DiffController(LogAnalyzerCommandController):
 
 @CommandHelp(
     "Displays histogram information for Aerospike server log.",
-    "  Options:",
-    "    -h <string>  - Histogram Name, MANDATORY - NO DEFAULT",
-    '    -f <string>  - Log time from which to analyze e.g. head or "Sep 22 2011 22:40:14" or -3600 or -1:00:00,',
-    "                   default: head",
-    "    -d <string>  - Maximum duration for which to analyze, e.g. 3600 or 1:00:00",
-    "    -t <string>  - Analysis slice interval, default: 10,  e.g. 3600 or 1:00:00",
-    "    -b <string>  - Number of buckets to display, default: 3",
-    "    -e <string>  - Show 0-th then every e-th bucket, default: 3",
-    "    -o           - Showing original time range for slices. Default is showing time with seconds value rounded to next nearest multiple of 10.",
-    "    -n <string>  - Comma separated node numbers. You can get these numbers by list command. Ex. : -n '1,2,5'",
-    "                   If not set then runs on all server logs in selected list.",
-    "    -p <int>     - Showing output in pages with p entries per page. default: 10.",
-    "    -r <int>     - Repeating output table title and row header after every r node columns.",
-    "                   default: 0, no repetition.",
-    "    -N <string>  - Namespace name. It will display histogram latency for ns namespace.",
-    "                   This feature is available for namespace level histograms in server >= 3.9.",
+    usage="-h <histogram-name> [-f <start-time>] [-d <duration>] [-t <interval>] [-b <bucket-count>] [-e <exponent-increment>] [-o] [-n <nodes>] [-p <entries-per-page>] [-r <int>] [-N <ns>]",
+    modifiers=(
+        ModifierHelp("-h", "Histogram Name"),
+        ModifierHelp(
+            "-f",
+            'Log time from which to analyze e.g. head or "Sep 22 2011 22:40:14" or -3600 or -1:00:00.',
+            default="head",
+        ),
+        ModifierHelp(
+            "-d", "Maximum duration for which to analyze, e.g. 3600 or 1:00:00"
+        ),
+        ModifierHelp(
+            "-t", "Analysis slice interval, e.g. 3600 or 1:00:00", default="10"
+        ),
+        ModifierHelp("-b", "Number of buckets to display", default="3"),
+        ModifierHelp("-e", "Show 0-th then every 2^e-th bucket", default="3"),
+        ModifierHelp(
+            "-o",
+            "Showing original time range for slices. Default is showing time with seconds value rounded to next nearest multiple of 10.",
+        ),
+        ModifierHelp(
+            "-n",
+            "Comma separated node numbers. You can get these numbers using the 'list' command. If not set, then runs on all server logs in selected list.",
+            default="all",
+        ),
+        ModifierHelp(
+            "-p", "Showing output in pages with p entries per page", default="10"
+        ),
+        ModifierHelp(
+            "-r",
+            "Repeating output table title and row header after every r node columns",
+            default="0, no repetition.",
+        ),
+        ModifierHelp(
+            "-N",
+            "Namespace name. It will display histogram latency for ns namespace.",
+        ),
+    ),
 )
 class HistogramController(LogAnalyzerCommandController):
     def __init__(self):
@@ -195,10 +268,8 @@ class HistogramController(LogAnalyzerCommandController):
 
 
 @CommandHelp(
-    "Adds server logs.",
-    "For log file of server (version >=3.7.1), "
-    "asadm fetches node ID from log and set it as a display name. Otherwise uses MD5_<MD5_hash_of_path>.",
-    "Format : add 'server log path1' 'server log path2' 'server log directory path' ...",
+    "Adds server logs for analysis",
+    usage="log/file/path.log [log/file/path2.log ...]",
 )
 class AddController(LogAnalyzerCommandController):
     def __init__(self):
@@ -229,7 +300,6 @@ class AddController(LogAnalyzerCommandController):
 @CommandHelp("Displays list of all server logs.")
 class ListController(LogAnalyzerCommandController):
     def __init__(self):
-        self.controller_map = {}
         self.modifiers = set()
 
     def _do_default(self, line):
@@ -260,14 +330,18 @@ class ListController(LogAnalyzerCommandController):
 
 
 @CommandHelp(
-    "Select list of server logs. Use 'all' to add all server logs.",
-    "or specify server log numbers",
-    "Use 'list' command for list of server logs and respective numbers.",
-    "Format : select all  OR  select 1 2 3",
+    "Select list of server logs",
+    modifiers=(
+        ModifierHelp("all", "Select all server logs"),
+        ModifierHelp(
+            "<server-log-num>",
+            "Select server log with given number.  Use the 'list' command for list of server logs and respective numbers",
+        ),
+    ),
+    usage="all | <server-log-num> [<server-log-num> ...]",
 )
 class SelectController(LogAnalyzerCommandController):
     def __init__(self):
-        self.controller_map = {}
         self.modifiers = set()
 
     def _do_default(self, line):
@@ -275,10 +349,15 @@ class SelectController(LogAnalyzerCommandController):
 
 
 @CommandHelp(
-    "Remove Logs from list of server logs. Use 'all' to remove all server logs.",
-    "or specify server log numbers",
-    "Use 'list' command for list of server logs and respective numbers.",
-    "Format : remove all   OR remove 1 2 3",
+    "Remove Logs from list of server logs",
+    modifiers=(
+        ModifierHelp("all", "Deselect all server logs"),
+        ModifierHelp(
+            "<server-log-num>",
+            "Deselect server log with given number.  Use the 'list' command for list of server logs and respective numbers",
+        ),
+    ),
+    usage="all | <server-log-num> [<server-log-num> ...]",
 )
 class RemoveController(LogAnalyzerCommandController):
     def __init__(self):
@@ -288,23 +367,19 @@ class RemoveController(LogAnalyzerCommandController):
         self.log_handler.remove_logs_by_index(line)
 
 
-@CommandHelp("Set pager for output")
+@CommandHelp("Turn terminal pager on and off")
 class PagerController(LogAnalyzerCommandController):
     def __init__(self):
         self.modifiers = set()
 
-    def _do_default(self, line):
-        self.execute_help(line)
-
     @CommandHelp(
-        "Displays output with vertical and horizontal paging for each output table same as linux 'less' command.",
-        "Use arrow keys to scroll output and 'q' to end page for table.",
-        "All linux less commands can work in this pager option.",
+        "Displays output with vertical and horizontal paging for each output table same as linux 'less' command. Use arrow keys to scroll output and 'q' to end page for table. All linux less commands can work in this pager option.",
+        short_msg="Enables output paging. Similar to linux 'less'",
     )
     def do_on(self, line):
         CliView.pager = CliView.LESS
 
-    @CommandHelp("Removes pager and prints output normally")
+    @CommandHelp("Disables paging and prints output normally")
     def do_off(self, line):
         CliView.pager = CliView.NO_PAGER
 

--- a/lib/utils/constants.py
+++ b/lib/utils/constants.py
@@ -127,6 +127,23 @@ class NodeSelection:
     RANDOM = "random"
 
 
+class Modifiers:
+    WITH = "with"
+    FOR = "for"
+    LIKE = "like"
+    DIFF = "diff"
+
+
+class ModifierUsage:
+    WITH = "with node1 [node2 [...]]"
+    # FOR = "for <key>=<value>"
+    LIKE = "like <substring>"
+
+
+class ModifierHelp:
+    WITH = "Show results from specified nodes. Acceptable values are ip:port, node-id, or FQDN"
+
+
 class JobType:
     SCAN = "scan"
     QUERY = "query"

--- a/lib/view/terminal/terminal.py
+++ b/lib/view/terminal/terminal.py
@@ -49,7 +49,7 @@ esc = None
 term = None
 
 sclear_code = None
-cur_format: Union[list[str], set[str], None] = None
+cur_format: list[str] | set[str] | None = None
 
 
 def enable_color(is_enable):

--- a/test/unit/live_cluster/test_manage_controller.py
+++ b/test/unit/live_cluster/test_manage_controller.py
@@ -183,8 +183,8 @@ Run 'help fakea1 COMMAND' for more information on a command.
             (
                 ["fakeb2"],
                 """
-Fake Command 2 Help. Here is a really long line that should wrap around. Let's check if it does. We
-need to make sure it is long enough.
+Fake Command 2 Help. Here is a really long line that should wrap around. Let's
+check if it does. We need to make sure it is long enough.
 
 Usage:  fakeb2 <arg2> COMMAND
 or

--- a/test/unit/live_cluster/test_manage_controller.py
+++ b/test/unit/live_cluster/test_manage_controller.py
@@ -1225,7 +1225,7 @@ class ManageConfigAutoCompleteTest(asynctest.TestCase):
         )
         self.cluster.update_node(self.node)
         self.controller = ManageConfigController()
-        self.controller.context = ["manage", "config"]
+        self.controller._context = ["manage", "config"]
         ManageConfigLeafController.mods = {}
         self.logger_mock = patch("lib.base_controller.BaseController.logger").start()
         self.view_mock = patch("lib.base_controller.BaseController.view").start()

--- a/test/unit/live_cluster/test_manage_controller.py
+++ b/test/unit/live_cluster/test_manage_controller.py
@@ -14,9 +14,16 @@
 
 import unittest
 from pytest import PytestUnraisableExceptionWarning
-from lib.base_controller import BaseController, ShellException
+from lib.base_controller import (
+    BaseController,
+    CommandController,
+    CommandHelp,
+    ModifierHelp,
+    ShellException,
+)
 from mock import MagicMock, patch
 from mock.mock import AsyncMock, call
+from parameterized import parameterized
 
 from lib.live_cluster.client import (
     ASINFO_RESPONSE_OK,
@@ -33,6 +40,7 @@ from lib.live_cluster.live_cluster_command_controller import (
     LiveClusterCommandController,
 )
 from lib.live_cluster.manage_controller import (
+    LiveClusterManageCommandController,
     ManageACLCreateRoleController,
     ManageACLCreateUserController,
     ManageACLQuotasRoleController,
@@ -62,6 +70,160 @@ import warnings
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     import asynctest
+
+
+@CommandHelp(
+    "I am ROOT!!!",
+)
+class FakeRoot(BaseController):
+    def __init__(self):
+        self.modifiers = set()
+
+        self.controller_map = {"fakea1": FakeCommand1, "fakeb2": FakeCommand2}
+
+
+@CommandHelp(
+    "Fake Command 1 Help",
+    short_msg="Fake Command 1 Help.",
+    usage="<default usage>",
+)
+class FakeCommand1(LiveClusterManageCommandController):
+    def __init__(self):
+        pass
+
+    @CommandHelp(
+        "Fake Command 1 Default",
+    )
+    async def _do_default(self, line):
+        return await self.do_cmd(line[:])
+
+    @CommandHelp(
+        "Fake Command 1 cmd but is hidden so should not be in the list",
+        hide=True,
+    )
+    async def do_cmd(self, line):
+        return "fake1", line
+
+
+@CommandHelp(
+    "Fake Command 2 Help. Here is a really long line that should wrap around. Let's check if it does. We need to make sure it is long enough",
+    short_msg="Fake Command 2 Help.",
+    usage="<default usage>",
+)
+class FakeCommand2(LiveClusterManageCommandController):
+    def __init__(self):
+        self.controller_arg = "arg2"
+
+    @CommandHelp("Fake Command 2 Default")
+    async def _do_default(self, line):
+        return await self.do_cmd(line[:])
+
+    @CommandHelp(
+        "cmd help",
+    )
+    async def do_cmd(self, line):
+        return "fake2", line
+
+    @CommandHelp(
+        "foo help",
+        usage="<foo usage>",
+        modifiers=(
+            ModifierHelp("one", "all about one", default="1"),
+            ModifierHelp("two", "all about two", default="2"),
+        ),
+    )
+    async def do_foo(self, line):
+        return "foo", line
+
+    async def do_for(self, line):
+        return "for", line
+
+    async def do_zoo(self, line):
+        return "zoo", line
+
+
+class BaseControllerTest(asynctest.TestCase):
+    maxDiff = None
+
+    @parameterized.expand(
+        [
+            (
+                [],
+                """
+I am ROOT!!!.
+
+Usage:   COMMAND
+
+Commands:
+
+    Default     Print this help message
+    fakea1      Fake Command 1 Help
+    fakeb2      Fake Command 2 Help
+
+Run 'help COMMAND' for more information on a command.
+""",
+            ),
+            (["fake"], "ShellException"),
+            (
+                ["fakea1"],
+                """
+Fake Command 1 Help.
+
+Usage:  fakea1 COMMAND
+or
+Usage:  fakea1 <default usage>
+
+Commands:
+
+    Default     Fake Command 1 Default
+
+Run 'help fakea1 COMMAND' for more information on a command.
+""",
+            ),
+            (
+                ["fakeb2"],
+                """
+Fake Command 2 Help. Here is a really long line that should wrap around. Let's check if it does. We
+need to make sure it is long enough.
+
+Usage:  fakeb2 <arg2> COMMAND
+or
+Usage:  fakeb2 <arg2> <default usage>
+
+Commands:
+
+    Default     Fake Command 2 Default
+    cmd         cmd help
+    foo         foo help
+
+Run 'help fakeb2 COMMAND' for more information on a command.
+""",
+            ),
+            (
+                ["fakeb2", "foo"],
+                """
+foo help.
+
+Usage:  fakeb2 <arg2> foo <foo usage>
+
+        one     - all about one
+                  Default: 1
+        two     - all about two
+                  Default: 2
+""",
+            ),
+        ]
+    )
+    def test_execute_help(self, line, expected_result):
+        r = FakeRoot()
+
+        try:
+            actual_result = r.execute_help(line)
+            print(actual_result)
+        except ShellException:
+            self.assertEqual(expected_result, "ShellException")
+        else:
+            self.assertListEqual(expected_result.split("\n"), actual_result.split("\n"))
 
 
 @asynctest.fail_on(active_handles=True)

--- a/test/unit/test_base_controller.py
+++ b/test/unit/test_base_controller.py
@@ -14,6 +14,7 @@
 
 import unittest
 import warnings
+from parameterized import parameterized
 
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -23,6 +24,7 @@ from lib.base_controller import (
     BaseController,
     CommandController,
     CommandHelp,
+    ModifierHelp,
     ShellException,
 )
 
@@ -40,6 +42,9 @@ class CommandHelpTest(unittest.TestCase):
         self.assertTrue(CommandHelp.has_help(tester))
 
 
+@CommandHelp(
+    "I am ROOT!!!",
+)
 class FakeRoot(BaseController):
     def __init__(self):
         self.modifiers = set()
@@ -47,21 +52,50 @@ class FakeRoot(BaseController):
         self.controller_map = {"fakea1": FakeCommand1, "fakeb2": FakeCommand2}
 
 
+@CommandHelp(
+    "Fake Command 1 Help",
+    short_msg="Fake Command 1 Help.",
+    usage="<default usage>",
+)
 class FakeCommand1(CommandController):
+    @CommandHelp(
+        "Fake Command 1 Default",
+    )
     async def _do_default(self, line):
         return await self.do_cmd(line[:])
 
+    @CommandHelp(
+        "Fake Command 1 cmd but is hidden so should not be in the list",
+        hide=True,
+    )
     async def do_cmd(self, line):
         return "fake1", line
 
 
+@CommandHelp(
+    "Fake Command 2 Help. Here is a really long line that should wrap around. Let's check if it does. We need to make sure it is long enough",
+    short_msg="Fake Command 2 Help.",
+    usage="<default usage>",
+)
 class FakeCommand2(CommandController):
+    @CommandHelp("Fake Command 2 Default")
     async def _do_default(self, line):
         return await self.do_cmd(line[:])
 
+    @CommandHelp(
+        "cmd help",
+    )
     async def do_cmd(self, line):
         return "fake2", line
 
+    @CommandHelp(
+        "foo help",
+        usage="<foo usage>",
+        modifiers=(
+            ModifierHelp("one", "all about one", default="1"),
+            ModifierHelp("two", "all about two", default="2"),
+        ),
+    )
     async def do_foo(self, line):
         return "foo", line
 
@@ -73,6 +107,8 @@ class FakeCommand2(CommandController):
 
 
 class BaseControllerTest(asynctest.TestCase):
+    maxDiff = None
+
     def test_complete(self):
         test_lines = [
             ([], ["fakea1", "fakeb2"]),
@@ -141,12 +177,97 @@ class BaseControllerTest(asynctest.TestCase):
         for line, expected_result in test_lines:
             try:
                 actual_result = await r(line)
-                # actual_result =  actual_result
                 actual_result = actual_result[0]
             except ShellException:
                 self.assertEqual(expected_result, "ShellException")
             else:
                 self.assertEqual(expected_result, actual_result)
+
+    @parameterized.expand(
+        [
+            (
+                [],
+                """
+I am ROOT!!!.
+
+Usage:   COMMAND
+
+Commands:
+
+    Default         Print this help message
+    fakea1          Fake Command 1 Help
+    fakeb2          Fake Command 2 Help
+
+Run 'help COMMAND' for more information on a command.
+""",
+            ),
+            (["fake"], "ShellException"),
+            (
+                ["fakea1"],
+                """
+Fake Command 1 Help.
+
+Usage:  fakea1 COMMAND
+or
+Usage:  fakea1 <default usage>
+
+Commands:
+
+    Default         Fake Command 1 Default
+
+Run 'help fakea1 COMMAND' for more information on a command.
+""",
+            ),
+            (
+                ["fakeb2"],
+                """
+Fake Command 2 Help. Here is a really long line that should wrap around. Let's check if it does. We
+need to make sure it is long enough.
+
+Usage:  fakeb2 COMMAND
+or
+Usage:  fakeb2 <default usage>
+
+Commands:
+
+    Default         Fake Command 2 Default
+    cmd             cmd help
+    foo             foo help
+
+Run 'help fakeb2 COMMAND' for more information on a command.
+""",
+            ),
+            (
+                ["fakeb2", "foo"],
+                """
+foo help.
+
+Usage:  fakeb2 foo <foo usage>
+
+        one     - all about one
+                  Default: 1
+        two     - all about two
+                  Default: 2
+""",
+            ),
+        ]
+    )
+    def test_execute_help(self, line, expected_result):
+        # (["fakea1"], "fake1"),
+        # (["fakeb2"], "fake2"),
+        # (["fakeb", "c"], "fake2"),
+        # (["fakeb2", "f"], "ShellException"),
+        # (["fakeb2", "foo"], "foo"),
+
+        r = FakeRoot()
+
+        try:
+            actual_result = r.execute_help(line)
+            print(actual_result)
+        except ShellException:
+            self.assertEqual(expected_result, "ShellException")
+        else:
+            self.assertListEqual(expected_result.split("\n"), actual_result.split("\n"))
 
     async def test_pre_command(self):
         test_lines = [

--- a/test/unit/test_base_controller.py
+++ b/test/unit/test_base_controller.py
@@ -194,9 +194,9 @@ Usage:   COMMAND
 
 Commands:
 
-    Default         Print this help message
-    fakea1          Fake Command 1 Help
-    fakeb2          Fake Command 2 Help
+    Default     Print this help message
+    fakea1      Fake Command 1 Help
+    fakeb2      Fake Command 2 Help
 
 Run 'help COMMAND' for more information on a command.
 """,
@@ -213,7 +213,7 @@ Usage:  fakea1 <default usage>
 
 Commands:
 
-    Default         Fake Command 1 Default
+    Default     Fake Command 1 Default
 
 Run 'help fakea1 COMMAND' for more information on a command.
 """,
@@ -221,8 +221,8 @@ Run 'help fakea1 COMMAND' for more information on a command.
             (
                 ["fakeb2"],
                 """
-Fake Command 2 Help. Here is a really long line that should wrap around. Let's check if it does. We
-need to make sure it is long enough.
+Fake Command 2 Help. Here is a really long line that should wrap around. Let's
+check if it does. We need to make sure it is long enough.
 
 Usage:  fakeb2 COMMAND
 or
@@ -230,9 +230,9 @@ Usage:  fakeb2 <default usage>
 
 Commands:
 
-    Default         Fake Command 2 Default
-    cmd             cmd help
-    foo             foo help
+    Default     Fake Command 2 Default
+    cmd         cmd help
+    foo         foo help
 
 Run 'help fakeb2 COMMAND' for more information on a command.
 """,
@@ -253,12 +253,6 @@ Usage:  fakeb2 foo <foo usage>
         ]
     )
     def test_execute_help(self, line, expected_result):
-        # (["fakea1"], "fake1"),
-        # (["fakeb2"], "fake2"),
-        # (["fakeb", "c"], "fake2"),
-        # (["fakeb2", "f"], "ShellException"),
-        # (["fakeb2", "foo"], "foo"),
-
         r = FakeRoot()
 
         try:


### PR DESCRIPTION
Examples of different output:

help
```
A tool for interacting with your Aerospike cluster.

Usage:   COMMAND

Commands:

    Default         Print this help message
    asinfo          Provides raw access to the info protocol
    collectinfo     Collects cluster info, system stats, and aerospike conf file for local node
    disable         Exits privileged mode
    enable          Enters privileged mode
    exit            Terminate session
    features        Lists the features in use in a running Aerospike cluster
    info            Provides summary tables for various aspects of Aerospike functionality
    manage          Administrative tasks like managing users, roles, udf, and sindexes
    pager           Turn terminal pager on or off
    show            A collection of commands used to display information about the Aerospike cluster
    summary         Displays summary of Aerospike cluster
    watch           Runs a command for a specified pause and iterations

Run 'help COMMAND' for more information on a command.
```

help show
```
A collection of commands used to display information about the Aerospike cluster.

Usage:  show COMMAND

Commands:

  Default            
  best-practices     Displays any of Aerospike's violated "best-practices"
  config             A collection of commands that display configuration settings
  distribution       A collection of commands that display the distribution of object sizes and time to live
  jobs               A collection of commands that display jobs and associated metadata
  latencies          Displays the server latency histograms
  pmap               Displays partition map analysis of Aerospike cluster
  racks              Displays rack information for a rack-aware cluster
  roles              Displays roles and their assigned privileges, allowlist, and quotas
  roster             Displays roster information per node
  sindex             Displays secondary indexes and static metadata
  statistics         A collection of commands that displays runtime statistics
  stop-writes        Displays all metrics that could trigger stop-writes
  udfs               Displays UDF modules along with metadata
  users              A collection of commands that display user configuration and statistics


Run 'help show COMMAND' for more information on a command.
```

help show config
```
A collection of commands that display configuration settings.

Usage:  show config COMMAND
        or
Usage:  show config [-r] [--flip] [diff] [like <config-substring>]

        -r         - Repeat output table title and row header after
                     every <terminal width> columns.
                     Default: False
        --flip     - Flip output table to show Nodes on Y axis and
                     config on X axis.
        diff       - Only display rows and values that differ between
                     nodes.
        like       - Filter by configuration parameter substring match

Commands:

  Default         Displays security, service, network, and namespace configuration
  namespace       Displays namespace configuration
  network         Displays network configuration
  security        Displays security configuration
  service         Displays service configuration
  xdr             A collection of commands that display xdr configuration


Run 'help show config COMMAND' for more information on a command.
```

help show config xdr
```
A collection of commands that display xdr configuration.

Usage:  show config xdr COMMAND
        or
Usage:  show config xdr [-r] [-flip] [diff] [for <dc-substring>|<ns-substring>] [like <config-substring>]

        -r         - Repeat output table title and row header after
                     every <terminal width> columns.
                     Default: False
        --flip     - Flip output table to show Nodes on Y axis and
                     config on X axis.
        diff       - Only display rows and values that differ between
                     nodes.
        for        - Filter by datacenter or namespace substring match
        like       - Filter by configuration parameter substring match

Commands:

  Default         Displays xdr, xdr datacenter, and xdr namespace configuration
  dc              Displays xdr datacenter configuration
  filter          Displays configured xdr filters
  namespace       Displays xdr namespace configuration


Run 'help show config xdr COMMAND' for more information on a command.
```

help show config xdr dc
```
Displays xdr datacenter configuration.

Usage:  show config xdr dc [-r] [-flip] [diff] [for <dc-substring>] [like <config-substring>]

        -r         - Repeat output table title and row header after
                     every <terminal width> columns.
                     Default: False
        --flip     - Flip output table to show Nodes on Y axis and
                     config on X axis.
        diff       - Only display rows and values that differ between
                     nodes.
        for        - Filter by datacenter substring match
        like       - Filter by configuration parameter substring match
```
