### PR TITLE
TOOLS-2541 remove empty contexts and change name of genconf cmd

### DIFF
--- a/lib/live_cluster/generate_config_controller.py
+++ b/lib/live_cluster/generate_config_controller.py
@@ -12,6 +12,16 @@ from lib.utils.constants import ModifierUsage, Modifiers
 
 
 @CommandHelp(
+    "BETA: Currently only supports generating a static configuration file from a live node via the 'config' subcommand.",
+)
+class GenerateController(LiveClusterCommandController):
+    def __init__(self):
+        self.controller_map = {
+            "config": GenerateConfigController,
+        }
+
+
+@CommandHelp(
     "BETA: Generates a static configuration file from a live node.",
     usage=f"[-o <output_file>] {ModifierUsage.WITH}",
     modifiers=(
@@ -25,7 +35,7 @@ from lib.utils.constants import ModifierUsage, Modifiers
         ),
     ),
 )
-class ConfGenController(LiveClusterCommandController):
+class GenerateConfigController(LiveClusterCommandController):
     def __init__(self):
         self.required_modifiers = set(["with"])
 

--- a/lib/live_cluster/live_cluster_root_controller.py
+++ b/lib/live_cluster/live_cluster_root_controller.py
@@ -15,7 +15,9 @@
 import asyncio
 from io import StringIO
 import sys
-from lib.live_cluster.generate_config_controller import ConfGenController
+from lib.live_cluster.generate_config_controller import (
+    GenerateController,
+)
 
 from lib.utils import constants, util
 from lib.base_controller import (
@@ -80,7 +82,7 @@ class LiveClusterRootController(BaseController, AsyncObject):
 
         self.controller_map = {
             "health": HealthCheckController,
-            "confgen": ConfGenController,
+            "generate": GenerateController,
             "summary": SummaryController,
             "features": FeaturesController,
             "pager": PagerController,

--- a/test/e2e/live_cluster/test_all.py
+++ b/test/e2e/live_cluster/test_all.py
@@ -113,13 +113,13 @@ CMDS = [
     ("show sindex"),
     ("show stop-writes"),
     ("summary"),
-    (f"confgen with all"),
+    (f"generate config with all"),
 ]
 NOT_IN_CI_MODE = [
     "show mapping ip",
     "show mapping node",
     "show pmap",
-    f"confgen with all",
+    f"generate config with all",
 ]
 
 

--- a/test/e2e/live_cluster/test_confgen.py
+++ b/test/e2e/live_cluster/test_confgen.py
@@ -84,12 +84,12 @@ class TestConfGen(asynctest.TestCase):
     """
     This test has the following steps:
     1. Start a cluster with a template aerospike.conf file
-    2. Run confgen with the cluster IP and port and save the generated aerospike.conf to
+    2. Run "generate config" with the cluster IP and port and save the generated aerospike.conf to
     run on a new server.
     3. Store all `show config *` command output
     4. Stop the cluster
     5. Start a new cluster with the generated aerospike.conf file
-    6. Run confgen with the cluster IP and port and save the generated aerospike.conf to
+    6. Run "generate config" with the cluster IP and port and save the generated aerospike.conf to
     compare with the first generated aerospike.conf
     7. Store all `show config *` command output
     8. Compare the two aerospike.conf files
@@ -107,10 +107,10 @@ class TestConfGen(asynctest.TestCase):
     def tearDown(self):
         lib.stop()
 
-    async def test_confgen(self):
+    async def test_genconf(self):
         lib.start(num_nodes=1, template_content=aerospike_conf)
         time.sleep(1)
-        conf_gen_cmd = f"confgen with 127.0.0.1:{lib.PORT}"
+        conf_gen_cmd = f"generate config with 127.0.0.1:{lib.PORT}"
         show_config_cmd = "show config; show config security; show config xdr"
         cp = util.run_asadm(
             f"-h {lib.SERVER_IP}:{lib.PORT} --enable -e '{conf_gen_cmd}' -Uadmin -Padmin"
@@ -166,10 +166,10 @@ class TestConfGen(asynctest.TestCase):
             TestConfGen.rm_timestamp_from_output(second_show_config),
         )
 
-    async def test_confgen_save_to_file(self):
+    async def test_genconf_save_to_file(self):
         lib.start(num_nodes=1, template_content=aerospike_conf)
         time.sleep(1)
-        conf_gen_cmd = f"confgen with all"
+        conf_gen_cmd = f"generate config with all"
         cp = util.run_asadm(
             f"-h {lib.SERVER_IP}:{lib.PORT} --enable -e '{conf_gen_cmd}' -Uadmin -Padmin"
         )
@@ -180,7 +180,7 @@ class TestConfGen(asynctest.TestCase):
             self.fail()
 
         first_conf = cp.stdout
-        tmp_file = "/tmp/test_confgen_save_to_file.conf"
+        tmp_file = "/tmp/test_genconf_save_to_file.conf"
 
         cp = util.run_asadm(
             f"-h {lib.SERVER_IP}:{lib.PORT} --enable -e '{conf_gen_cmd} -o {tmp_file}' -Uadmin -Padmin"


### PR DESCRIPTION
We now remove any empty contexts except for xdr.dc, xdr.dc.namespace, and security contexts.

The command `genconf` has also been renamed to `generate config`.