### PR TITLE
fix: Execute mode error does not have non-zero return code

### DIFF
--- a/lib/live_cluster/client/assocket.py
+++ b/lib/live_cluster/client/assocket.py
@@ -17,7 +17,7 @@ import socket
 import warnings
 import asyncio
 
-from .types import ASResponse, ASProtocolError
+from .types import ASProtocolExcFactory, ASResponse, ASProtocolError
 from .info import (
     add_privileges,
     authenticate_new,
@@ -170,7 +170,7 @@ class ASSocket:
         )
 
         if resp_code != ASResponse.OK:
-            raise ASProtocolError(resp_code, "Login failed")
+            raise ASProtocolExcFactory.create_exc(resp_code, "Login failed")
 
         return True
 
@@ -198,7 +198,7 @@ class ASSocket:
             )
 
         if resp_code != ASResponse.OK:
-            raise ASProtocolError(resp_code, "Unable to authenticate")
+            raise ASProtocolExcFactory.create_exc(resp_code, "Unable to authenticate")
 
         return True
 
@@ -256,7 +256,7 @@ class ASSocket:
         )
 
         if rsp_code != ASResponse.OK:
-            raise ASProtocolError(rsp_code, "Failed to create user")
+            raise ASProtocolExcFactory.create_exc(rsp_code, "Failed to create user")
 
         return ASResponse.OK
 
@@ -266,7 +266,7 @@ class ASSocket:
         )
 
         if rsp_code != ASResponse.OK:
-            raise ASProtocolError(rsp_code, "Failed to delete user")
+            raise ASProtocolExcFactory.create_exc(rsp_code, "Failed to delete user")
 
         return ASResponse.OK
 
@@ -276,7 +276,7 @@ class ASSocket:
         )
 
         if rsp_code != ASResponse.OK:
-            raise ASProtocolError(rsp_code, "Failed to set password")
+            raise ASProtocolExcFactory.create_exc(rsp_code, "Failed to set password")
 
         return ASResponse.OK
 
@@ -287,7 +287,7 @@ class ASSocket:
         )
 
         if rsp_code != ASResponse.OK:
-            raise ASProtocolError(rsp_code, "Failed to change password")
+            raise ASProtocolExcFactory.create_exc(rsp_code, "Failed to change password")
 
         return ASResponse.OK
 
@@ -297,7 +297,7 @@ class ASSocket:
         )
 
         if rsp_code != ASResponse.OK:
-            raise ASProtocolError(rsp_code, "Failed to grant roles")
+            raise ASProtocolExcFactory.create_exc(rsp_code, "Failed to grant roles")
 
         return ASResponse.OK
 
@@ -307,7 +307,7 @@ class ASSocket:
         )
 
         if rsp_code != ASResponse.OK:
-            raise ASProtocolError(rsp_code, "Failed to revoke roles")
+            raise ASProtocolExcFactory.create_exc(rsp_code, "Failed to revoke roles")
 
         return ASResponse.OK
 
@@ -317,7 +317,7 @@ class ASSocket:
         )
 
         if rsp_code != ASResponse.OK:
-            raise ASProtocolError(rsp_code, "Failed to query users")
+            raise ASProtocolExcFactory.create_exc(rsp_code, "Failed to query users")
 
         return users_dict
 
@@ -327,7 +327,7 @@ class ASSocket:
         )
 
         if rsp_code != ASResponse.OK:
-            raise ASProtocolError(rsp_code, "Failed to query user")
+            raise ASProtocolExcFactory.create_exc(rsp_code, "Failed to query user")
 
         return users_dict
 
@@ -348,7 +348,7 @@ class ASSocket:
         )
 
         if rsp_code != ASResponse.OK:
-            raise ASProtocolError(rsp_code, "Failed to create role")
+            raise ASProtocolExcFactory.create_exc(rsp_code, "Failed to create role")
 
         return ASResponse.OK
 
@@ -358,7 +358,7 @@ class ASSocket:
         )
 
         if rsp_code != ASResponse.OK:
-            raise ASProtocolError(rsp_code, "Failed to delete role")
+            raise ASProtocolExcFactory.create_exc(rsp_code, "Failed to delete role")
 
         return ASResponse.OK
 
@@ -368,7 +368,7 @@ class ASSocket:
         )
 
         if rsp_code != ASResponse.OK:
-            raise ASProtocolError(rsp_code, "Failed to grant privilege")
+            raise ASProtocolExcFactory.create_exc(rsp_code, "Failed to grant privilege")
 
         return ASResponse.OK
 
@@ -378,7 +378,9 @@ class ASSocket:
         )
 
         if rsp_code != ASResponse.OK:
-            raise ASProtocolError(rsp_code, "Failed to revoke privilege")
+            raise ASProtocolExcFactory.create_exc(
+                rsp_code, "Failed to revoke privilege"
+            )
 
         return ASResponse.OK
 
@@ -388,7 +390,7 @@ class ASSocket:
         )
 
         if rsp_code != ASResponse.OK:
-            raise ASProtocolError(rsp_code, "Failed to set allowlist")
+            raise ASProtocolExcFactory.create_exc(rsp_code, "Failed to set allowlist")
 
         return ASResponse.OK
 
@@ -398,7 +400,9 @@ class ASSocket:
         )
 
         if rsp_code != ASResponse.OK:
-            raise ASProtocolError(rsp_code, "Failed to delete allowlist")
+            raise ASProtocolExcFactory.create_exc(
+                rsp_code, "Failed to delete allowlist"
+            )
 
         return ASResponse.OK
 
@@ -409,7 +413,7 @@ class ASSocket:
         )
 
         if rsp_code != ASResponse.OK:
-            raise ASProtocolError(
+            raise ASProtocolExcFactory.create_exc(
                 rsp_code,
                 "Failed to set quota{}".format(
                     "s" if read_quota is not None and write_quota is not None else ""
@@ -428,7 +432,7 @@ class ASSocket:
         )
 
         if rsp_code != ASResponse.OK:
-            raise ASProtocolError(
+            raise ASProtocolExcFactory.create_exc(
                 rsp_code,
                 "Failed to delete quota{}".format(
                     "s" if read_quota and write_quota else ""
@@ -443,7 +447,7 @@ class ASSocket:
         )
 
         if rsp_code != ASResponse.OK:
-            raise ASProtocolError(rsp_code, "Failed to query roles")
+            raise ASProtocolExcFactory.create_exc(rsp_code, "Failed to query roles")
 
         return role_dict
 
@@ -453,6 +457,6 @@ class ASSocket:
         )
 
         if rsp_code != ASResponse.OK:
-            raise ASProtocolError(rsp_code, "Failed to query role")
+            raise ASProtocolExcFactory.create_exc(rsp_code, "Failed to query role")
 
         return role_dict

--- a/lib/live_cluster/client/node.py
+++ b/lib/live_cluster/client/node.py
@@ -40,6 +40,7 @@ from .types import (
     ASINFO_RESPONSE_OK,
     ASInfoNotAuthenticatedError,
     ASInfoClusterStableError,
+    ASProtocolConnectionError,
     ASProtocolError,
     ASResponse,
     Addr_Port_TLSName,
@@ -84,6 +85,9 @@ def async_return_exceptions(func):
     async def wrapper(*args, **kwargs):
         try:
             return await func(*args, **kwargs)
+        except (ASInfoNotAuthenticatedError, ASProtocolConnectionError) as e:
+            args[0].alive = False
+            return e
         except (ASInfoError, ASProtocolError) as e:
             return e
         except Exception as e:

--- a/lib/live_cluster/client/types.py
+++ b/lib/live_cluster/client/types.py
@@ -166,6 +166,27 @@ class ASProtocolError(Exception):
         return False
 
 
+class ASProtocolConnectionError(ASProtocolError):
+    pass
+
+
+class ASProtocolExcFactory:
+    @staticmethod
+    def create_exc(as_response, message):
+        if as_response in {
+            ASResponse.NO_USER_OR_UNRECOGNIZED_USER,
+            ASResponse.EXPIRED_PASSWORD,
+            ASResponse.NO_CREDENTIAL_OR_BAD_CREDENTIAL,
+            ASResponse.NOT_AUTHENTICATED,
+            ASResponse.ROLE_OR_PRIVILEGE_VIOLATION,
+            ASResponse.NOT_WHITELISTED,
+            ASResponse.EXPIRED_SESSION,
+        }:
+            return ASProtocolConnectionError(as_response, message)
+
+        return ASProtocolError(as_response, message)
+
+
 ASINFO_RESPONSE_OK = "ok"
 GENERIC_ERROR_MSG = "Unknown error occurred"
 

--- a/lib/utils/logger.py
+++ b/lib/utils/logger.py
@@ -18,7 +18,6 @@ import logging
 import traceback
 from sys import exit
 from typing import Optional
-from lib.live_cluster.client.types import ASInfoError
 from lib.utils.logger_debug import DebugFormatter
 
 
@@ -138,5 +137,5 @@ from lib.base_controller import (  # noqa: E402 - suppress flake warning
 )
 from lib.live_cluster.client import (  # noqa: E402 - suppress flake warning
     ASProtocolError,
-    ASInfoResponseError,
+    ASInfoError,
 )

--- a/test/unit/live_cluster/client/test_node.py
+++ b/test/unit/live_cluster/client/test_node.py
@@ -27,7 +27,7 @@ import pytest
 
 import lib
 from lib.live_cluster.client.ctx import CDTContext, CTXItem, CTXItems
-from lib.live_cluster.client.types import ASProtocolError, ASResponse
+from lib.live_cluster.client.types import ASProtocolError, ASProtocolExcFactory, ASResponse
 from test.unit import util
 from lib.utils import constants
 from lib.live_cluster.client.assocket import ASSocket
@@ -360,7 +360,9 @@ class NodeTest(asynctest.TestCase):
 
         def side_effect(token):
             if token is None:
-                raise ASProtocolError(ASResponse.NO_CREDENTIAL_OR_BAD_CREDENTIAL, "foo")
+                raise ASProtocolExcFactory.create_exc(
+                    ASResponse.NO_CREDENTIAL_OR_BAD_CREDENTIAL, "foo"
+                )
             elif token == session_token:
                 return True
 


### PR DESCRIPTION
The problem was because of the import order in `logger.py`.  I found another potential future problem where certain ASInfoErrors and ASProtocolErrors should result in the Node being marked dead so I added a new ASProtocolError type and used multiple `except` statements.