### PR TITLE
TOOLS-2669 TOOLS-2683 TOOLS-2705 TOOLS-2706 7.0 config/stats changes

### DIFF
--- a/lib/collectinfo_analyzer/info_controller.py
+++ b/lib/collectinfo_analyzer/info_controller.py
@@ -253,6 +253,7 @@ class InfoNamespaceController(CollectinfoCommandController):
     @CommandHelp("Displays usage information for each namespace")
     def do_usage(self, line):
         ns_stats = self.stat_getter.get_namespace()
+        service_stats = self.stat_getter.get_service()
 
         for timestamp in sorted(ns_stats.keys()):
             if not ns_stats[timestamp]:
@@ -260,6 +261,7 @@ class InfoNamespaceController(CollectinfoCommandController):
 
             self.view.info_namespace_usage(
                 ns_stats[timestamp],
+                service_stats[timestamp],
                 self.log_handler.get_cinfo_log_at(timestamp=timestamp),
                 timestamp=timestamp,
                 **self.mods,

--- a/lib/health/query.py
+++ b/lib/health/query.py
@@ -113,16 +113,31 @@ ASSERT(r1, False, "Skewed cluster disk utilization.", "ANOMALY", WARNING,
 				 "Disk utilization Anomaly.");
 
 
-avail=select like(".*available_pct") as "free_disk" from NAMESPACE.STATISTICS save;
-disk_free = select "device_free_pct" as "free_disk", "free-pct-disk" as "free_disk" from NAMESPACE.STATISTICS save;
-r = do disk_free - avail save as "fragmented blocks pct";
+SET CONSTRAINT VERSION < 7.0;
+avail = select "device_available_pct" as "free_disk", "pmem_available_pct" as "free_disk", "available_pct" as "free_disk"  from NAMESPACE.STATISTICS save;
+data_free = select "device_free_pct" as "free_disk", "pmem_free_pct" as "free_disk", "free-pct-disk" as "free_disk" from NAMESPACE.STATISTICS save;
+r = do data_free - avail save as "fragmented blocks pct";
 r = do r <= 30;
 r = group by CLUSTER, NAMESPACE r;
 ASSERT(r, True, "High (> 30%) fragmented blocks.", "PERFORMANCE", WARNING,
 				"Listed namespace[s] have higher than normal (>30%) fragmented blocks at the time of sampling. Please run 'show config namespace like defrag' to check defrag configurations. Possible cause can be Aerospike disk defragmentation not keeping up with write rate and/or large record sizes causing fragmentation. Refer to knowledge base article discuss.aerospike.com/t/defragmentation for more details.",
 				"Fragmented Blocks check.");
 
+/*
+Same as above but beginning in 7.0 we must flip data_used to get data_free
+*/
+SET CONSTRAINT VERSION >= 7.0;
+data_avail = select "data_avail_pct" as "free_disk" from NAMESPACE.STATISTICS save;
+data_used = select "data_used_pct" as "free_disk" from NAMESPACE.STATISTICS save;
+data_free = do 100 - data_used;
+r = do data_free - data_avail save as "fragmented blocks pct";
+r = do r <= 30;
+r = group by CLUSTER, NAMESPACE r;
+ASSERT(r, True, "High (> 30%) fragmented blocks.", "PERFORMANCE", WARNING,
+				"Listed namespace[s] have higher than normal (>30%) fragmented blocks at the time of sampling. Please run 'show config namespace like defrag' to check defrag configurations. Possible cause can be Aerospike disk defragmentation not keeping up with write rate and/or large record sizes causing fragmentation. Refer to knowledge base article discuss.aerospike.com/t/defragmentation for more details.",
+				"Fragmented Blocks check.");
 
+SET CONSTRAINT VERSION ALL;
 s = select "%iowait" from SYSTEM.IOSTAT save;
 r = do s > 10;
 ASSERT(r, False, "High (> 10%) CPU IO wait time.", "PERFORMANCE", WARNING,
@@ -188,6 +203,8 @@ ASSERT(r, False, "Low system memory percentage.", "LIMITS", CRITICAL,
 				"Listed node[s] have lower than normal (< 20%) system free memory percentage. Please run 'show statistics service like system_free_mem_pct' to get actual values. Possible misconfiguration.",
 				"System memory percentage check.");
 
+SET CONSTRAINT VERSION < 7.0;
+
 f = select "memory_free_pct" as "stats", "free-pct-memory" as "stats" from NAMESPACE.STATISTICS save;
 s = select "stop-writes-pct" as "stats" from NAMESPACE.CONFIG save;
 u = do 100 - f save as "memory_used_pct";
@@ -215,8 +232,8 @@ e = do r <= 274877906944;
 ASSERT(e, True, "Namespace configured to use more than 256G.", "LIMITS", WARNING,
 				"On listed nodes namespace as mentioned have configured more than 256G of memory. Namespace with data not in memory can have max upto 4 billion keys and can utilize only up to 256G. Please run 'show statistics namespace like memory-size' to check configured memory.",
 				"Namespace per node memory limit check.");
-SET CONSTRAINT VERSION ALL;
 
+SET CONSTRAINT VERSION < 7.0;
 /*
 Following query selects assigned memory-size from namespace config and total ram size from system statistics.
 group by for namespace stats sums all memory size and gives node level memory size.
@@ -237,7 +254,7 @@ ASSERT(r, True, "Aerospike runtime memory configured < 5G.", "LIMITS", INFO,
 				"Listed node[s] have less than 5G free memory available for Aerospike runtime. Please run 'show statistics namespace like memory-size' to check configured memory and check output of 'free' for system memory. Possible misconfiguration.",
 				"Runtime memory configuration check.");
 
-
+SET CONSTRAINT VERSION ALL;
 /*
 Current configurations and config file values difference check
 */
@@ -290,19 +307,52 @@ ASSERT(r, False, "High system client connections.", "OPERATIONS", WARNING,
 				"Listed node[s] show higher than normal client-connections (> 80% of the max configured proto-fd-max). Please run 'show config like proto-fd-max' and 'show statistics like client_connections' for actual values. Possible can be network issue / improper client behavior / FD leak.",
 				"Client connections check.");
 
-s = select like(".*available_pct") as "stats" from NAMESPACE.STATISTICS save;
-m = select like(".*min-avail-pct") as "stats" from NAMESPACE.CONFIG save;
-critical_check = do s >= m;
-ASSERT(critical_check, True, "Low namespace disk available pct (stop-write enabled).", "OPERATIONS", CRITICAL,
-				"Listed namespace[s] have lower than normal (< min-avail-pct) available disk space. Probable cause - namespace size misconfiguration.",
-				"Critical Namespace disk available pct check.");
+SET CONSTRAINT VERSION < 7.0.0;
+free = select "device_free_pct" as "stats", "pmem_free_pct" as "stats" from NAMESPACE.STATISTICS save;
+used = do 100 - free save as "storage-engine used pct";
+stop_used_pct = select "storage-engine.stop-writes-used-pct" as "stats", "storage-engine.max-used-pct" as "stats" from NAMESPACE.CONFIG save;
+critical = do used <= stop_used_pct;
+ASSERT(critical, True, "High namespace storage-engine used pct (stop-write enabled).", "OPERATIONS", CRITICAL,
+				"Listed namespace[s] have higher than normal used storage-engine space. Probable cause - namespace size misconfiguration.",
+				"Critical Namespace storage-engine used pct check.");
 
-critical_check = do s < m;
-r = do s >= 20;
-r = do r || critical_check;
-ASSERT(r, True, "Low namespace disk available pct.", "OPERATIONS", WARNING,
+avail = select "device_available_pct" as "stats", "pmem_available_pct" as "stats" from NAMESPACE.STATISTICS save;
+stop_min_avail = select "storage-engine.min-avail-pct" as "stats" from NAMESPACE.CONFIG save;
+critical = do avail >= stop_min_avail;
+ASSERT(critical, True, "Low namespace storage-engine available pct (stop-write enabled).", "OPERATIONS", CRITICAL,
+				"Listed namespace[s] have lower than normal available storage-engine space. Probable cause - namespace size misconfiguration.",
+				"Critical Namespace storage-engine available pct check.");
+				
+skip = do critical == False;
+warn = do avail >= 20;
+warn = do warn || skip;
+ASSERT(warn, True, "Low namespace disk available pct.", "OPERATIONS", WARNING,
 				"Listed namespace[s] have lower than normal (< 20 %) available disk space. Probable cause - namespace size misconfiguration.",
 				"Namespace disk available pct check.");
+
+SET CONSTRAINT VERSION >= 7.0.0;
+used = select "data_used_pct" as "stats" from NAMESPACE.STATISTICS save;
+stop_used_pct = select "storage-engine.stop-writes-used-pct" as "stats" from NAMESPACE.CONFIG save;
+critical = do used <= stop_used_pct;
+ASSERT(critical, True, "High namespace storage-engine used pct (stop-write enabled).", "OPERATIONS", CRITICAL,
+				"Listed namespace[s] have higher than normal used storage-engine space. Probable cause - namespace size misconfiguration.",
+				"Critical Namespace storage-engine used pct check.");
+
+avail = select "data_avail_pct" as "stats" from NAMESPACE.STATISTICS save;
+stop_avail_pct = select "storage-engine.stop-writes-avail-pct" as "stats" from NAMESPACE.CONFIG save;
+critical = do avail >= stop_avail_pct;
+ASSERT(critical, True, "Low namespace storage-engine available pct (stop-write enabled).", "OPERATIONS", CRITICAL,
+				"Listed namespace[s] have lower than normal available storage-engine space. Probable cause - namespace size misconfiguration.",
+				"Critical Namespace storage-engine available pct check.");
+				
+skip = do critical == False;
+warn = do avail >= 20;
+warn = do warn || skip;
+ASSERT(warn, True, "Low namespace storage-engine available pct.", "OPERATIONS", WARNING,
+				"Listed namespace[s] have lower than normal (< 20 %) available storage-engine space. Probable cause - namespace size misconfiguration.",
+				"Namespace storage-engine available pct check.");
+
+SET CONSTRAINT VERSION ALL;
 
 s = select * from SERVICE.CONFIG ignore "heartbeat.mtu", "node-id-interface", "node-id", "pidfile", like(".*address"), like(".*port")  save;
 r = group by CLUSTER, KEY do NO_MATCH(s, ==, MAJORITY) save;
@@ -357,19 +407,30 @@ r = do APPLY_TO_ANY(d, IN, f);
 ASSERT(r, False, "Device name misconfigured.", "OPERATIONS", WARNING,
 				"Listed device[s] have partitions on same node. This might create situation like data corruption where data written to main drive gets overwritten/corrupted from data written to or deleted from the partition with the same name.",
 				"Device name misconfiguration check.");
-
-s = select "device_total_bytes", "device-total-bytes", "total-bytes-disk" from NAMESPACE.STATISTICS save;
+    
+s = select  "data_total_bytes", "device_total_bytes", "pmem_total_bytes", "device-total-bytes", "total-bytes-disk"  from NAMESPACE.STATISTICS save;
 r = group by CLUSTER, NAMESPACE do NO_MATCH(s, ==, MAJORITY) save;
 ASSERT(r, False, "Different namespace device size configuration.", "OPERATIONS", WARNING,
 				"Listed namespace[s] have difference in configured disk size. Please run 'show statistics namespace like bytes' to check total device size. Probable cause - config file misconfiguration.",
 				"Namespace device size configuration difference check.");
 
+SET CONSTRAINT VERSION < 4.9;
 hwm = select "high-water-disk-pct" from NAMESPACE.CONFIG save;
 hwm = group by CLUSTER, NAMESPACE hwm;
 r = do hwm == 50;
-ASSERT(r, True, "Non-default namespace device high water mark configuration.", "OPERATIONS", INFO,
-				"Listed namespace[s] have non-default high water mark configuration. Please run 'show config namespace like high-water-disk-pct' to check value. Probable cause - config file misconfiguration.",
-				"Non-default namespace device high water mark check.");
+ASSERT(r, True, "Non-default namespace storage-engine eviction threshold configuration.", "OPERATIONS", INFO,
+				"Listed namespace[s] have non-default eviction threshold configuration. Please run 'show config namespace like high-water evict-used' to check value. Probable cause - config file misconfiguration.",
+				"Non-default namespace storage-engine eviction threshold check.");
+    
+SET CONSTRAINT VERSION >= 4.9;
+hwm = select "high-water-disk-pct", "storage-engine.evict-used-pct" from NAMESPACE.CONFIG save;
+hwm = group by CLUSTER, NAMESPACE hwm;
+r = do hwm == 0;
+ASSERT(r, True, "Non-default namespace storage-engine eviction threshold configuration.", "OPERATIONS", INFO,
+				"Listed namespace[s] have non-default eviction threshold configuration. Please run 'show config namespace like high-water evict-used' to check value. Probable cause - config file misconfiguration.",
+				"Non-default namespace storage-engine eviction threshold check.");
+
+SET CONSTRAINT VERSION ALL;
 
 lwm = select like(".*defrag-lwm-pct") from NAMESPACE.CONFIG save;
 lwm = group by CLUSTER, NAMESPACE lwm;
@@ -378,12 +439,12 @@ ASSERT(r, True, "Non-default namespace device low water mark configuration.", "O
 				"Listed namespace[s] have non-default low water mark configuration. Probable cause - config file misconfiguration.",
 				"Non-default namespace device low water mark check.");
 
-hwm = select "high-water-disk-pct" as "defrag-lwm-pct" from NAMESPACE.CONFIG save;
+hwm = select "high-water-disk-pct" as "defrag-lwm-pct", "storage-engine.evict-used-pct" as "defrag-lwm-pct" from NAMESPACE.CONFIG save;
 lwm = select like(".*defrag-lwm-pct") as "defrag-lwm-pct" from NAMESPACE.CONFIG save;
 r = do lwm < hwm on common;
 r = group by CLUSTER, NAMESPACE r;
 ASSERT(r, False, "Defrag low water mark misconfigured.", "OPERATIONS", WARNING,
-				"Listed namespace[s] have defrag-lwm-pct lower than high-water-disk-pct. This might create situation like no block to write, no eviction and no defragmentation. Please run 'show config namespace like high-water-disk-pct defrag-lwm-pct' to check configured values. Probable cause - namespace watermark misconfiguration.",
+				"Listed namespace[s] have defrag-lwm-pct lower than eviction threshold. This might create situation like no block to write, no eviction and no defragmentation. Please run 'show config namespace like high-water evict-used defrag-lwm-pct' to check configured values. Probable cause - namespace watermark misconfiguration.",
 				"Defrag low water mark misconfiguration check.");
 
 commit_to_device = select "storage-engine.commit-to-device" from NAMESPACE.CONFIG;
@@ -434,21 +495,23 @@ It collects cluster-size and uses it to find out expected data distribution for 
 with available space per node per namespace.
 */
 
-t = select "device_total_bytes" as "disk_space", "device-total-bytes" as "disk_space", "total-bytes-disk" as "disk_space" from NAMESPACE.STATISTICS;
-u = select "used-bytes-disk" as "disk_space", "device_used_bytes" as "disk_space" from NAMESPACE.STATISTICS;
+t = select "data_total_bytes" as "disk_space", "pmem_total_bytes" as "disk_space", "device_total_bytes" as "disk_space", "device-total-bytes" as "disk_space", "total-bytes-disk" as "disk_space" from NAMESPACE.STATISTICS;
+u = select "data_used_bytes" as "disk_space", "pmem_used_bytes" as "disk_space", "device_used_bytes" as "disk_space", "used-bytes-disk" as "disk_space" from NAMESPACE.STATISTICS;
 /* Available extra space */
 e = do t - u;
-e = group by CLUSTER, NAMESPACE, NODE do SUM(e) save as "available device space";
+e = group by CLUSTER, NAMESPACE, NODE do SUM(e) save as "available storage space";
 s = select "cluster_size" as "size" from SERVICE;
 n = do MAX(s);
 n = do n - 1;
 /* Extra space need if 1 node goes down */
 e1 = do u / n;
-e1 = group by CLUSTER, NAMESPACE do MAX(e1) save as "distribution share of used device space per node";
+e1 = group by CLUSTER, NAMESPACE do MAX(e1) save as "distribution share of used storage space per node";
 r = do e > e1;
-ASSERT(r, True, "Namespace under configured (disk) for single node failure.", "OPERATIONS", WARNING,
-				"Listed namespace[s] does not have enough disk space configured to deal with increase in data per node in case of 1 node failure. Please run 'show statistics namespace like bytes' to check device space. It is non-issue if single replica limit is set to larger values, i.e if number of replica copies are reduced in case of node loss.",
-				"Namespace single node failure disk config check.");
+ASSERT(r, False, "Namespace storage under configured for single node failure.", "OPERATIONS", WARNING,
+				"Listed namespace[s] does not have enough storage space configured to deal with increase in data per node in case of 1 node failure. Please run 'show statistics namespace like bytes' to check storage space. It is non-issue if single replica limit is set to larger values, i.e if number of replica copies are reduced in case of node loss.",
+				"Namespace single node failure storage space config check.");
+
+SET CONSTRAINT VERSION < 7.0.0;
 
 /*
 Same as above query but for memory
@@ -1937,7 +2000,7 @@ cluster_size = select "cluster_size" as "sprig_limit_critical" from SERVICE.STAT
 cluster_size = group by CLUSTER do MAX(cluster_size) save as "cluster-size";
 repl = select "effective_replication_factor" as "sprig_limit_critical" from NAMESPACE.STATISTICS save as "effective_repl_factor";
 pts = select "partition-tree-sprigs" as "sprig_limit_critical" from NAMESPACE.CONFIG save as "partition-tree-sprigs";
-size_limit = select "index-type.mounts-size-limit" as "sprig_limit_critical" from NAMESPACE.CONFIG;
+size_limit = select "index-type.mounts-size-limit" as "sprig_limit_critical", "index-type.mounts-budget" as "sprig_limit_critical" from NAMESPACE.CONFIG;
 // below statement adds thousand delimiter to mounts-size-limiter when it prints
 size_limit = do size_limit * 1 save as "mounts-size-limit";
 
@@ -1958,11 +2021,12 @@ dont_skip = group by CLUSTER, NODE, NAMESPACE do OR(dont_skip);
 num_partitions = do 4096 * repl;
 partitions_per_node = do num_partitions/cluster_size;
 pts_per_node = do partitions_per_node * pts;
+// 4K partition-tree-sprig overhead
 total_pts = do pts_per_node * 4096 save as "Minimum space required";
 result = do total_pts > size_limit;
 
 ASSERT(result, False, "ALL FLASH - Too many sprigs per partition for current available index mounted space. Some records are likely failing to be created.", "OPERATIONS", CRITICAL,
-				"Minimum space required for sprig overhead at current cluster size exceeds mounts-size-limit.
+				"Minimum space required for sprig overhead at current cluster size exceeds mounts-budget/mounts-size-limit.
 				 See: https://www.aerospike.com/docs/operations/configure/namespace/index/#flash-index and https://www.aerospike.com/docs/operations/plan/capacity/#aerospike-all-flash",
 				"Check for too many sprigs for current cluster size.",
 				dont_skip);
@@ -1973,9 +2037,9 @@ mcs = select "min-cluster-size" as "sprig_limit_warning" from SERVICE;
 mcs = group by CLUSTER do MAX(mcs) save as "min-cluster-size";
 repl = select "replication-factor" as "sprig_limit_warning" from NAMESPACE.STATISTICS;
 pts = select "partition-tree-sprigs" as "sprig_limit_warning" from NAMESPACE.CONFIG;
-msl = select "index-type.mounts-size-limit" as "sprig_limit_warning" from NAMESPACE.CONFIG;
+msl = select "index-type.mounts-size-limit" as "sprig_limit_warning", "index-type.mounts-budget" as "sprig_limit_warning" from NAMESPACE.CONFIG;
 // below statement adds thousand delimiter to mounts-size-limiter when it prints
-msl = do msl * 1 save as "mounts-size-limit";
+msl = do msl * 1 save;
 
 // calculate sprig overhead
 // The replication factor should be min(repl, mcs)
@@ -1989,7 +2053,7 @@ repl_smaller = do repl < mcs;
 e1 = do repl_smaller && dont_skip;
 
 ASSERT(r1, False, "ALL FLASH - Too many sprigs per partition for configured min-cluster-size.", "OPERATIONS", WARNING,
-				"Minimum space required for sprig overhead at min-cluster-size exceeds mounts-size-limit. 
+				"Minimum space required for sprig overhead at min-cluster-size exceeds index-mount size. 
 				 See: https://www.aerospike.com/docs/operations/configure/namespace/index/#flash-index and https://www.aerospike.com/docs/operations/plan/capacity/#aerospike-all-flash",
 				"Check for too many sprigs for minimum cluster size.",
 				e1);
@@ -1998,6 +2062,7 @@ ASSERT(r1, False, "ALL FLASH - Too many sprigs per partition for configured min-
 // Only is asserted if min-cluster-size is smaller than replication-factor.
 // r2 = do 4096 * mcs;
 // r2 = do r2/mcs;
+// 4096 * mcs / mcs = 4096
 r2 = 4096;
 r2 = do r2 * pts;
 r2 = do r2 * 4096 save as "Minimum space required";
@@ -2007,7 +2072,7 @@ mcs_smaller = do mcs <= repl;
 e2 = do mcs_smaller && dont_skip;
 
 ASSERT(r2, False, "ALL FLASH - Too many sprigs per partition for configured min-cluster-size.", "OPERATIONS", WARNING,
-				"Minimum space required for sprig overhead at min-cluster-size exceeds mounts-size-limit. 
+				"Minimum space required for sprig overhead at min-cluster-size exceeds index-mount size. 
 				 See: https://www.aerospike.com/docs/operations/configure/namespace/index/#flash-index and https://www.aerospike.com/docs/operations/plan/capacity/#aerospike-all-flash",
 				"Check for too many sprigs for minimum cluster size.",
 				e2);

--- a/lib/health/query.py
+++ b/lib/health/query.py
@@ -310,7 +310,7 @@ ASSERT(r, False, "High system client connections.", "OPERATIONS", WARNING,
 SET CONSTRAINT VERSION < 7.0.0;
 free = select "device_free_pct" as "stats", "pmem_free_pct" as "stats" from NAMESPACE.STATISTICS save;
 used = do 100 - free save as "storage-engine used pct";
-stop_used_pct = select "storage-engine.stop-writes-used-pct" as "stats", "storage-engine.max-used-pct" as "stats" from NAMESPACE.CONFIG save;
+stop_used_pct = select "storage-engine.max-used-pct" as "stats" from NAMESPACE.CONFIG save;
 critical = do used <= stop_used_pct;
 ASSERT(critical, True, "High namespace storage-engine used pct (stop-write enabled).", "OPERATIONS", CRITICAL,
 				"Listed namespace[s] have higher than normal used storage-engine space. Probable cause - namespace size misconfiguration.",
@@ -2025,7 +2025,7 @@ total_pts = do pts_per_node * 4096 save as "Minimum space required";
 result = do total_pts > size_limit;
 
 ASSERT(result, False, "ALL FLASH - Too many sprigs per partition for current available index mounted space. Some records are likely failing to be created.", "OPERATIONS", CRITICAL,
-				"Minimum space required for sprig overhead at current cluster size exceeds mounts-budget/mounts-size-limit.
+				"Minimum space required for sprig overhead at current cluster size exceeds index-mount size.
 				 See: https://www.aerospike.com/docs/operations/configure/namespace/index/#flash-index and https://www.aerospike.com/docs/operations/plan/capacity/#aerospike-all-flash",
 				"Check for too many sprigs for current cluster size.",
 				dont_skip);

--- a/lib/health/query.py
+++ b/lib/health/query.py
@@ -1503,8 +1503,7 @@ ASSERT(r, True, "Non-zero sindex basic short query errors", "OPERATIONS", INFO,
 // Secondary Index Aggregation Query Statistics, fromally Query Agg statistics
 s = select "si_query_aggr_complete" as "val" from NAMESPACE.STATISTICS save;
 e = select "si_query_aggr_error" as "val" from NAMESPACE.STATISTICS save;
-total_transactions = do s + e; 
-total_transaction = do total_transactions + a save as "total sindex query aggregations";
+total_transactions = do s + e save as "total sindex query aggregations";
 total_transactions_per_sec = do total_transactions/u;
 total_transactions_per_sec = group by CLUSTER, NAMESPACE, NODE do MAX(total_transactions_per_sec);
 
@@ -1620,7 +1619,7 @@ ASSERT(r, True, "Non-zero scan aggregation errors", "OPERATIONS", INFO,
     
 // Scan Basic statistics
 s = select "scan_basic_complete" as "cnt" from NAMESPACE.STATISTICS;
-e = select "scan_basic_error", as "cnt" from NAMESPACE.STATISTICS;
+e = select "scan_basic_error" as "cnt" from NAMESPACE.STATISTICS;
 total_transactions = do s + e save as "total basic scans";
 total_transactions_per_sec = do total_transactions/u;
 total_transactions_per_sec = group by CLUSTER, NAMESPACE, NODE do MAX(total_transactions_per_sec);

--- a/lib/health/query/health.hql
+++ b/lib/health/query/health.hql
@@ -113,16 +113,31 @@ ASSERT(r1, False, "Skewed cluster disk utilization.", "ANOMALY", WARNING,
 				 "Disk utilization Anomaly.");
 
 
-avail=select like(".*available_pct") as "free_disk" from NAMESPACE.STATISTICS save;
-disk_free = select "device_free_pct" as "free_disk", "free-pct-disk" as "free_disk" from NAMESPACE.STATISTICS save;
-r = do disk_free - avail save as "fragmented blocks pct";
+SET CONSTRAINT VERSION < 7.0;
+avail = select "device_available_pct" as "free_disk", "pmem_available_pct" as "free_disk", "available_pct" as "free_disk"  from NAMESPACE.STATISTICS save;
+data_free = select "device_free_pct" as "free_disk", "pmem_free_pct" as "free_disk", "free-pct-disk" as "free_disk" from NAMESPACE.STATISTICS save;
+r = do data_free - avail save as "fragmented blocks pct";
 r = do r <= 30;
 r = group by CLUSTER, NAMESPACE r;
 ASSERT(r, True, "High (> 30%) fragmented blocks.", "PERFORMANCE", WARNING,
 				"Listed namespace[s] have higher than normal (>30%) fragmented blocks at the time of sampling. Please run 'show config namespace like defrag' to check defrag configurations. Possible cause can be Aerospike disk defragmentation not keeping up with write rate and/or large record sizes causing fragmentation. Refer to knowledge base article discuss.aerospike.com/t/defragmentation for more details.",
 				"Fragmented Blocks check.");
 
+/*
+Same as above but beginning in 7.0 we must flip data_used to get data_free
+*/
+SET CONSTRAINT VERSION >= 7.0;
+data_avail = select "data_avail_pct" as "free_disk" from NAMESPACE.STATISTICS save;
+data_used = select "data_used_pct" as "free_disk" from NAMESPACE.STATISTICS save;
+data_free = do 100 - data_used;
+r = do data_free - data_avail save as "fragmented blocks pct";
+r = do r <= 30;
+r = group by CLUSTER, NAMESPACE r;
+ASSERT(r, True, "High (> 30%) fragmented blocks.", "PERFORMANCE", WARNING,
+				"Listed namespace[s] have higher than normal (>30%) fragmented blocks at the time of sampling. Please run 'show config namespace like defrag' to check defrag configurations. Possible cause can be Aerospike disk defragmentation not keeping up with write rate and/or large record sizes causing fragmentation. Refer to knowledge base article discuss.aerospike.com/t/defragmentation for more details.",
+				"Fragmented Blocks check.");
 
+SET CONSTRAINT VERSION ALL;
 s = select "%iowait" from SYSTEM.IOSTAT save;
 r = do s > 10;
 ASSERT(r, False, "High (> 10%) CPU IO wait time.", "PERFORMANCE", WARNING,
@@ -188,6 +203,8 @@ ASSERT(r, False, "Low system memory percentage.", "LIMITS", CRITICAL,
 				"Listed node[s] have lower than normal (< 20%) system free memory percentage. Please run 'show statistics service like system_free_mem_pct' to get actual values. Possible misconfiguration.",
 				"System memory percentage check.");
 
+SET CONSTRAINT VERSION < 7.0;
+
 f = select "memory_free_pct" as "stats", "free-pct-memory" as "stats" from NAMESPACE.STATISTICS save;
 s = select "stop-writes-pct" as "stats" from NAMESPACE.CONFIG save;
 u = do 100 - f save as "memory_used_pct";
@@ -198,6 +215,7 @@ ASSERT(r, True, "Low namespace memory available pct (stop-write enabled).", "OPE
 
 /* NB : ADD CHECKS IF NODES ARE NOT HOMOGENOUS MEM / NUM CPU etc */
 
+SET CONSTRAINT VERSION ALL;
 
 s = select "available_bin_names", "available-bin-names" from NAMESPACE save;
 r = group by NAMESPACE do s > 3200;
@@ -214,8 +232,8 @@ e = do r <= 274877906944;
 ASSERT(e, True, "Namespace configured to use more than 256G.", "LIMITS", WARNING,
 				"On listed nodes namespace as mentioned have configured more than 256G of memory. Namespace with data not in memory can have max upto 4 billion keys and can utilize only up to 256G. Please run 'show statistics namespace like memory-size' to check configured memory.",
 				"Namespace per node memory limit check.");
-SET CONSTRAINT VERSION ALL;
 
+SET CONSTRAINT VERSION < 7.0;
 /*
 Following query selects assigned memory-size from namespace config and total ram size from system statistics.
 group by for namespace stats sums all memory size and gives node level memory size.
@@ -236,7 +254,7 @@ ASSERT(r, True, "Aerospike runtime memory configured < 5G.", "LIMITS", INFO,
 				"Listed node[s] have less than 5G free memory available for Aerospike runtime. Please run 'show statistics namespace like memory-size' to check configured memory and check output of 'free' for system memory. Possible misconfiguration.",
 				"Runtime memory configuration check.");
 
-
+SET CONSTRAINT VERSION ALL;
 /*
 Current configurations and config file values difference check
 */
@@ -289,19 +307,52 @@ ASSERT(r, False, "High system client connections.", "OPERATIONS", WARNING,
 				"Listed node[s] show higher than normal client-connections (> 80% of the max configured proto-fd-max). Please run 'show config like proto-fd-max' and 'show statistics like client_connections' for actual values. Possible can be network issue / improper client behavior / FD leak.",
 				"Client connections check.");
 
-s = select like(".*available_pct") as "stats" from NAMESPACE.STATISTICS save;
-m = select like(".*min-avail-pct") as "stats" from NAMESPACE.CONFIG save;
-critical_check = do s >= m;
-ASSERT(critical_check, True, "Low namespace disk available pct (stop-write enabled).", "OPERATIONS", CRITICAL,
-				"Listed namespace[s] have lower than normal (< min-avail-pct) available disk space. Probable cause - namespace size misconfiguration.",
-				"Critical Namespace disk available pct check.");
+SET CONSTRAINT VERSION < 7.0.0;
+free = select "device_free_pct" as "stats", "pmem_free_pct" as "stats" from NAMESPACE.STATISTICS save;
+used = do 100 - free save as "storage-engine used pct";
+stop_used_pct = select "storage-engine.stop-writes-used-pct" as "stats", "storage-engine.max-used-pct" as "stats" from NAMESPACE.CONFIG save;
+critical = do used <= stop_used_pct;
+ASSERT(critical, True, "High namespace storage-engine used pct (stop-write enabled).", "OPERATIONS", CRITICAL,
+				"Listed namespace[s] have higher than normal used storage-engine space. Probable cause - namespace size misconfiguration.",
+				"Critical Namespace storage-engine used pct check.");
 
-critical_check = do s < m;
-r = do s >= 20;
-r = do r || critical_check;
-ASSERT(r, True, "Low namespace disk available pct.", "OPERATIONS", WARNING,
+avail = select "device_available_pct" as "stats", "pmem_available_pct" as "stats" from NAMESPACE.STATISTICS save;
+stop_min_avail = select "storage-engine.min-avail-pct" as "stats" from NAMESPACE.CONFIG save;
+critical = do avail >= stop_min_avail;
+ASSERT(critical, True, "Low namespace storage-engine available pct (stop-write enabled).", "OPERATIONS", CRITICAL,
+				"Listed namespace[s] have lower than normal available storage-engine space. Probable cause - namespace size misconfiguration.",
+				"Critical Namespace storage-engine available pct check.");
+				
+skip = do critical == False;
+warn = do avail >= 20;
+warn = do warn || skip;
+ASSERT(warn, True, "Low namespace disk available pct.", "OPERATIONS", WARNING,
 				"Listed namespace[s] have lower than normal (< 20 %) available disk space. Probable cause - namespace size misconfiguration.",
 				"Namespace disk available pct check.");
+
+SET CONSTRAINT VERSION >= 7.0.0;
+used = select "data_used_pct" as "stats" from NAMESPACE.STATISTICS save;
+stop_used_pct = select "storage-engine.stop-writes-used-pct" as "stats" from NAMESPACE.CONFIG save;
+critical = do used <= stop_used_pct;
+ASSERT(critical, True, "High namespace storage-engine used pct (stop-write enabled).", "OPERATIONS", CRITICAL,
+				"Listed namespace[s] have higher than normal used storage-engine space. Probable cause - namespace size misconfiguration.",
+				"Critical Namespace storage-engine used pct check.");
+
+avail = select "data_avail_pct" as "stats" from NAMESPACE.STATISTICS save;
+stop_avail_pct = select "storage-engine.stop-writes-avail-pct" as "stats" from NAMESPACE.CONFIG save;
+critical = do avail >= stop_avail_pct;
+ASSERT(critical, True, "Low namespace storage-engine available pct (stop-write enabled).", "OPERATIONS", CRITICAL,
+				"Listed namespace[s] have lower than normal available storage-engine space. Probable cause - namespace size misconfiguration.",
+				"Critical Namespace storage-engine available pct check.");
+				
+skip = do critical == False;
+warn = do avail >= 20;
+warn = do warn || skip;
+ASSERT(warn, True, "Low namespace storage-engine available pct.", "OPERATIONS", WARNING,
+				"Listed namespace[s] have lower than normal (< 20 %) available storage-engine space. Probable cause - namespace size misconfiguration.",
+				"Namespace storage-engine available pct check.");
+
+SET CONSTRAINT VERSION ALL;
 
 s = select * from SERVICE.CONFIG ignore "heartbeat.mtu", "node-id-interface", "node-id", "pidfile", like(".*address"), like(".*port")  save;
 r = group by CLUSTER, KEY do NO_MATCH(s, ==, MAJORITY) save;
@@ -312,7 +363,7 @@ ASSERT(r, False, "Different service configurations.", "OPERATIONS", WARNING,
 multicast_mode_enabled = select like(".*mode") from NETWORK.CONFIG;
 multicast_mode_enabled = do multicast_mode_enabled == "multicast";
 multicast_mode_enabled = group by CLUSTER, NODE do OR(multicast_mode_enabled);
-s = select like(".*mtu")  from SERVICE.CONFIG save;
+s = select like(".*mtu")  from NETWORK.CONFIG save;
 r = group by CLUSTER do NO_MATCH(s, ==, MAJORITY) save;
 ASSERT(r, False, "Different heartbeat.mtu.", "OPERATIONS", WARNING,
 				"Listed node[s] have a different heartbeat.mtu configured. A multicast packet can only be as large as the interface mtu. Different mtu values might create cluster stability issue. Please contact Aerospike Support team.",
@@ -356,19 +407,30 @@ r = do APPLY_TO_ANY(d, IN, f);
 ASSERT(r, False, "Device name misconfigured.", "OPERATIONS", WARNING,
 				"Listed device[s] have partitions on same node. This might create situation like data corruption where data written to main drive gets overwritten/corrupted from data written to or deleted from the partition with the same name.",
 				"Device name misconfiguration check.");
-
-s = select "device_total_bytes", "device-total-bytes", "total-bytes-disk" from NAMESPACE.STATISTICS save;
+    
+s = select  "data_total_bytes", "device_total_bytes", "pmem_total_bytes", "device-total-bytes", "total-bytes-disk"  from NAMESPACE.STATISTICS save;
 r = group by CLUSTER, NAMESPACE do NO_MATCH(s, ==, MAJORITY) save;
 ASSERT(r, False, "Different namespace device size configuration.", "OPERATIONS", WARNING,
 				"Listed namespace[s] have difference in configured disk size. Please run 'show statistics namespace like bytes' to check total device size. Probable cause - config file misconfiguration.",
 				"Namespace device size configuration difference check.");
 
+SET CONSTRAINT VERSION < 4.9;
 hwm = select "high-water-disk-pct" from NAMESPACE.CONFIG save;
 hwm = group by CLUSTER, NAMESPACE hwm;
 r = do hwm == 50;
-ASSERT(r, True, "Non-default namespace device high water mark configuration.", "OPERATIONS", INFO,
-				"Listed namespace[s] have non-default high water mark configuration. Please run 'show config namespace like high-water-disk-pct' to check value. Probable cause - config file misconfiguration.",
-				"Non-default namespace device high water mark check.");
+ASSERT(r, True, "Non-default namespace storage-engine eviction threshold configuration.", "OPERATIONS", INFO,
+				"Listed namespace[s] have non-default eviction threshold configuration. Please run 'show config namespace like high-water evict-used' to check value. Probable cause - config file misconfiguration.",
+				"Non-default namespace storage-engine eviction threshold check.");
+    
+SET CONSTRAINT VERSION >= 4.9;
+hwm = select "high-water-disk-pct", "storage-engine.evict-used-pct" from NAMESPACE.CONFIG save;
+hwm = group by CLUSTER, NAMESPACE hwm;
+r = do hwm == 0;
+ASSERT(r, True, "Non-default namespace storage-engine eviction threshold configuration.", "OPERATIONS", INFO,
+				"Listed namespace[s] have non-default eviction threshold configuration. Please run 'show config namespace like high-water evict-used' to check value. Probable cause - config file misconfiguration.",
+				"Non-default namespace storage-engine eviction threshold check.");
+
+SET CONSTRAINT VERSION ALL;
 
 lwm = select like(".*defrag-lwm-pct") from NAMESPACE.CONFIG save;
 lwm = group by CLUSTER, NAMESPACE lwm;
@@ -377,12 +439,12 @@ ASSERT(r, True, "Non-default namespace device low water mark configuration.", "O
 				"Listed namespace[s] have non-default low water mark configuration. Probable cause - config file misconfiguration.",
 				"Non-default namespace device low water mark check.");
 
-hwm = select "high-water-disk-pct" as "defrag-lwm-pct" from NAMESPACE.CONFIG save;
+hwm = select "high-water-disk-pct" as "defrag-lwm-pct", "storage-engine.evict-used-pct" as "defrag-lwm-pct" from NAMESPACE.CONFIG save;
 lwm = select like(".*defrag-lwm-pct") as "defrag-lwm-pct" from NAMESPACE.CONFIG save;
 r = do lwm < hwm on common;
 r = group by CLUSTER, NAMESPACE r;
 ASSERT(r, False, "Defrag low water mark misconfigured.", "OPERATIONS", WARNING,
-				"Listed namespace[s] have defrag-lwm-pct lower than high-water-disk-pct. This might create situation like no block to write, no eviction and no defragmentation. Please run 'show config namespace like high-water-disk-pct defrag-lwm-pct' to check configured values. Probable cause - namespace watermark misconfiguration.",
+				"Listed namespace[s] have defrag-lwm-pct lower than eviction threshold. This might create situation like no block to write, no eviction and no defragmentation. Please run 'show config namespace like high-water evict-used defrag-lwm-pct' to check configured values. Probable cause - namespace watermark misconfiguration.",
 				"Defrag low water mark misconfiguration check.");
 
 commit_to_device = select "storage-engine.commit-to-device" from NAMESPACE.CONFIG;
@@ -407,13 +469,13 @@ ASSERT(r, True, "Number of Sets equal to or above 750", "LIMITS", INFO,
 stop_writes = select "stop_writes" from NAMESPACE.STATISTICS;
 stop_writes = group by CLUSTER, NAMESPACE stop_writes;
 ASSERT(stop_writes, False, "Namespace has hit stop-writes (stop_writes = true)", "OPERATIONS" , CRITICAL,
-				"Listed namespace(s) have hit stop-write. Please run 'show statistics namespace like stop_writes' for details.",
+				"Listed namespace(s) have hit stop-write. Please run 'show stop-writes' for details.",
 				"Namespace stop-writes flag check.");
 
 clock_skew_stop_writes = select "clock_skew_stop_writes" from NAMESPACE.STATISTICS;
 clock_skew_stop_writes = group by CLUSTER, NAMESPACE clock_skew_stop_writes;
 ASSERT(clock_skew_stop_writes, False, "Namespace has hit clock-skew-stop-writes (clock_skew_stop_writes = true)", "OPERATIONS" , CRITICAL,
-				"Listed namespace(s) have hit clock-skew-stop-writes. Please run 'show statistics namespace like clock_skew_stop_writes' for details.",
+				"Listed namespace(s) have hit clock-skew-stop-writes. Please run 'show stop-writes' for details.",
 				"Namespace clock-skew-stop-writes flag check.");
 
 SET CONSTRAINT VERSION < 4.3;
@@ -433,21 +495,23 @@ It collects cluster-size and uses it to find out expected data distribution for 
 with available space per node per namespace.
 */
 
-t = select "device_total_bytes" as "disk_space", "device-total-bytes" as "disk_space", "total-bytes-disk" as "disk_space" from NAMESPACE.STATISTICS;
-u = select "used-bytes-disk" as "disk_space", "device_used_bytes" as "disk_space" from NAMESPACE.STATISTICS;
+t = select "data_total_bytes" as "disk_space", "pmem_total_bytes" as "disk_space", "device_total_bytes" as "disk_space", "device-total-bytes" as "disk_space", "total-bytes-disk" as "disk_space" from NAMESPACE.STATISTICS;
+u = select "data_used_bytes" as "disk_space", "pmem_used_bytes" as "disk_space", "device_used_bytes" as "disk_space", "used-bytes-disk" as "disk_space" from NAMESPACE.STATISTICS;
 /* Available extra space */
 e = do t - u;
-e = group by CLUSTER, NAMESPACE, NODE do SUM(e) save as "available device space";
+e = group by CLUSTER, NAMESPACE, NODE do SUM(e) save as "available storage space";
 s = select "cluster_size" as "size" from SERVICE;
 n = do MAX(s);
 n = do n - 1;
 /* Extra space need if 1 node goes down */
 e1 = do u / n;
-e1 = group by CLUSTER, NAMESPACE do MAX(e1) save as "distribution share of used device space per node";
+e1 = group by CLUSTER, NAMESPACE do MAX(e1) save as "distribution share of used storage space per node";
 r = do e > e1;
-ASSERT(r, True, "Namespace under configured (disk) for single node failure.", "OPERATIONS", WARNING,
-				"Listed namespace[s] does not have enough disk space configured to deal with increase in data per node in case of 1 node failure. Please run 'show statistics namespace like bytes' to check device space. It is non-issue if single replica limit is set to larger values, i.e if number of replica copies are reduced in case of node loss.",
-				"Namespace single node failure disk config check.");
+ASSERT(r, False, "Namespace storage under configured for single node failure.", "OPERATIONS", WARNING,
+				"Listed namespace[s] does not have enough storage space configured to deal with increase in data per node in case of 1 node failure. Please run 'show statistics namespace like bytes' to check storage space. It is non-issue if single replica limit is set to larger values, i.e if number of replica copies are reduced in case of node loss.",
+				"Namespace single node failure storage space config check.");
+
+SET CONSTRAINT VERSION < 7.0.0;
 
 /*
 Same as above query but for memory
@@ -609,7 +673,7 @@ u = group by CLUSTER, NODE do MAX(u);
 s = do s / u on common;
 r = group by CLUSTER, DC, KEY do SD_ANOMALY(s, ==, 3);
 ASSERT(r, False, "Skewed cluster remote DC statistics.", "ANOMALY", WARNING,
-				"Listed DC statistic[s] show skew for the listed node[s]. Please run 'show statistics dc' to get all DC stats. May be non-issue if remote Data center connectivity behavior for nodes is not same.",
+				"Listed DC statistic[s] show skew for the listed node[s]. Please run 'show statistics  dc' to get all DC stats. May be non-issue if remote Data center connectivity behavior for nodes is not same.",
 				"Remote DC statistics anomaly check.");
 
 /*
@@ -1936,7 +2000,7 @@ cluster_size = select "cluster_size" as "sprig_limit_critical" from SERVICE.STAT
 cluster_size = group by CLUSTER do MAX(cluster_size) save as "cluster-size";
 repl = select "effective_replication_factor" as "sprig_limit_critical" from NAMESPACE.STATISTICS save as "effective_repl_factor";
 pts = select "partition-tree-sprigs" as "sprig_limit_critical" from NAMESPACE.CONFIG save as "partition-tree-sprigs";
-size_limit = select "index-type.mounts-size-limit" as "sprig_limit_critical" from NAMESPACE.CONFIG;
+size_limit = select "index-type.mounts-size-limit" as "sprig_limit_critical", "index-type.mounts-budget" as "sprig_limit_critical" from NAMESPACE.CONFIG;
 // below statement adds thousand delimiter to mounts-size-limiter when it prints
 size_limit = do size_limit * 1 save as "mounts-size-limit";
 
@@ -1957,11 +2021,12 @@ dont_skip = group by CLUSTER, NODE, NAMESPACE do OR(dont_skip);
 num_partitions = do 4096 * repl;
 partitions_per_node = do num_partitions/cluster_size;
 pts_per_node = do partitions_per_node * pts;
+// 4K partition-tree-sprig overhead
 total_pts = do pts_per_node * 4096 save as "Minimum space required";
 result = do total_pts > size_limit;
 
 ASSERT(result, False, "ALL FLASH - Too many sprigs per partition for current available index mounted space. Some records are likely failing to be created.", "OPERATIONS", CRITICAL,
-				"Minimum space required for sprig overhead at current cluster size exceeds mounts-size-limit.
+				"Minimum space required for sprig overhead at current cluster size exceeds mounts-budget/mounts-size-limit.
 				 See: https://www.aerospike.com/docs/operations/configure/namespace/index/#flash-index and https://www.aerospike.com/docs/operations/plan/capacity/#aerospike-all-flash",
 				"Check for too many sprigs for current cluster size.",
 				dont_skip);
@@ -1972,9 +2037,9 @@ mcs = select "min-cluster-size" as "sprig_limit_warning" from SERVICE;
 mcs = group by CLUSTER do MAX(mcs) save as "min-cluster-size";
 repl = select "replication-factor" as "sprig_limit_warning" from NAMESPACE.STATISTICS;
 pts = select "partition-tree-sprigs" as "sprig_limit_warning" from NAMESPACE.CONFIG;
-msl = select "index-type.mounts-size-limit" as "sprig_limit_warning" from NAMESPACE.CONFIG;
+msl = select "index-type.mounts-size-limit" as "sprig_limit_warning", "index-type.mounts-budget" as "sprig_limit_warning" from NAMESPACE.CONFIG;
 // below statement adds thousand delimiter to mounts-size-limiter when it prints
-msl = do msl * 1 save as "mounts-size-limit";
+msl = do msl * 1 save;
 
 // calculate sprig overhead
 // The replication factor should be min(repl, mcs)
@@ -1988,7 +2053,7 @@ repl_smaller = do repl < mcs;
 e1 = do repl_smaller && dont_skip;
 
 ASSERT(r1, False, "ALL FLASH - Too many sprigs per partition for configured min-cluster-size.", "OPERATIONS", WARNING,
-				"Minimum space required for sprig overhead at min-cluster-size exceeds mounts-size-limit. 
+				"Minimum space required for sprig overhead at min-cluster-size exceeds index-mount size. 
 				 See: https://www.aerospike.com/docs/operations/configure/namespace/index/#flash-index and https://www.aerospike.com/docs/operations/plan/capacity/#aerospike-all-flash",
 				"Check for too many sprigs for minimum cluster size.",
 				e1);
@@ -1997,6 +2062,7 @@ ASSERT(r1, False, "ALL FLASH - Too many sprigs per partition for configured min-
 // Only is asserted if min-cluster-size is smaller than replication-factor.
 // r2 = do 4096 * mcs;
 // r2 = do r2/mcs;
+// 4096 * mcs / mcs = 4096
 r2 = 4096;
 r2 = do r2 * pts;
 r2 = do r2 * 4096 save as "Minimum space required";
@@ -2006,7 +2072,7 @@ mcs_smaller = do mcs <= repl;
 e2 = do mcs_smaller && dont_skip;
 
 ASSERT(r2, False, "ALL FLASH - Too many sprigs per partition for configured min-cluster-size.", "OPERATIONS", WARNING,
-				"Minimum space required for sprig overhead at min-cluster-size exceeds mounts-size-limit. 
+				"Minimum space required for sprig overhead at min-cluster-size exceeds index-mount size. 
 				 See: https://www.aerospike.com/docs/operations/configure/namespace/index/#flash-index and https://www.aerospike.com/docs/operations/plan/capacity/#aerospike-all-flash",
 				"Check for too many sprigs for minimum cluster size.",
 				e2);

--- a/lib/health/query/health.hql
+++ b/lib/health/query/health.hql
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-QUERIES = """
 /***************************************************
 * System Resource                                  *
 ****************************************************/
@@ -1503,8 +1502,7 @@ ASSERT(r, True, "Non-zero sindex basic short query errors", "OPERATIONS", INFO,
 // Secondary Index Aggregation Query Statistics, fromally Query Agg statistics
 s = select "si_query_aggr_complete" as "val" from NAMESPACE.STATISTICS save;
 e = select "si_query_aggr_error" as "val" from NAMESPACE.STATISTICS save;
-total_transactions = do s + e; 
-total_transaction = do total_transactions + a save as "total sindex query aggregations";
+total_transactions = do s + e save as "total sindex query aggregations";
 total_transactions_per_sec = do total_transactions/u;
 total_transactions_per_sec = group by CLUSTER, NAMESPACE, NODE do MAX(total_transactions_per_sec);
 
@@ -1620,7 +1618,7 @@ ASSERT(r, True, "Non-zero scan aggregation errors", "OPERATIONS", INFO,
     
 // Scan Basic statistics
 s = select "scan_basic_complete" as "cnt" from NAMESPACE.STATISTICS;
-e = select "scan_basic_error", as "cnt" from NAMESPACE.STATISTICS;
+e = select "scan_basic_error" as "cnt" from NAMESPACE.STATISTICS;
 total_transactions = do s + e save as "total basic scans";
 total_transactions_per_sec = do total_transactions/u;
 total_transactions_per_sec = group by CLUSTER, NAMESPACE, NODE do MAX(total_transactions_per_sec);
@@ -2154,5 +2152,3 @@ ASSERT(m, False, "Outlier[s] detected by the server health check.", "OPERATIONS"
 			    "Server health check outlier detection. Run command 'asinfo -v health-outliers' to see list of outliers");
 
 SET CONSTRAINT VERSION ALL;
-
-"""

--- a/lib/live_cluster/info_controller.py
+++ b/lib/live_cluster/info_controller.py
@@ -260,9 +260,9 @@ class InfoNamespaceController(LiveClusterCommandController):
         modifiers=(with_modifier_help,),
     )
     async def do_usage(self, line):
-        service_stats = await self.stats_getter.get_service(nodes=self.nodes)
-        ns_stats = await self.stats_getter.get_namespace(
-            nodes=self.nodes
+        service_stats, ns_stats = await asyncio.gather(
+            self.stats_getter.get_service(nodes=self.nodes),
+            self.stats_getter.get_namespace(nodes=self.nodes),
         )  # Includes stats and configs
         return util.callable(
             self.view.info_namespace_usage,

--- a/lib/live_cluster/info_controller.py
+++ b/lib/live_cluster/info_controller.py
@@ -238,6 +238,7 @@ class InfoNamespaceController(LiveClusterCommandController):
     def __init__(self, get_futures=False):
         self.modifiers = set(["with"])
         self.get_futures = get_futures
+        self.stats_getter = GetStatisticsController(self.cluster)
 
     @CommandHelp(
         "Displays usage and objects information for each namespace",
@@ -259,9 +260,16 @@ class InfoNamespaceController(LiveClusterCommandController):
         modifiers=(with_modifier_help,),
     )
     async def do_usage(self, line):
-        stats = await self.cluster.info_all_namespace_statistics(nodes=self.nodes)
+        service_stats = await self.stats_getter.get_service(nodes=self.nodes)
+        ns_stats = await self.stats_getter.get_namespace(
+            nodes=self.nodes
+        )  # Includes stats and configs
         return util.callable(
-            self.view.info_namespace_usage, stats, self.cluster, **self.mods
+            self.view.info_namespace_usage,
+            ns_stats,
+            service_stats,
+            self.cluster,
+            **self.mods,
         )
 
     @CommandHelp(

--- a/lib/live_cluster/show_controller.py
+++ b/lib/live_cluster/show_controller.py
@@ -902,7 +902,6 @@ class ShowStatisticsController(LiveClusterCommandController):
     )
     async def _do_default(self, line):
         return await asyncio.gather(
-            self.do_bins(line[:]),
             self.do_sets(line[:]),
             self.do_service(line[:]),
             self.do_namespace(line[:]),

--- a/lib/utils/common.py
+++ b/lib/utils/common.py
@@ -35,7 +35,7 @@ from typing_extensions import NotRequired, Required
 import distro
 import socket
 import time
-from urllib import request, error, parse
+from urllib import request
 import aiohttp
 import zipfile
 from collections import OrderedDict
@@ -63,7 +63,7 @@ comp_ops = {
     "!=": operator.ne,
 }
 
-CompareValue = str | int | bool
+CompareValue = str | int | bool | float
 CompareCallable = Callable[[Any, Any], bool]
 CheckCallback = Callable[
     [dict[str, Any], tuple[str, ...], CompareCallable, str | int | bool], bool
@@ -511,6 +511,8 @@ feature_checks = (
                 "data_compression_ratio",
                 "device_compression_ratio",
             ),
+            comp_ops["<"],
+            1.0,
         ),
     ),
 )

--- a/lib/utils/common.py
+++ b/lib/utils/common.py
@@ -89,7 +89,7 @@ def _check_value(
 
     for key in keys:
         k = key
-        default_value = 0.0
+        default_value = None
         type_check = float
 
         if isinstance(value, str):

--- a/lib/utils/common.py
+++ b/lib/utils/common.py
@@ -1259,7 +1259,7 @@ def create_summary(
         ns_total_devices = sum(device_counts.values())
         ns_total_nodes = len(ns_stats.keys())
 
-        if ns_total_devices:
+        if ns_total_devices and ns_total_nodes > 0:
             summary_dict["NAMESPACES"][ns]["devices_total"] = ns_total_devices
             summary_dict["NAMESPACES"][ns]["devices_per_node"] = round(
                 ns_total_devices / ns_total_nodes

--- a/lib/view/templates.py
+++ b/lib/view/templates.py
@@ -753,7 +753,7 @@ info_set_sheet = Sheet(
             aggregator=Aggregators.sum(),
         ),
         Subgroup(
-            "Quota",
+            "Size Quota",
             (
                 Field(
                     "Total",
@@ -791,7 +791,7 @@ info_set_sheet = Sheet(
                     ),
                     converter=Converters.ratio_to_pct,
                     aggregator=ComplexAggregator(
-                        create_usage_weighted_avg("Quota"),
+                        create_usage_weighted_avg("Size Quota"),
                         converter=Converters.ratio_to_pct,
                     ),
                     formatters=(
@@ -804,12 +804,41 @@ info_set_sheet = Sheet(
             ),
         ),
         Field(
-            "Objects",
+            "Total Records",
             Projectors.Number("set_stats", "objects", "n_objects"),
             converter=Converters.scientific_units,
             aggregator=Aggregators.sum(),
         ),
-        Field("Stop Writes Count", Projectors.Number("set_stats", "stop-writes-count")),
+        Subgroup(
+            "Records Quota",
+            (
+                Field(
+                    "Total",
+                    Projectors.Number("set_stats", "stop-writes-count"),
+                ),
+                Field(
+                    "Used%",
+                    Projectors.Div(
+                        Projectors.Number(
+                            "set_stats",
+                            "objects",
+                        ),
+                        Projectors.Number("set_stats", "stop-writes-count"),
+                    ),
+                    converter=Converters.ratio_to_pct,
+                    aggregator=ComplexAggregator(
+                        create_usage_weighted_avg("Records Quota"),
+                        converter=Converters.ratio_to_pct,
+                    ),
+                    formatters=(
+                        Formatters.red_alert(lambda edata: edata.value * 100 >= 90.0),
+                        Formatters.yellow_alert(
+                            lambda edata: edata.value * 100 >= 75.0
+                        ),
+                    ),
+                ),
+            ),
+        ),
         Field("Disable Eviction", Projectors.Boolean("set_stats", "disable-eviction")),
         Field("Set Enable XDR", Projectors.String("set_stats", "set-enable-xdr")),
         Field(

--- a/lib/view/templates.py
+++ b/lib/view/templates.py
@@ -261,8 +261,8 @@ info_namespace_usage_sheet = Sheet(
             "System Memory",
             (
                 Field(
-                    "Avail%", Projectors.Percent("ns_stats", "system_free_mem_pct")
-                ),  # TODO get global metric
+                    "Avail%", Projectors.Percent("service_stats", "system_free_mem_pct")
+                ),
                 Field(
                     "Evict%",
                     Projectors.Percent("ns_stats", "evict-sys-memory-pct"),
@@ -572,7 +572,7 @@ info_namespace_usage_sheet = Sheet(
             ),
         ),
     ),
-    from_source=("node_ids", "node_names", "ns_stats"),
+    from_source=("node_ids", "node_names", "ns_stats", "service_stats"),
     for_each="ns_stats",
     group_by=("Namespace"),
     order_by=FieldSorter("Node"),
@@ -1304,8 +1304,8 @@ summary_cluster_sheet = Sheet(
             "Migrations",
             Projectors.String("cluster_dict", "migrations_in_progress"),
             formatters=(
-                Formatters.green_alert(lambda edata: edata.value),
-                Formatters.red_alert(lambda edata: not edata.value),
+                Formatters.red_alert(lambda edata: edata.value),
+                Formatters.green_alert(lambda edata: not edata.value),
             ),
         ),
         Field(

--- a/lib/view/templates.py
+++ b/lib/view/templates.py
@@ -318,13 +318,13 @@ info_namespace_usage_sheet = Sheet(
                     formatters=(
                         Formatters.yellow_alert(
                             lambda edata: edata.value * 100
-                            >= edata.record["Primary Index"]["HWM%"]
-                            and edata.record["Primary Index"]["HWM%"] != 0
+                            >= edata.record["Primary Index"]["Evict%"]
+                            and edata.record["Primary Index"]["Evict%"] != 0
                         ),
                     ),
                 ),
                 Field(
-                    "HWM%",
+                    "Evict%",
                     Projectors.Number(
                         "ns_stats",
                         "index-type.evict-mounts-pct",  # Added in 7.0
@@ -382,14 +382,14 @@ info_namespace_usage_sheet = Sheet(
                     ),
                     formatters=(
                         Formatters.yellow_alert(
-                            lambda edata: edata.value
-                            >= edata.record["Secondary Index"]["HWM%"]
-                            and edata.record["Secondary Index"]["HWM%"] != 0
+                            lambda edata: edata.value * 100
+                            >= edata.record["Secondary Index"]["Evict%"]
+                            and edata.record["Secondary Index"]["Evict%"] != 0
                         ),
                     ),
                 ),
                 Field(
-                    "HWM%",
+                    "Evict%",
                     Projectors.Number(
                         "ns_stats",
                         "sindex-type.evict-mounts-pct",  # Added in 7.0
@@ -1450,11 +1450,7 @@ summary_cluster_sheet = Sheet(
         #     this will only be displayed in 7.0. Pre 7.0 includes shmem index metrics
         #     as apart of memory metrics.
         #     (
-        create_summary_total("cluster_dict", "shmem_index"),
         create_summary_used("cluster_dict", "shmem_index"),
-        create_summary_used_pct("cluster_dict", "shmem_index"),
-        create_summary_avail("cluster_dict", "shmem_index"),
-        create_summary_avail_pct("cluster_dict", "shmem_index"),
         #     ),
         # ),
         # Subgroup(

--- a/lib/view/templates.py
+++ b/lib/view/templates.py
@@ -270,179 +270,6 @@ info_namespace_usage_sheet = Sheet(
             ),
         ),
         Subgroup(
-            "Storage Engine",
-            (
-                Field("Type", Projectors.String("ns_stats", "storage-engine")),
-                Field(
-                    "Total",
-                    Projectors.Number(
-                        "ns_stats",
-                        "data_total_bytes",
-                    ),
-                    hidden=True,
-                ),
-                Field(
-                    "Used",
-                    Projectors.Number(
-                        "ns_stats",
-                        "data_used_bytes",
-                    ),
-                    converter=Converters.byte,
-                    aggregator=Aggregators.sum(),
-                ),
-                Field(
-                    "Used%",
-                    Projectors.Div(
-                        Projectors.Number(
-                            "ns_stats",
-                            "data_used_bytes",
-                        ),
-                        Projectors.Number(
-                            "ns_stats",
-                            "data_total_bytes",
-                        ),
-                    ),
-                    converter=Converters.ratio_to_pct,
-                    aggregator=ComplexAggregator(
-                        create_usage_weighted_avg("Storage Engine"),
-                        converter=Converters.ratio_to_pct,
-                    ),
-                    formatters=(
-                        Formatters.yellow_alert(
-                            lambda edata: edata.value * 100
-                            >= edata.record["Storage Engine"]["Evict%"]
-                            and edata.record["Storage Engine"]["Evict%"] != 0
-                        ),
-                    ),
-                ),
-                Field(
-                    "Evict%",
-                    Projectors.Number("ns_stats", "evict-used-pct"),
-                    converter=Converters.pct,
-                ),
-                Field(
-                    "Avail%",
-                    Projectors.Number(
-                        "ns_stats",
-                        "data_avail_pct",
-                    ),
-                    converter=Converters.pct,
-                    formatters=(Formatters.red_alert(lambda edata: edata.value < 10),),
-                ),
-            ),
-        ),
-        # Replaced by "Storage Engine" in 7.0. This will
-        # only be displayed if the cluster is running 6.4 or earlier.
-        Subgroup(
-            "Device",
-            (
-                Field(
-                    "Total",
-                    Projectors.Number(
-                        "ns_stats", "device_total_bytes", "total-bytes-disk"
-                    ),
-                    hidden=True,
-                ),
-                Field(
-                    "Used",
-                    Projectors.Number(
-                        "ns_stats", "device_used_bytes", "used-bytes-disk"
-                    ),
-                    converter=Converters.byte,
-                    aggregator=Aggregators.sum(),
-                ),
-                Field(
-                    "Used%",
-                    Projectors.Div(
-                        Projectors.Number(
-                            "ns_stats", "device_used_bytes", "used-bytes-disk"
-                        ),
-                        Projectors.Number(
-                            "ns_stats", "device_total_bytes", "total-bytes-disk"
-                        ),
-                    ),
-                    converter=Converters.ratio_to_pct,
-                    aggregator=ComplexAggregator(
-                        create_usage_weighted_avg("Device"),
-                        converter=Converters.ratio_to_pct,
-                    ),
-                    formatters=(
-                        Formatters.yellow_alert(
-                            lambda edata: edata.value * 100
-                            >= edata.record["Device"]["HWM%"]
-                            and edata.record["Device"]["HWM%"] != 0
-                        ),
-                    ),
-                ),
-                Field(
-                    "HWM%",
-                    Projectors.Number("ns_stats", "high-water-disk-pct"),
-                    converter=Converters.pct,
-                ),
-                Field(
-                    "Avail%",
-                    Projectors.Number(
-                        "ns_stats", "device_available_pct", "available_pct"
-                    ),
-                    converter=Converters.pct,
-                    formatters=(Formatters.red_alert(lambda edata: edata.value < 10),),
-                ),
-            ),
-        ),
-        # Memory was unified in pindex, sindex, and storage-engine in 7.0. This will
-        # only be displayed if the cluster is running 6.4 or earlier.
-        Subgroup(
-            "Memory",
-            (
-                Field(
-                    "Total",
-                    Projectors.Number("ns_stats", "memory-size", "total-bytes-memory"),
-                    hidden=True,
-                ),
-                Field(
-                    "Used",
-                    Projectors.Number(
-                        "ns_stats", "memory_used_bytes", "used-bytes-memory"
-                    ),
-                    converter=Converters.byte,
-                    aggregator=Aggregators.sum(),
-                ),
-                Field(
-                    "Used%",
-                    Projectors.Div(
-                        Projectors.Number(
-                            "ns_stats", "memory_used_bytes", "used-bytes-memory"
-                        ),
-                        Projectors.Number(
-                            "ns_stats", "memory-size", "total-bytes-memory"
-                        ),
-                    ),
-                    converter=Converters.ratio_to_pct,
-                    aggregator=ComplexAggregator(
-                        create_usage_weighted_avg("Memory"),
-                        converter=Converters.ratio_to_pct,
-                    ),
-                    formatters=(
-                        Formatters.yellow_alert(
-                            lambda edata: edata.value * 100
-                            > edata.record["Memory"]["HWM%"]
-                            and edata.record["Memory"]["HWM%"] != 0
-                        ),
-                    ),
-                ),
-                Field(
-                    "HWM%",
-                    Projectors.Number("ns_stats", "high-water-memory-pct"),
-                    converter=Converters.pct,
-                ),
-                Field(
-                    "Stop%",
-                    Projectors.Number("ns_stats", "stop-writes-pct"),
-                    converter=Converters.pct,
-                ),
-            ),
-        ),
-        Subgroup(
             "Primary Index",
             (
                 Field("Type", Projectors.String("ns_stats", "index-type")),
@@ -568,6 +395,179 @@ info_namespace_usage_sheet = Sheet(
                         "sindex-type.evict-mounts-pct",  # Added in 7.0
                         "sindex-type.mounts-high-water-pct",
                     ),
+                ),
+            ),
+        ),
+        Subgroup(
+            "Storage Engine",
+            (
+                Field("Type", Projectors.String("ns_stats", "storage-engine")),
+                Field(
+                    "Total",
+                    Projectors.Number(
+                        "ns_stats",
+                        "data_total_bytes",
+                    ),
+                    hidden=True,
+                ),
+                Field(
+                    "Used",
+                    Projectors.Number(
+                        "ns_stats",
+                        "data_used_bytes",
+                    ),
+                    converter=Converters.byte,
+                    aggregator=Aggregators.sum(),
+                ),
+                Field(
+                    "Used%",
+                    Projectors.Div(
+                        Projectors.Number(
+                            "ns_stats",
+                            "data_used_bytes",
+                        ),
+                        Projectors.Number(
+                            "ns_stats",
+                            "data_total_bytes",
+                        ),
+                    ),
+                    converter=Converters.ratio_to_pct,
+                    aggregator=ComplexAggregator(
+                        create_usage_weighted_avg("Storage Engine"),
+                        converter=Converters.ratio_to_pct,
+                    ),
+                    formatters=(
+                        Formatters.yellow_alert(
+                            lambda edata: edata.value * 100
+                            >= edata.record["Storage Engine"]["Evict%"]
+                            and edata.record["Storage Engine"]["Evict%"] != 0
+                        ),
+                    ),
+                ),
+                Field(
+                    "Evict%",
+                    Projectors.Number("ns_stats", "evict-used-pct"),
+                    converter=Converters.pct,
+                ),
+                Field(
+                    "Avail%",
+                    Projectors.Number(
+                        "ns_stats",
+                        "data_avail_pct",
+                    ),
+                    converter=Converters.pct,
+                    formatters=(Formatters.red_alert(lambda edata: edata.value < 10),),
+                ),
+            ),
+        ),
+        # Memory was unified in pindex, sindex, and storage-engine in 7.0. This will
+        # only be displayed if the cluster is running 6.4 or earlier.
+        Subgroup(
+            "Memory",
+            (
+                Field(
+                    "Total",
+                    Projectors.Number("ns_stats", "memory-size", "total-bytes-memory"),
+                    hidden=True,
+                ),
+                Field(
+                    "Used",
+                    Projectors.Number(
+                        "ns_stats", "memory_used_bytes", "used-bytes-memory"
+                    ),
+                    converter=Converters.byte,
+                    aggregator=Aggregators.sum(),
+                ),
+                Field(
+                    "Used%",
+                    Projectors.Div(
+                        Projectors.Number(
+                            "ns_stats", "memory_used_bytes", "used-bytes-memory"
+                        ),
+                        Projectors.Number(
+                            "ns_stats", "memory-size", "total-bytes-memory"
+                        ),
+                    ),
+                    converter=Converters.ratio_to_pct,
+                    aggregator=ComplexAggregator(
+                        create_usage_weighted_avg("Memory"),
+                        converter=Converters.ratio_to_pct,
+                    ),
+                    formatters=(
+                        Formatters.yellow_alert(
+                            lambda edata: edata.value * 100
+                            > edata.record["Memory"]["HWM%"]
+                            and edata.record["Memory"]["HWM%"] != 0
+                        ),
+                    ),
+                ),
+                Field(
+                    "HWM%",
+                    Projectors.Number("ns_stats", "high-water-memory-pct"),
+                    converter=Converters.pct,
+                ),
+                Field(
+                    "Stop%",
+                    Projectors.Number("ns_stats", "stop-writes-pct"),
+                    converter=Converters.pct,
+                ),
+            ),
+        ),
+        # Replaced by "Storage Engine" in 7.0. This will
+        # only be displayed if the cluster is running 6.4 or earlier.
+        Subgroup(
+            "Device",
+            (
+                Field(
+                    "Total",
+                    Projectors.Number(
+                        "ns_stats", "device_total_bytes", "total-bytes-disk"
+                    ),
+                    hidden=True,
+                ),
+                Field(
+                    "Used",
+                    Projectors.Number(
+                        "ns_stats", "device_used_bytes", "used-bytes-disk"
+                    ),
+                    converter=Converters.byte,
+                    aggregator=Aggregators.sum(),
+                ),
+                Field(
+                    "Used%",
+                    Projectors.Div(
+                        Projectors.Number(
+                            "ns_stats", "device_used_bytes", "used-bytes-disk"
+                        ),
+                        Projectors.Number(
+                            "ns_stats", "device_total_bytes", "total-bytes-disk"
+                        ),
+                    ),
+                    converter=Converters.ratio_to_pct,
+                    aggregator=ComplexAggregator(
+                        create_usage_weighted_avg("Device"),
+                        converter=Converters.ratio_to_pct,
+                    ),
+                    formatters=(
+                        Formatters.yellow_alert(
+                            lambda edata: edata.value * 100
+                            >= edata.record["Device"]["HWM%"]
+                            and edata.record["Device"]["HWM%"] != 0
+                        ),
+                    ),
+                ),
+                Field(
+                    "HWM%",
+                    Projectors.Number("ns_stats", "high-water-disk-pct"),
+                    converter=Converters.pct,
+                ),
+                Field(
+                    "Avail%",
+                    Projectors.Number(
+                        "ns_stats", "device_available_pct", "available_pct"
+                    ),
+                    converter=Converters.pct,
+                    formatters=(Formatters.red_alert(lambda edata: edata.value < 10),),
                 ),
             ),
         ),

--- a/lib/view/templates.py
+++ b/lib/view/templates.py
@@ -437,16 +437,25 @@ info_namespace_usage_sheet = Sheet(
                         converter=Converters.ratio_to_pct,
                     ),
                     formatters=(
-                        Formatters.yellow_alert(
+                        Formatters.red_alert(
                             lambda edata: edata.value * 100
                             >= edata.record["Storage Engine"]["Evict%"]
                             and edata.record["Storage Engine"]["Evict%"] != 0
+                            or edata.value * 100
+                            >= edata.record["Storage Engine"]["Used Stop%"]
                         ),
                     ),
                 ),
                 Field(
                     "Evict%",
-                    Projectors.Number("ns_stats", "evict-used-pct"),
+                    Projectors.Number("ns_stats", "storage-engine.evict-used-pct"),
+                    converter=Converters.pct,
+                ),
+                Field(
+                    "Used Stop%",
+                    Projectors.Number(
+                        "ns_stats", "storage-engine.stop-writes-used-pct"
+                    ),
                     converter=Converters.pct,
                 ),
                 Field(
@@ -456,7 +465,19 @@ info_namespace_usage_sheet = Sheet(
                         "data_avail_pct",
                     ),
                     converter=Converters.pct,
-                    formatters=(Formatters.red_alert(lambda edata: edata.value < 10),),
+                    formatters=(
+                        Formatters.red_alert(
+                            lambda edata: edata.value
+                            <= edata.record["Storage Engine"]["Avail Stop%"]
+                        ),
+                    ),
+                ),
+                Field(
+                    "Avail Stop%",
+                    Projectors.Number(
+                        "ns_stats", "storage-engine.stop-writes-avail-pct"
+                    ),
+                    converter=Converters.pct,
                 ),
             ),
         ),

--- a/lib/view/templates.py
+++ b/lib/view/templates.py
@@ -770,7 +770,11 @@ info_set_sheet = Sheet(
                         Projectors.Any(
                             FieldType.number,
                             Projectors.Number("set_stats", "data_used_bytes"),
-                            Projectors.Sum(
+                            Projectors.Func(
+                                FieldType.number,
+                                lambda m_data, d_data: d_data
+                                if m_data == 0
+                                else m_data,
                                 Projectors.Number(
                                     "set_stats",
                                     "memory_data_bytes",

--- a/lib/view/templates.py
+++ b/lib/view/templates.py
@@ -710,14 +710,24 @@ info_set_sheet = Sheet(
         hidden_node_id_field,
         Field("Set Delete", Projectors.Boolean("set_stats", "deleting", "set-delete")),
         Field(
+            "Storage Engine Used",
+            Projectors.Number("set_stats", "data_used_bytes"),  # New in server 7.0
+            converter=Converters.byte,
+            aggregator=Aggregators.sum(),
+        ),
+        Field(
             "Memory Used",
-            Projectors.Number("set_stats", "memory_data_bytes", "n-bytes-memory"),
+            Projectors.Number(
+                "set_stats", "memory_data_bytes", "n-bytes-memory"
+            ),  # Unified into data_used_bytes in 7.0
             converter=Converters.byte,
             aggregator=Aggregators.sum(),
         ),
         Field(
             "Disk Used",
-            Projectors.Number("set_stats", "device_data_bytes", "n-bytes-device"),
+            Projectors.Number(
+                "set_stats", "device_data_bytes", "n-bytes-device"
+            ),  # Unified into data_used_bytes in 7.0
             converter=Converters.byte,
             aggregator=Aggregators.sum(),
         ),
@@ -736,12 +746,20 @@ info_set_sheet = Sheet(
                 Field(
                     "Used%",
                     Projectors.Div(
-                        Projectors.Sum(
-                            Projectors.Number(
-                                "set_stats", "memory_data_bytes", "n-bytes-memory"
-                            ),
-                            Projectors.Number(
-                                "set_stats", "device_data_bytes", "n-bytes-device"
+                        Projectors.Any(
+                            FieldType.number,
+                            Projectors.Number("set_stats", "data_used_bytes"),
+                            Projectors.Sum(
+                                Projectors.Number(
+                                    "set_stats",
+                                    "memory_data_bytes",
+                                    "n-bytes-memory",  # Unified into data_used_bytes in 7.0
+                                ),
+                                Projectors.Number(
+                                    "set_stats",
+                                    "device_data_bytes",
+                                    "n-bytes-device",  # Unified into data_used_bytes in 7.0
+                                ),
                             ),
                         ),
                         Projectors.Number("set_stats", "stop-writes-size"),

--- a/lib/view/view.py
+++ b/lib/view/view.py
@@ -2327,8 +2327,8 @@ class CliView(object):
     @staticmethod
     def _summary_namespace_list_view(
         stats: SummaryNamespacesDict, **ignore
-    ) -> list[str | list[str | SummaryLine]]:
-        lines: list[str | list[str | CliView.SummaryLine]] = []
+    ) -> list[str | NumberedList]:
+        lines: list[str | CliView.NumberedList] = []
         lines.append("Namespaces")
         lines.append("==========")
         lines.append("")

--- a/lib/view/view.py
+++ b/lib/view/view.py
@@ -2087,7 +2087,7 @@ class CliView(object):
             self.info = info
 
         def __str__(self) -> str:
-            s = self.name.ljust(19)
+            s = self.name.ljust(25)
             s += ":" + (" " * 2)
             return s + self.info
 

--- a/lib/view/view.py
+++ b/lib/view/view.py
@@ -161,7 +161,9 @@ class CliView(object):
 
     @staticmethod
     @reserved_modifiers
-    def info_namespace_usage(stats, cluster, timestamp="", with_=None, **ignore):
+    def info_namespace_usage(
+        ns_stats, service_stats, cluster, timestamp="", with_=None, **ignore
+    ):
         node_names = cluster.get_node_names(with_)
         node_ids = cluster.get_node_ids(with_)
         title_suffix = CliView._get_timestamp_suffix(timestamp)
@@ -169,7 +171,8 @@ class CliView(object):
         sources = dict(
             node_ids=node_ids,
             node_names=node_names,
-            ns_stats=stats,
+            ns_stats=ns_stats,
+            service_stats=service_stats,
         )
         common = dict(principal=cluster.get_expected_principal())
 

--- a/lib/view/view.py
+++ b/lib/view/view.py
@@ -2145,9 +2145,9 @@ class CliView(object):
             try:
                 # license_data was computed by uda
                 time_ = license_dict["latest_time"]
-                time_.strftime("%H:%M:%S %m/%d/%Y")
+                time_str = time_.isoformat()
 
-                s += f"Latest ({time_}): {file_size.size(license_dict['latest'])} Min: {file_size.size(license_dict['min'])} Max: {file_size.size(license_dict['max'])} Avg: {file_size.size(license_dict['avg'])}"
+                s += f"Latest ({time_str}): {file_size.size(license_dict['latest'])} Min: {file_size.size(license_dict['min'])} Max: {file_size.size(license_dict['max'])} Avg: {file_size.size(license_dict['avg'])}"
 
             except Exception:
                 # license_data was manually computed by asadm

--- a/test/unit/utils/test_common.py
+++ b/test/unit/utils/test_common.py
@@ -1183,13 +1183,13 @@ class CreateStopWritesSummaryTests(asynctest.TestCase):
                     },
                 },
                 ns_config={
-                    "1.1.1.1": {"ns1": {"stop-writes-used-pct": "90"}},
+                    "1.1.1.1": {"ns1": {"storage-engine.stop-writes-used-pct": "90"}},
                 },
                 expected={
                     "1.1.1.1": {
                         ("ns1", None, "data_used_bytes"): {
                             "metric": "data_used_bytes",
-                            "config": "stop-writes-used-pct",
+                            "config": "storage-engine.stop-writes-used-pct",
                             "stop_writes": False,
                             "metric_usage": 10,
                             "metric_threshold": 90,
@@ -1210,13 +1210,13 @@ class CreateStopWritesSummaryTests(asynctest.TestCase):
                     },
                 },
                 ns_config={
-                    "1.1.1.1": {"ns1": {"stop-writes-used-pct": "90"}},
+                    "1.1.1.1": {"ns1": {"storage-engine.stop-writes-used-pct": "90"}},
                 },
                 expected={
                     "1.1.1.1": {
                         ("ns1", None, "data_used_bytes"): {
                             "metric": "data_used_bytes",
-                            "config": "stop-writes-used-pct",
+                            "config": "storage-engine.stop-writes-used-pct",
                             "stop_writes": True,
                             "metric_usage": 90,
                             "metric_threshold": 90,

--- a/test/unit/utils/test_common.py
+++ b/test/unit/utils/test_common.py
@@ -51,542 +51,635 @@ class ComputeLicenseDataSizeTest(asynctest.TestCase):
             expected_summary_dict, summary_dict, "Input: " + str(namespace_stats)
         )
 
-    def test_success_with_out_agent(self):
-        test_cases = [
-            {
-                "ns_stats": {},
-                "license_data": None,
-                "server_builds": {},
-                "allow_unstable": False,
-                "exp_summary_dict": {},
-            },
-            {
-                "ns_stats": {
-                    "foo": {
-                        "1.1.1.1": {
-                            "master_objects": 100,
-                            "effective_replication_factor": 2,
-                            "pmem_used_bytes": 99000,
-                        }
-                    }
+    @parameterized.expand(
+        [
+            (
+                {
+                    "ns_stats": {},
+                    "license_data": None,
+                    "server_builds": {},
+                    "allow_unstable": False,
+                    "exp_summary_dict": {},
                 },
-                "license_data": None,
-                "server_builds": {"1.1.1.1": "5.0.0.0"},
-                "allow_unstable": False,
-                "exp_summary_dict": {
-                    "CLUSTER": {"license_data": {"latest": 46000}},
-                    "NAMESPACES": {"foo": {"license_data": {"latest": 46000}}},
-                },
-            },
-            {
-                "ns_stats": {
-                    "foo": {
-                        "1.1.1.1": {
-                            "master_objects": 100,
-                            "effective_replication_factor": 2,
-                            "pmem_used_bytes": 99000,
-                        },
-                        "2.2.2.2": {
-                            "master_objects": 100,
-                            "effective_replication_factor": 0,  # tie-breaker node
-                            "pmem_used_bytes": 99000,
-                        },
-                    }
-                },
-                "server_builds": {"1.1.1.1": "5.0.0.0"},
-                "license_data": {},
-                "allow_unstable": False,
-                "exp_summary_dict": {
-                    "CLUSTER": {
-                        "license_data": {"latest": int((99000 / 2) - (35 * 100))}
-                    },
-                    "NAMESPACES": {
+            ),
+            (
+                {
+                    "ns_stats": {
                         "foo": {
+                            "1.1.1.1": {
+                                "master_objects": 100,
+                                "effective_replication_factor": 2,
+                                "pmem_used_bytes": 99000,
+                            }
+                        }
+                    },
+                    "license_data": None,
+                    "server_builds": {"1.1.1.1": "5.0.0.0"},
+                    "allow_unstable": False,
+                    "exp_summary_dict": {
+                        "CLUSTER": {"license_data": {"latest": 46000}},
+                        "NAMESPACES": {"foo": {"license_data": {"latest": 46000}}},
+                    },
+                },
+            ),
+            (
+                {
+                    "ns_stats": {
+                        "foo": {
+                            "1.1.1.1": {
+                                "master_objects": 100,
+                                "effective_replication_factor": 2,
+                                "pmem_used_bytes": 99000,
+                            },
+                            "2.2.2.2": {
+                                "master_objects": 100,
+                                "effective_replication_factor": 0,  # tie-breaker node
+                                "pmem_used_bytes": 99000,
+                            },
+                        }
+                    },
+                    "server_builds": {"1.1.1.1": "5.0.0.0"},
+                    "license_data": {},
+                    "allow_unstable": False,
+                    "exp_summary_dict": {
+                        "CLUSTER": {
                             "license_data": {"latest": int((99000 / 2) - (35 * 100))}
-                        }
+                        },
+                        "NAMESPACES": {
+                            "foo": {
+                                "license_data": {
+                                    "latest": int((99000 / 2) - (35 * 100))
+                                }
+                            }
+                        },
                     },
                 },
-            },
-            {
-                "ns_stats": {
-                    "foo": {
-                        "1.1.1.1": {
-                            "master_objects": 100,
-                            "effective_replication_factor": 2,
-                            "pmem_used_bytes": 99000,
-                        },
-                        "2.2.2.2": {
-                            "master_objects": 100,
-                            "effective_replication_factor": 2,  # tie-breaker node
-                            "pmem_used_bytes": 99000,
-                        },
-                    }
-                },
-                "server_builds": {"1.1.1.1": "5.0.0.0", "2.2.2.2": "6.0.0.0"},
-                "license_data": {},
-                "allow_unstable": False,
-                "exp_summary_dict": {
-                    "CLUSTER": {
-                        "license_data": {
-                            "latest": int(
-                                ((99000 / 2) - (35 * 100)) + ((99000 / 2) - (39 * 100))
-                            )
-                        }
-                    },
-                    "NAMESPACES": {
+            ),
+            (
+                {
+                    "ns_stats": {
                         "foo": {
+                            "1.1.1.1": {
+                                "master_objects": 100,
+                                "effective_replication_factor": 2,
+                                "pmem_used_bytes": 99000,
+                            },
+                            "2.2.2.2": {
+                                "master_objects": 100,
+                                "effective_replication_factor": 2,  # tie-breaker node
+                                "pmem_used_bytes": 99000,
+                            },
+                        }
+                    },
+                    "server_builds": {"1.1.1.1": "5.0.0.0", "2.2.2.2": "6.0.0.0"},
+                    "license_data": {},
+                    "allow_unstable": False,
+                    "exp_summary_dict": {
+                        "CLUSTER": {
                             "license_data": {
                                 "latest": int(
                                     ((99000 / 2) - (35 * 100))
                                     + ((99000 / 2) - (39 * 100))
                                 )
                             }
-                        }
-                    },
-                },
-            },
-            {
-                "ns_stats": {
-                    "foo": {
-                        "1.1.1.1": {
-                            "master_objects": 100,
-                            "effective_replication_factor": 2,
-                            "device_used_bytes": 7200,
-                        }
-                    }
-                },
-                "server_builds": {"1.1.1.1": "5.0.0.0"},
-                "license_data": None,
-                "allow_unstable": False,
-                "exp_summary_dict": {
-                    "CLUSTER": {"license_data": {"latest": 100}},
-                    "NAMESPACES": {"foo": {"license_data": {"latest": 100}}},
-                },
-            },
-            {
-                "ns_stats": {
-                    "foo": {
-                        "1.1.1.1": {
-                            "master_objects": 100,
-                            "effective_replication_factor": 2,
-                            "pmem_used_bytes": 8000,
-                            "memory_used_bytes": 800,
-                        }
-                    },
-                    "bar": {
-                        "1.1.1.1": {
-                            "master_objects": 50,
-                            "effective_replication_factor": 3,
-                            "device_used_bytes": 6000,
-                            "memory_used_bytes": 3300,
-                        }
-                    },
-                },
-                "license_data": None,
-                "server_builds": {"1.1.1.1": "5.0.0.0"},
-                "allow_unstable": False,
-                "exp_summary_dict": {
-                    "CLUSTER": {"license_data": {"latest": 500 + 250}},
-                    "NAMESPACES": {
-                        "foo": {"license_data": {"latest": 500}},
-                        "bar": {"license_data": {"latest": 250}},
-                    },
-                },
-            },
-            {
-                "ns_stats": {
-                    "foo": {
-                        "1.1.1.1": {
-                            "master_objects": 100,
-                            "effective_replication_factor": 2,
-                            "device_used_bytes": 7200,
-                            "memory_used_bytes": 800,
                         },
-                        "2.2.2.2": {
-                            "master_objects": 10,
-                            "effective_replication_factor": 2,
-                            "device_used_bytes": 3200,
-                            "memory_used_bytes": 10000,
-                        },
-                    },
-                    "bar": {
-                        "1.1.1.1": {
-                            "master_objects": 50,
-                            "effective_replication_factor": 3,
-                            "pmem_used_bytes": 50000,
-                        },
-                        "2.2.2.2": {
-                            "master_objects": 10,
-                            "effective_replication_factor": 3,
-                            "pmem_used_bytes": 10000,
+                        "NAMESPACES": {
+                            "foo": {
+                                "license_data": {
+                                    "latest": int(
+                                        ((99000 / 2) - (35 * 100))
+                                        + ((99000 / 2) - (39 * 100))
+                                    )
+                                }
+                            }
                         },
                     },
                 },
-                "license_data": None,
-                "allow_unstable": False,
-                "server_builds": {"1.1.1.1": "5.0.0.0", "2.2.2.2": "5.0.0.0"},
-                "exp_summary_dict": {
-                    "CLUSTER": {
-                        "license_data": {
-                            "latest": int(
-                                ((7200 + 3200) / 2)
-                                - (110 * 35)
-                                + ((50000 + 10000) / 3)
-                                - (35 * 60)
-                            )
-                        },
-                    },
-                    "NAMESPACES": {
+            ),
+            (
+                {
+                    "ns_stats": {
                         "foo": {
-                            "license_data": {
-                                "latest": int(((7200 + 3200) / 2) - (110 * 35))
+                            "1.1.1.1": {
+                                "master_objects": 100,
+                                "effective_replication_factor": 2,
+                                "device_used_bytes": 7200,
+                            }
+                        }
+                    },
+                    "server_builds": {"1.1.1.1": "5.0.0.0"},
+                    "license_data": None,
+                    "allow_unstable": False,
+                    "exp_summary_dict": {
+                        "CLUSTER": {"license_data": {"latest": 100}},
+                        "NAMESPACES": {"foo": {"license_data": {"latest": 100}}},
+                    },
+                },
+            ),
+            (
+                {
+                    "ns_stats": {
+                        "foo": {
+                            "1.1.1.1": {
+                                "master_objects": 100,
+                                "effective_replication_factor": 2,
+                                "pmem_used_bytes": 8000,
+                                "memory_used_bytes": 800,
                             }
                         },
                         "bar": {
+                            "1.1.1.1": {
+                                "master_objects": 50,
+                                "effective_replication_factor": 3,
+                                "device_used_bytes": 6000,
+                                "memory_used_bytes": 3300,
+                            }
+                        },
+                    },
+                    "license_data": None,
+                    "server_builds": {"1.1.1.1": "5.0.0.0"},
+                    "allow_unstable": False,
+                    "exp_summary_dict": {
+                        "CLUSTER": {"license_data": {"latest": 500 + 250}},
+                        "NAMESPACES": {
+                            "foo": {"license_data": {"latest": 500}},
+                            "bar": {"license_data": {"latest": 250}},
+                        },
+                    },
+                },
+            ),
+            (
+                {
+                    "ns_stats": {
+                        "foo": {
+                            "1.1.1.1": {
+                                "master_objects": 100,
+                                "effective_replication_factor": 2,
+                                "device_used_bytes": 7200,
+                                "memory_used_bytes": 800,
+                            },
+                            "2.2.2.2": {
+                                "master_objects": 10,
+                                "effective_replication_factor": 2,
+                                "device_used_bytes": 3200,
+                                "memory_used_bytes": 10000,
+                            },
+                        },
+                        "bar": {
+                            "1.1.1.1": {
+                                "master_objects": 50,
+                                "effective_replication_factor": 3,
+                                "pmem_used_bytes": 50000,
+                            },
+                            "2.2.2.2": {
+                                "master_objects": 10,
+                                "effective_replication_factor": 3,
+                                "pmem_used_bytes": 10000,
+                            },
+                        },
+                    },
+                    "license_data": None,
+                    "allow_unstable": False,
+                    "server_builds": {"1.1.1.1": "5.0.0.0", "2.2.2.2": "5.0.0.0"},
+                    "exp_summary_dict": {
+                        "CLUSTER": {
                             "license_data": {
-                                "latest": int(((50000 + 10000) / 3) - (35 * 60))
+                                "latest": int(
+                                    ((7200 + 3200) / 2)  # foo
+                                    - (110 * 35)
+                                    + ((50000 + 10000) / 3)  # bar
+                                    - (35 * 60)
+                                )
+                            },
+                        },
+                        "NAMESPACES": {
+                            "foo": {
+                                "license_data": {
+                                    "latest": int(((7200 + 3200) / 2) - (110 * 35))
+                                }
+                            },
+                            "bar": {
+                                "license_data": {
+                                    "latest": int(((50000 + 10000) / 3) - (35 * 60))
+                                }
+                            },
+                        },
+                    },
+                },
+            ),
+            (
+                {
+                    "ns_stats": {
+                        "foo": {
+                            "1.1.1.1": {
+                                "master_objects": 100,
+                                "effective_replication_factor": 2,
+                                "data_used_bytes": 7200,
+                                "data_compression_ratio": 0.5,
+                            },
+                            "2.2.2.2": {
+                                "master_objects": 10,
+                                "effective_replication_factor": 2,
+                                "data_used_bytes": 3200,
+                                "data_compression_ratio": 0.2,
+                            },
+                        },
+                        "bar": {
+                            "1.1.1.1": {
+                                "master_objects": 50,
+                                "effective_replication_factor": 3,
+                                "data_used_bytes": 50000,
+                            },
+                            "2.2.2.2": {
+                                "master_objects": 10,
+                                "effective_replication_factor": 3,
+                                "data_used_bytes": 10000,
+                            },
+                        },
+                    },
+                    "license_data": None,
+                    "allow_unstable": False,
+                    "server_builds": {"1.1.1.1": "5.0.0.0", "2.2.2.2": "5.0.0.0"},
+                    "exp_summary_dict": {
+                        "CLUSTER": {
+                            "license_data": {
+                                "latest": int(
+                                    ((7200 / 0.5 + 3200 / 0.2) / 2)  # foo
+                                    - (110 * 35)
+                                    + ((50000 + 10000) / 3)  # bar
+                                    - (35 * 60)
+                                )
+                            },
+                        },
+                        "NAMESPACES": {
+                            "foo": {
+                                "license_data": {
+                                    "latest": int(
+                                        ((7200 / 0.5 + 3200 / 0.2) / 2) - (110 * 35)
+                                    )
+                                }
+                            },
+                            "bar": {
+                                "license_data": {
+                                    "latest": int(((50000 + 10000) / 3) - (35 * 60))
+                                }
+                            },
+                        },
+                    },
+                },
+            ),
+        ]
+    )
+    # Try to parameterize these tests and add a test using "data_used_bytes"
+    def test_success_with_out_agent(self, tc):
+        self.run_test_case(
+            tc["ns_stats"],
+            tc["server_builds"],
+            tc["license_data"],
+            tc["allow_unstable"],
+            tc["exp_summary_dict"],
+        )
+
+    @parameterized.expand(
+        [
+            (
+                {
+                    "ns_stats": {"foo": {}},
+                    "license_data": {
+                        "license_usage": {
+                            "count": 1,
+                            "entries": [
+                                {
+                                    "time": "2022-04-07T22:59:47",
+                                    "unique_data_bytes": 500,
+                                    "level": "info",
+                                    "cluster_stable": True,
+                                    "namespaces": {"foo": {"unique_data_bytes": 100}},
+                                }
+                            ],
+                        },
+                    },
+                    "allow_unstable": False,
+                    "exp_summary_dict": {
+                        "CLUSTER": {
+                            "license_data": {
+                                "latest_time": datetime.fromisoformat(
+                                    "2022-04-07T22:59:47"
+                                ),
+                                "latest": 500,
+                                "min": 500,
+                                "max": 500,
+                                "avg": 500,
+                            }
+                        },
+                        "NAMESPACES": {
+                            "foo": {
+                                "license_data": {
+                                    "latest_time": datetime.fromisoformat(
+                                        "2022-04-07T22:59:47"
+                                    ),
+                                    "latest": 100,
+                                    "min": 100,
+                                    "max": 100,
+                                    "avg": 100,
+                                }
                             }
                         },
                     },
                 },
-            },
-        ]
-
-        for tc in test_cases:
-            self.run_test_case(
-                tc["ns_stats"],
-                tc["server_builds"],
-                tc["license_data"],
-                tc["allow_unstable"],
-                tc["exp_summary_dict"],
-            )
-
-    def test_success_with_agent(self):
-        test_cases = [
-            {
-                "ns_stats": {"foo": {}},
-                "license_data": {
-                    "license_usage": {
-                        "count": 1,
-                        "entries": [
-                            {
-                                "time": "2022-04-07T22:59:47",
-                                "unique_data_bytes": 500,
-                                "level": "info",
-                                "cluster_stable": True,
-                                "namespaces": {"foo": {"unique_data_bytes": 100}},
-                            }
-                        ],
-                    },
-                },
-                "allow_unstable": False,
-                "exp_summary_dict": {
-                    "CLUSTER": {
-                        "license_data": {
-                            "latest_time": datetime.fromisoformat(
-                                "2022-04-07T22:59:47"
-                            ),
-                            "latest": 500,
-                            "min": 500,
-                            "max": 500,
-                            "avg": 500,
+            ),
+            (
+                {
+                    "ns_stats": {"foo": {}},
+                    "license_data": {
+                        "license_usage": {
+                            "count": 1,
+                            "entries": [
+                                {
+                                    "time": "2022-04-07T22:59:47",
+                                    "unique_data_bytes": 500,
+                                    "level": "info",
+                                    "cluster_stable": True,
+                                    "namespaces": {"foo": {"unique_data_bytes": 100}},
+                                },
+                                {
+                                    "latest_time": "2022-04-07T22:59:47",
+                                    "unique_data_bytes": 0,
+                                    "level": "error",
+                                    "namespaces": {"foo": {"unique_data_bytes": 100}},
+                                },
+                            ],
                         }
                     },
-                    "NAMESPACES": {
-                        "foo": {
-                            "license_data": {
-                                "latest_time": datetime.fromisoformat(
-                                    "2022-04-07T22:59:47"
-                                ),
-                                "latest": 100,
-                                "min": 100,
-                                "max": 100,
-                                "avg": 100,
-                            }
-                        }
-                    },
-                },
-            },
-            {
-                "ns_stats": {"foo": {}},
-                "license_data": {
-                    "license_usage": {
-                        "count": 1,
-                        "entries": [
-                            {
-                                "time": "2022-04-07T22:59:47",
-                                "unique_data_bytes": 500,
-                                "level": "info",
-                                "cluster_stable": True,
-                                "namespaces": {"foo": {"unique_data_bytes": 100}},
-                            },
-                            {
-                                "latest_time": "2022-04-07T22:59:47",
-                                "unique_data_bytes": 0,
-                                "level": "error",
-                                "namespaces": {"foo": {"unique_data_bytes": 100}},
-                            },
-                        ],
-                    }
-                },
-                "allow_unstable": False,
-                "exp_summary_dict": {
-                    "CLUSTER": {
-                        "license_data": {
-                            "latest_time": datetime.fromisoformat(
-                                "2022-04-07T22:59:47"
-                            ),
-                            "latest": 500,
-                            "min": 500,
-                            "max": 500,
-                            "avg": 500,
-                        }
-                    },
-                    "NAMESPACES": {
-                        "foo": {
-                            "license_data": {
-                                "latest_time": datetime.fromisoformat(
-                                    "2022-04-07T22:59:47"
-                                ),
-                                "latest": 100,
-                                "min": 100,
-                                "max": 100,
-                                "avg": 100,
-                            }
-                        }
-                    },
-                },
-            },
-            {
-                "ns_stats": {"foo": {}},
-                "license_data": {
-                    "license_usage": {
-                        "count": 2,
-                        "entries": [
-                            {
-                                "time": "2022-04-07T22:58:47",
-                                "unique_data_bytes": 500,
-                                "level": "info",
-                                "cluster_stable": True,
-                                "namespaces": {"foo": {"unique_data_bytes": 1000}},
-                            },
-                            {
-                                "time": "2022-04-07T22:59:47",
-                                "unique_data_bytes": 100,
-                                "level": "info",
-                                "cluster_stable": True,
-                                "namespaces": {"foo": {"unique_data_bytes": 500}},
-                            },
-                            {"unique_data_bytes": 0, "level": "error"},
-                        ],
-                    }
-                },
-                "allow_unstable": False,
-                "exp_summary_dict": {
-                    "CLUSTER": {
-                        "license_data": {
-                            "latest_time": datetime.fromisoformat(
-                                "2022-04-07T22:59:47"
-                            ),
-                            "latest": 100,
-                            "min": 100,
-                            "max": 500,
-                            "avg": 300,
-                        }
-                    },
-                    "NAMESPACES": {
-                        "foo": {
+                    "allow_unstable": False,
+                    "exp_summary_dict": {
+                        "CLUSTER": {
                             "license_data": {
                                 "latest_time": datetime.fromisoformat(
                                     "2022-04-07T22:59:47"
                                 ),
                                 "latest": 500,
                                 "min": 500,
-                                "max": 1000,
-                                "avg": 750,
+                                "max": 500,
+                                "avg": 500,
                             }
-                        }
+                        },
+                        "NAMESPACES": {
+                            "foo": {
+                                "license_data": {
+                                    "latest_time": datetime.fromisoformat(
+                                        "2022-04-07T22:59:47"
+                                    ),
+                                    "latest": 100,
+                                    "min": 100,
+                                    "max": 100,
+                                    "avg": 100,
+                                }
+                            }
+                        },
                     },
                 },
-            },
-            {
-                "ns_stats": {
-                    "foo": {
-                        "1.1.1.1": {
-                            "master_objects": 100,
-                            "effective_replication_factor": 2,
-                            "pmem_used_bytes": 99000,
-                        }
-                    }
-                },
-                "license_data": {
-                    "license_usage": {
-                        "count": 3,
-                        "entries": [
-                            {"unique_data_bytes": 500, "level": "error"},
-                            {"unique_data_bytes": 100, "level": "error"},
-                            {"unique_data_bytes": 0, "level": "error"},
-                        ],
-                    }
-                },
-                "allow_unstable": False,
-                "exp_summary_dict": {
-                    "CLUSTER": {"license_data": {"latest": 46000}},
-                    "NAMESPACES": {"foo": {"license_data": {"latest": 46000}}},
-                },
-            },
-            {
-                "ns_stats": {
-                    "foo": {
-                        "1.1.1.1": {
-                            "master_objects": 100,
-                            "effective_replication_factor": 2,
-                            "pmem_used_bytes": 99000,
-                        }
-                    }
-                },
-                "license_data": {
-                    "license_usage": {
-                        "count": 2,
-                        "entries": [
-                            {
-                                "time": "2022-04-07T22:58:47",
-                                "unique_data_bytes": 500,
-                                "level": "info",
-                                "cluster_stable": False,
-                                "namespaces": {"foo": {"unique_data_bytes": 1000}},
-                            },
-                            {
-                                "time": "2022-04-07T22:59:47",
-                                "unique_data_bytes": 100,
-                                "level": "info",
-                                "cluster_stable": False,
-                                "namespaces": {"foo": {"unique_data_bytes": 500}},
-                            },
-                            {"unique_data_bytes": 0, "level": "error"},
-                        ],
-                    }
-                },
-                "allow_unstable": False,
-                "exp_summary_dict": {
-                    "CLUSTER": {"license_data": {"latest": 46000}},
-                    "NAMESPACES": {"foo": {"license_data": {"latest": 46000}}},
-                },
-            },
-            {
-                "ns_stats": {"foo": {}},
-                "license_data": {
-                    "license_usage": {
-                        "count": 2,
-                        "entries": [
-                            {
-                                "time": "2022-04-07T22:58:47",
-                                "unique_data_bytes": 500,
-                                "level": "info",
-                                "cluster_stable": False,
-                                "namespaces": {"foo": {"unique_data_bytes": 1000}},
-                            },
-                            {
-                                "time": "2022-04-07T22:59:47",
-                                "unique_data_bytes": 100,
-                                "level": "info",
-                                "cluster_stable": False,
-                                "namespaces": {"foo": {"unique_data_bytes": 500}},
-                            },
-                            {"unique_data_bytes": 0, "level": "error"},
-                        ],
-                    }
-                },
-                "allow_unstable": True,
-                "exp_summary_dict": {
-                    "CLUSTER": {
-                        "license_data": {
-                            "latest_time": datetime.fromisoformat(
-                                "2022-04-07T22:59:47"
-                            ),
-                            "latest": 100,
-                            "min": 100,
-                            "max": 500,
-                            "avg": 300,
+            ),
+            (
+                {
+                    "ns_stats": {"foo": {}},
+                    "license_data": {
+                        "license_usage": {
+                            "count": 2,
+                            "entries": [
+                                {
+                                    "time": "2022-04-07T22:58:47",
+                                    "unique_data_bytes": 500,
+                                    "level": "info",
+                                    "cluster_stable": True,
+                                    "namespaces": {"foo": {"unique_data_bytes": 1000}},
+                                },
+                                {
+                                    "time": "2022-04-07T22:59:47",
+                                    "unique_data_bytes": 100,
+                                    "level": "info",
+                                    "cluster_stable": True,
+                                    "namespaces": {"foo": {"unique_data_bytes": 500}},
+                                },
+                                {"unique_data_bytes": 0, "level": "error"},
+                            ],
                         }
                     },
-                    "NAMESPACES": {
-                        "foo": {
+                    "allow_unstable": False,
+                    "exp_summary_dict": {
+                        "CLUSTER": {
                             "license_data": {
                                 "latest_time": datetime.fromisoformat(
                                     "2022-04-07T22:59:47"
                                 ),
-                                "latest": 500,
-                                "min": 500,
-                                "max": 1000,
-                                "avg": 750,
+                                "latest": 100,
+                                "min": 100,
+                                "max": 500,
+                                "avg": 300,
+                            }
+                        },
+                        "NAMESPACES": {
+                            "foo": {
+                                "license_data": {
+                                    "latest_time": datetime.fromisoformat(
+                                        "2022-04-07T22:59:47"
+                                    ),
+                                    "latest": 500,
+                                    "min": 500,
+                                    "max": 1000,
+                                    "avg": 750,
+                                }
+                            }
+                        },
+                    },
+                },
+            ),
+            (
+                {
+                    "ns_stats": {
+                        "foo": {
+                            "1.1.1.1": {
+                                "master_objects": 100,
+                                "effective_replication_factor": 2,
+                                "pmem_used_bytes": 99000,
                             }
                         }
                     },
-                },
-            },
-            {
-                "ns_stats": {"foo": {}},
-                "license_data": {
-                    "license_usage": {
-                        "count": 2,
-                        "entries": [
-                            {
-                                "time": "2022-04-07T22:58:47",
-                                "unique_data_bytes": 500,
-                                "level": "info",
-                                "cluster_stable": True,
-                                "namespaces": {"foo": {"unique_data_bytes": 1000}},
-                            },
-                            {
-                                "time": "2022-04-07T22:59:47",
-                                "unique_data_bytes": 100,
-                                "level": "info",
-                                "cluster_stable": False,
-                                "namespaces": {"foo": {"unique_data_bytes": 500}},
-                            },
-                            {"unique_data_bytes": 0, "level": "error"},
-                        ],
-                    }
-                },
-                "allow_unstable": False,
-                "exp_summary_dict": {
-                    "CLUSTER": {
-                        "license_data": {
-                            "latest_time": datetime.fromisoformat(
-                                "2022-04-07T22:58:47"
-                            ),
-                            "latest": 500,
-                            "min": 500,
-                            "max": 500,
-                            "avg": 500,
+                    "license_data": {
+                        "license_usage": {
+                            "count": 3,
+                            "entries": [
+                                {"unique_data_bytes": 500, "level": "error"},
+                                {"unique_data_bytes": 100, "level": "error"},
+                                {"unique_data_bytes": 0, "level": "error"},
+                            ],
                         }
                     },
-                    "NAMESPACES": {
+                    "allow_unstable": False,
+                    "exp_summary_dict": {
+                        "CLUSTER": {"license_data": {"latest": 46000}},
+                        "NAMESPACES": {"foo": {"license_data": {"latest": 46000}}},
+                    },
+                },
+            ),
+            (
+                {
+                    "ns_stats": {
                         "foo": {
+                            "1.1.1.1": {
+                                "master_objects": 100,
+                                "effective_replication_factor": 2,
+                                "pmem_used_bytes": 99000,
+                            }
+                        }
+                    },
+                    "license_data": {
+                        "license_usage": {
+                            "count": 2,
+                            "entries": [
+                                {
+                                    "time": "2022-04-07T22:58:47",
+                                    "unique_data_bytes": 500,
+                                    "level": "info",
+                                    "cluster_stable": False,
+                                    "namespaces": {"foo": {"unique_data_bytes": 1000}},
+                                },
+                                {
+                                    "time": "2022-04-07T22:59:47",
+                                    "unique_data_bytes": 100,
+                                    "level": "info",
+                                    "cluster_stable": False,
+                                    "namespaces": {"foo": {"unique_data_bytes": 500}},
+                                },
+                                {"unique_data_bytes": 0, "level": "error"},
+                            ],
+                        }
+                    },
+                    "allow_unstable": False,
+                    "exp_summary_dict": {
+                        "CLUSTER": {"license_data": {"latest": 46000}},
+                        "NAMESPACES": {"foo": {"license_data": {"latest": 46000}}},
+                    },
+                },
+            ),
+            (
+                {
+                    "ns_stats": {"foo": {}},
+                    "license_data": {
+                        "license_usage": {
+                            "count": 2,
+                            "entries": [
+                                {
+                                    "time": "2022-04-07T22:58:47",
+                                    "unique_data_bytes": 500,
+                                    "level": "info",
+                                    "cluster_stable": False,
+                                    "namespaces": {"foo": {"unique_data_bytes": 1000}},
+                                },
+                                {
+                                    "time": "2022-04-07T22:59:47",
+                                    "unique_data_bytes": 100,
+                                    "level": "info",
+                                    "cluster_stable": False,
+                                    "namespaces": {"foo": {"unique_data_bytes": 500}},
+                                },
+                                {"unique_data_bytes": 0, "level": "error"},
+                            ],
+                        }
+                    },
+                    "allow_unstable": True,
+                    "exp_summary_dict": {
+                        "CLUSTER": {
+                            "license_data": {
+                                "latest_time": datetime.fromisoformat(
+                                    "2022-04-07T22:59:47"
+                                ),
+                                "latest": 100,
+                                "min": 100,
+                                "max": 500,
+                                "avg": 300,
+                            }
+                        },
+                        "NAMESPACES": {
+                            "foo": {
+                                "license_data": {
+                                    "latest_time": datetime.fromisoformat(
+                                        "2022-04-07T22:59:47"
+                                    ),
+                                    "latest": 500,
+                                    "min": 500,
+                                    "max": 1000,
+                                    "avg": 750,
+                                }
+                            }
+                        },
+                    },
+                },
+            ),
+            (
+                {
+                    "ns_stats": {"foo": {}},
+                    "license_data": {
+                        "license_usage": {
+                            "count": 2,
+                            "entries": [
+                                {
+                                    "time": "2022-04-07T22:58:47",
+                                    "unique_data_bytes": 500,
+                                    "level": "info",
+                                    "cluster_stable": True,
+                                    "namespaces": {"foo": {"unique_data_bytes": 1000}},
+                                },
+                                {
+                                    "time": "2022-04-07T22:59:47",
+                                    "unique_data_bytes": 100,
+                                    "level": "info",
+                                    "cluster_stable": False,
+                                    "namespaces": {"foo": {"unique_data_bytes": 500}},
+                                },
+                                {"unique_data_bytes": 0, "level": "error"},
+                            ],
+                        }
+                    },
+                    "allow_unstable": False,
+                    "exp_summary_dict": {
+                        "CLUSTER": {
                             "license_data": {
                                 "latest_time": datetime.fromisoformat(
                                     "2022-04-07T22:58:47"
                                 ),
-                                "latest": 1000,
-                                "min": 1000,
-                                "max": 1000,
-                                "avg": 1000,
+                                "latest": 500,
+                                "min": 500,
+                                "max": 500,
+                                "avg": 500,
                             }
-                        }
+                        },
+                        "NAMESPACES": {
+                            "foo": {
+                                "license_data": {
+                                    "latest_time": datetime.fromisoformat(
+                                        "2022-04-07T22:58:47"
+                                    ),
+                                    "latest": 1000,
+                                    "min": 1000,
+                                    "max": 1000,
+                                    "avg": 1000,
+                                }
+                            }
+                        },
                     },
                 },
-            },
+            ),
         ]
-
-        for tc in test_cases:
-            self.run_test_case(
-                tc["ns_stats"],
-                {"1.1.1.1": "5.0.0.0"},
-                tc["license_data"],
-                tc["allow_unstable"],
-                tc["exp_summary_dict"],
-            )
+    )
+    def test_success_with_agent(self, tc):
+        self.run_test_case(
+            tc["ns_stats"],
+            {"1.1.1.1": "5.0.0.0"},
+            tc["license_data"],
+            tc["allow_unstable"],
+            tc["exp_summary_dict"],
+        )
 
 
 class CreateStopWritesSummaryTests(asynctest.TestCase):
@@ -812,6 +905,7 @@ class CreateStopWritesSummaryTests(asynctest.TestCase):
                     }
                 },
             ),
+            # stop_writes triggered by device_available_pct
             create_tc(
                 ns_stats={
                     "1.1.1.1": {
@@ -837,6 +931,7 @@ class CreateStopWritesSummaryTests(asynctest.TestCase):
                     }
                 },
             ),
+            # stop_writes not triggered by pmem_available_pct
             create_tc(
                 ns_stats={
                     "1.1.1.1": {
@@ -1076,6 +1171,60 @@ class CreateStopWritesSummaryTests(asynctest.TestCase):
                     }
                 },
             ),
+            # stop_writes not triggered by data_used_bytes
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "ns1": {
+                            "stop_writes": "true",
+                            "data_used_bytes": "10",
+                            "data_total_bytes": "100",
+                        }
+                    },
+                },
+                ns_config={
+                    "1.1.1.1": {"ns1": {"stop-writes-used-pct": "90"}},
+                },
+                expected={
+                    "1.1.1.1": {
+                        ("ns1", None, "data_used_bytes"): {
+                            "metric": "data_used_bytes",
+                            "config": "stop-writes-used-pct",
+                            "stop_writes": False,
+                            "metric_usage": 10,
+                            "metric_threshold": 90,
+                            "namespace": "ns1",
+                        },
+                    }
+                },
+            ),
+            # stop_writes is triggered by data_used_bytes
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "ns1": {
+                            "stop_writes": "true",
+                            "data_used_bytes": "90",
+                            "data_total_bytes": "100",
+                        }
+                    },
+                },
+                ns_config={
+                    "1.1.1.1": {"ns1": {"stop-writes-used-pct": "90"}},
+                },
+                expected={
+                    "1.1.1.1": {
+                        ("ns1", None, "data_used_bytes"): {
+                            "metric": "data_used_bytes",
+                            "config": "stop-writes-used-pct",
+                            "stop_writes": True,
+                            "metric_usage": 90,
+                            "metric_threshold": 90,
+                            "namespace": "ns1",
+                        },
+                    }
+                },
+            ),
             # stop_writes is not triggered by memory_used_bytes
             create_tc(
                 ns_stats={
@@ -1276,7 +1425,7 @@ class CreateStopWritesSummaryTests(asynctest.TestCase):
             ),
         ],
     )
-    def test_summary_creation(
+    def test_stop_writes_summary_creation(
         self, service_stats, ns_stats, ns_config, set_stats, set_config, expected
     ):
         self.assertDictEqual(
@@ -1316,3 +1465,825 @@ class CreateStopWritesSummaryTests(asynctest.TestCase):
             common.active_stop_writes(stop_writes_dict),
             expected,
         )
+
+
+class CreateSummaryTests(unittest.TestCase):
+    maxDiff = None
+
+    @staticmethod
+    def create_tc(
+        service_stats={},
+        ns_stats={},
+        xdr_dc_stats={},
+        metadata={},
+        license_allow_unstable=False,
+        service_configs={},
+        ns_configs={},
+        security_configs={},
+        license_data_usage={},
+        expected={},
+    ):
+        namespaces = list(expected.get("NAMESPACES", {}).keys())
+        hosts = ns_stats.keys()
+        builds = metadata.setdefault("server_build", {})
+
+        for host in hosts:
+            builds.setdefault(host, "7.0.0")
+            service_stats.setdefault(host, {})
+            for ns in namespaces:
+                ns_stats.setdefault(host, {}).setdefault(ns, {})
+                ns_configs.setdefault(host, {}).setdefault(ns, {})
+
+        init_expected = common._initialize_summary_output(namespaces)
+        expected = util.deep_merge_dicts(init_expected, expected)
+
+        return (
+            service_stats,
+            ns_stats,
+            xdr_dc_stats,
+            metadata,
+            license_allow_unstable,
+            service_configs,
+            ns_configs,
+            security_configs,
+            license_data_usage,
+            init_expected,
+        )
+
+    @parameterized.expand(
+        [
+            # Test Devices Counts
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine.device[0]": 0,
+                            "replication-factor": 1,
+                        },
+                        "bar": {
+                            "storage-engine.device": 0,
+                            "storage-engine.file[0]": 0,
+                            "storage-engine.file": 0,
+                            "replication-factor": 2,
+                        },
+                    },
+                    "2.2.2.2": {
+                        "test": {
+                            "storage-engine.device[0]": 0,
+                            "replication-factor": 1,
+                        },
+                        "bar": {
+                            "storage-engine.device": 0,
+                            "storage-engine.file[0]": 0,
+                            "storage-engine.file": 0,
+                            "replication-factor": 2,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "device_count": 8,
+                        "device_count_per_node": 4,
+                        "ns_count": 2,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "devices_total": 2,
+                            "devices_per_node": 1,
+                            "repl_factor": [1],
+                        },
+                        "bar": {
+                            "devices_total": 6,
+                            "devices_per_node": 3,
+                            "repl_factor": [2],
+                        },
+                    },
+                },
+            ),
+            # Test Pre 7.0 Memory Usage. Shmem is not displayed in this case by choice
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "memory_used_bytes": 1024,
+                        },
+                    },
+                    "2.2.2.2": {
+                        "bar": {
+                            "memory_used_bytes": 1024,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "memory",
+                            "memory-size": 2048,
+                            "index-type": "shmem",
+                            "replication-factor": 1,
+                        },
+                    },
+                    "2.2.2.2": {
+                        "bar": {
+                            "storage-engine": "memory",
+                            "memory-size": 2048,
+                            "index-type": "shmem",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-shmem"],
+                        "ns_count": 2,
+                        "license_data": {
+                            "latest": 0
+                        },  # memory_data_used_bytes and memory_index_used_bytes are used for license calculation
+                        "memory_data_and_indexes": {
+                            "total": 4096,
+                            "used": 2048,
+                            "used_pct": 50.0,
+                            "avail": 2048,
+                            "avail_pct": 50.0,
+                        },
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "memory_data_and_indexes": {
+                                "total": 2048,
+                                "used": 1024,
+                                "used_pct": 50.0,
+                                "avail": 1024,
+                                "avail_pct": 50.0,
+                            },
+                            "repl_factor": [1],
+                            "license_data": {"latest": 0},
+                        },
+                        "bar": {
+                            "memory_data_and_indexes": {
+                                "total": 2048,
+                                "used": 1024,
+                                "used_pct": 50.0,
+                                "avail": 1024,
+                                "avail_pct": 50.0,
+                            },
+                            "repl_factor": [1],
+                            "license_data": {"latest": 0},
+                        },
+                    },
+                },
+            ),
+            # Test Pre 7.0 Pmem/Pmem-index usage
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "memory_used_bytes": 1024,
+                            "index_pmem_used_bytes": 512,
+                            "pmem_used_bytes": 1024,
+                            "pmem_total_bytes": 2048,
+                            "pmem_available_pct": 50,
+                        },
+                    },
+                    "2.2.2.2": {
+                        "bar": {
+                            "memory_used_bytes": 1024,
+                            "index_pmem_used_bytes": 512,
+                            "pmem_used_bytes": 1024,
+                            "pmem_total_bytes": 2048,
+                            "pmem_available_pct": 50,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "memory-size": 2048,
+                            "storage-engine": "pmem",
+                            "index-type": "pmem",
+                            "index-type.mounts-size-limit": 1024,
+                            "replication-factor": 1,
+                        },
+                    },
+                    "2.2.2.2": {
+                        "bar": {
+                            "memory-size": 2048,
+                            "storage-engine": "pmem",
+                            "index-type": "pmem",
+                            "index-type.mounts-size-limit": 1024,
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-pmem"],
+                        "ns_count": 2,
+                        "license_data": {"latest": 2048},
+                        "memory_data_and_indexes": {
+                            "total": 4096,
+                            "used": 2048,
+                            "used_pct": 50.0,
+                            "avail": 2048,
+                            "avail_pct": 50.0,
+                        },
+                        "pmem_index": {
+                            "total": 2048,
+                            "used": 1024,
+                            "used_pct": 50.0,
+                            "avail": 1024,
+                            "avail_pct": 50.0,
+                        },
+                        "pmem": {
+                            "total": 4096,
+                            "used": 2048,
+                            "used_pct": 50.0,
+                            "avail": 2048.0,
+                            "avail_pct": 50.0,
+                        },
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "pmem",
+                            "memory_data_and_indexes": {
+                                "total": 2048,
+                                "used": 1024,
+                                "used_pct": 50.0,
+                                "avail": 1024,
+                                "avail_pct": 50.0,
+                            },
+                            "pmem_index": {
+                                "total": 1024,
+                                "used": 512,
+                                "used_pct": 50.0,
+                                "avail": 512,
+                                "avail_pct": 50.0,
+                            },
+                            "pmem": {
+                                "total": 2048,
+                                "used": 1024,
+                                "used_pct": 50.0,
+                                "avail": 1024.0,
+                                "avail_pct": 50.0,
+                            },
+                            "repl_factor": [1],
+                            "license_data": {"latest": 1024},
+                        },
+                        "bar": {
+                            "index_type": "pmem",
+                            "memory_data_and_indexes": {
+                                "total": 2048,
+                                "used": 1024,
+                                "used_pct": 50.0,
+                                "avail": 1024,
+                                "avail_pct": 50.0,
+                            },
+                            "pmem_index": {
+                                "total": 1024,
+                                "used": 512,
+                                "used_pct": 50.0,
+                                "avail": 512,
+                                "avail_pct": 50.0,
+                            },
+                            "pmem": {
+                                "total": 2048,
+                                "used": 1024,
+                                "used_pct": 50.0,
+                                "avail": 1024.0,
+                                "avail_pct": 50.0,
+                            },
+                            "repl_factor": [1],
+                            "license_data": {"latest": 1024},
+                        },
+                    },
+                },
+            ),
+            # Test Pre 7.0 Device/Flash-index Usage
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "index_flash_used_bytes": 512,
+                            "device_used_bytes": 1024,
+                            "device_total_bytes": 2048,
+                            "device_available_pct": 50,
+                        },
+                    },
+                    "2.2.2.2": {
+                        "bar": {
+                            "index_flash_used_bytes": 512,
+                            "device_used_bytes": 1024,
+                            "device_total_bytes": 2048,
+                            "device_available_pct": 50,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "device",
+                            "index-type": "flash",
+                            "index-type.mounts-size-limit": 1024,
+                            "replication-factor": 1,
+                        },
+                    },
+                    "2.2.2.2": {
+                        "bar": {
+                            "storage-engine": "device",
+                            "index-type": "flash",
+                            "index-type.mounts-size-limit": 1024,
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-flash"],
+                        "ns_count": 2,
+                        "license_data": {"latest": 2048},
+                        "flash_index": {
+                            "total": 2048,
+                            "used": 1024,
+                            "used_pct": 50.0,
+                            "avail": 1024,
+                            "avail_pct": 50.0,
+                        },
+                        "device": {
+                            "total": 4096,
+                            "used": 2048,
+                            "used_pct": 50.0,
+                            "avail": 2048.0,
+                            "avail_pct": 50.0,
+                        },
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "flash",
+                            "flash_index": {
+                                "total": 1024,
+                                "used": 512,
+                                "used_pct": 50.0,
+                                "avail": 512,
+                                "avail_pct": 50.0,
+                            },
+                            "device": {
+                                "total": 2048,
+                                "used": 1024,
+                                "used_pct": 50.0,
+                                "avail": 1024.0,
+                                "avail_pct": 50.0,
+                            },
+                            "repl_factor": [1],
+                            "license_data": {"latest": 1024},
+                        },
+                        "bar": {
+                            "index_type": "flash",
+                            "flash_index": {
+                                "total": 1024,
+                                "used": 512,
+                                "used_pct": 50.0,
+                                "avail": 512,
+                                "avail_pct": 50.0,
+                            },
+                            "device": {
+                                "total": 2048,
+                                "used": 1024,
+                                "used_pct": 50.0,
+                                "avail": 1024.0,
+                                "avail_pct": 50.0,
+                            },
+                            "repl_factor": [1],
+                            "license_data": {"latest": 1024},
+                        },
+                    },
+                },
+            ),
+            # Test New 7.0 Memory/Shmem-index usage
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "index_used_bytes": 512,
+                            "data_used_bytes": 1024,
+                            "data_total_bytes": 2048,
+                            "data_avail_pct": 50,
+                        },
+                    },
+                    "2.2.2.2": {
+                        "bar": {
+                            "index_used_bytes": 512,
+                            "data_used_bytes": 1024,
+                            "data_total_bytes": 2048,
+                            "data_avail_pct": 50,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "memory",
+                            "index-type": "shmem",  # shmem index has no mounts-budget
+                            "replication-factor": 1,
+                        },
+                    },
+                    "2.2.2.2": {
+                        "bar": {
+                            "storage-engine": "memory",
+                            "index-type": "shmem",  # shmem index has no mounts-budget
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-shmem"],
+                        "ns_count": 2,
+                        "license_data": {"latest": 2048},
+                        "shmem_index": {
+                            "used": 1024,
+                        },
+                        "memory": {
+                            "total": 4096,
+                            "used": 2048,
+                            "used_pct": 50.0,
+                            "avail": 2048.0,
+                            "avail_pct": 50.0,
+                        },
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "shmem",
+                            "shmem_index": {
+                                "used": 512,
+                            },
+                            "memory": {
+                                "total": 2048,
+                                "used": 1024,
+                                "used_pct": 50.0,
+                                "avail": 1024.0,
+                                "avail_pct": 50.0,
+                            },
+                            "repl_factor": [1],
+                            "license_data": {"latest": 1024},
+                        },
+                        "bar": {
+                            "index_type": "shmem",
+                            "shmem_index": {
+                                "used": 512,
+                            },
+                            "memory": {
+                                "total": 2048,
+                                "used": 1024,
+                                "used_pct": 50.0,
+                                "avail": 1024.0,
+                                "avail_pct": 50.0,
+                            },
+                            "repl_factor": [1],
+                            "license_data": {"latest": 1024},
+                        },
+                    },
+                },
+            ),
+            # Test New 7.0 Device/Flash-index usage
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "index_used_bytes": 512,
+                            "data_used_bytes": 1024,
+                            "data_total_bytes": 2048,
+                            "data_avail_pct": 50,
+                        },
+                    },
+                    "2.2.2.2": {
+                        "bar": {
+                            "index_used_bytes": 512,
+                            "data_used_bytes": 1024,
+                            "data_total_bytes": 2048,
+                            "data_avail_pct": 50,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "device",
+                            "index-type": "flash",
+                            "index-type.mounts-budget": "1024",
+                            "replication-factor": 1,
+                        },
+                    },
+                    "2.2.2.2": {
+                        "bar": {
+                            "storage-engine": "device",
+                            "index-type": "flash",
+                            "index-type.mounts-budget": "1024",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-flash"],
+                        "ns_count": 2,
+                        "license_data": {"latest": 2048},
+                        "flash_index": {
+                            "total": 2048,
+                            "used": 1024,
+                            "used_pct": 50.0,
+                            "avail": 1024,
+                            "avail_pct": 50.0,
+                        },
+                        "device": {
+                            "total": 4096,
+                            "used": 2048,
+                            "used_pct": 50.0,
+                            "avail": 2048.0,
+                            "avail_pct": 50.0,
+                        },
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "flash",
+                            "flash_index": {
+                                "total": 1024,
+                                "used": 512,
+                                "used_pct": 50.0,
+                                "avail": 512,
+                                "avail_pct": 50.0,
+                            },
+                            "device": {
+                                "total": 2048,
+                                "used": 1024,
+                                "used_pct": 50.0,
+                                "avail": 1024.0,
+                                "avail_pct": 50.0,
+                            },
+                            "repl_factor": [1],
+                            "license_data": {"latest": 1024},
+                        },
+                        "bar": {
+                            "index_type": "flash",
+                            "flash_index": {
+                                "total": 1024,
+                                "used": 512,
+                                "used_pct": 50.0,
+                                "avail": 512,
+                                "avail_pct": 50.0,
+                            },
+                            "device": {
+                                "total": 2048,
+                                "used": 1024,
+                                "used_pct": 50.0,
+                                "avail": 1024.0,
+                                "avail_pct": 50.0,
+                            },
+                            "repl_factor": [1],
+                            "license_data": {"latest": 1024},
+                        },
+                    },
+                },
+            ),
+            # Test New 7.0 Pmem/Pmem-index usage
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "index_used_bytes": 512,
+                            "data_used_bytes": 1024,
+                            "data_total_bytes": 2048,
+                            "data_avail_pct": 50,
+                        },
+                    },
+                    "2.2.2.2": {
+                        "bar": {
+                            "index_used_bytes": 512,
+                            "data_used_bytes": 1024,
+                            "data_total_bytes": 2048,
+                            "data_avail_pct": 50,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "pmem",
+                            "index-type": "pmem",
+                            "index-type.mounts-budget": "1024",
+                            "replication-factor": 1,
+                        },
+                    },
+                    "2.2.2.2": {
+                        "bar": {
+                            "storage-engine": "pmem",
+                            "index-type": "pmem",
+                            "index-type.mounts-budget": "1024",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-pmem"],
+                        "ns_count": 2,
+                        "license_data": {"latest": 2048},
+                        "pmem_index": {
+                            "total": 2048,
+                            "used": 1024,
+                            "used_pct": 50.0,
+                            "avail": 1024,
+                            "avail_pct": 50.0,
+                        },
+                        "pmem": {
+                            "total": 4096,
+                            "used": 2048,
+                            "used_pct": 50.0,
+                            "avail": 2048.0,
+                            "avail_pct": 50.0,
+                        },
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "pmem",
+                            "pmem_index": {
+                                "total": 1024,
+                                "used": 512,
+                                "used_pct": 50.0,
+                                "avail": 512,
+                                "avail_pct": 50.0,
+                            },
+                            "pmem": {
+                                "total": 2048,
+                                "used": 1024,
+                                "used_pct": 50.0,
+                                "avail": 1024.0,
+                                "avail_pct": 50.0,
+                            },
+                            "repl_factor": [1],
+                            "license_data": {"latest": 1024},
+                        },
+                        "bar": {
+                            "index_type": "pmem",
+                            "pmem_index": {
+                                "total": 1024,
+                                "used": 512,
+                                "used_pct": 50.0,
+                                "avail": 512,
+                                "avail_pct": 50.0,
+                            },
+                            "pmem": {
+                                "total": 2048,
+                                "used": 1024,
+                                "used_pct": 50.0,
+                                "avail": 1024.0,
+                                "avail_pct": 50.0,
+                            },
+                            "repl_factor": [1],
+                            "license_data": {"latest": 1024},
+                        },
+                    },
+                },
+            ),
+            # Test Compression Ratio usage
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "pmem_compression_ratio": "0.75",
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Compression"],
+                        "ns_count": 1,
+                        "license_data": {"latest": 0},
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "compression_ratio": 0.75,
+                            "repl_factor": [1],
+                            "license_data": {"latest": 0},
+                        },
+                    },
+                },
+            ),
+        ]
+    )
+    def test_create_summary_namespace_usage_stats(
+        self,
+        service_stats,
+        ns_stats,
+        xdr_dc_stats,
+        metadata,
+        license_allow_unstable,
+        service_configs,
+        ns_configs,
+        security_configs,
+        license_data_usage,
+        expected,
+    ):
+        actual = common.create_summary(
+            service_stats,
+            ns_stats,
+            xdr_dc_stats,
+            metadata,
+            license_allow_unstable,
+            service_configs,
+            ns_configs,
+            security_configs,
+            license_data_usage,
+        )
+
+        self.assertDictEqual(actual, expected)
+
+    @parameterized.expand(
+        [
+            # Test Compression Ratio usage
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "data_compression_ratio": "0.73",  # Post 7.0
+                        },
+                        "bar": {
+                            "device_compression_ratio": "0.74",  # Pre 7.0
+                        },
+                        "foo": {
+                            "pmem_compression_ratio": "0.75",  # Pre 7.0
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "replication-factor": 1,
+                        },
+                        "bar": {
+                            "replication-factor": 1,
+                        },
+                        "foo": {
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Compression"],
+                        "ns_count": 3,
+                        "license_data": {"latest": 0},
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "compression_ratio": 0.73,
+                            "repl_factor": [1],
+                            "license_data": {"latest": 0},
+                        },
+                        "bar": {
+                            "compression_ratio": 0.74,
+                            "repl_factor": [1],
+                            "license_data": {"latest": 0},
+                        },
+                        "foo": {
+                            "compression_ratio": 0.75,
+                            "repl_factor": [1],
+                            "license_data": {"latest": 0},
+                        },
+                    },
+                },
+            ),
+        ]
+    )
+    def test_create_summary_compression_ratio(
+        self,
+        service_stats,
+        ns_stats,
+        xdr_dc_stats,
+        metadata,
+        license_allow_unstable,
+        service_configs,
+        ns_configs,
+        security_configs,
+        license_data_usage,
+        expected,
+    ):
+        actual = common.create_summary(
+            service_stats,
+            ns_stats,
+            xdr_dc_stats,
+            metadata,
+            license_allow_unstable,
+            service_configs,
+            ns_configs,
+            security_configs,
+            license_data_usage,
+        )
+
+        self.assertDictEqual(actual, expected)

--- a/test/unit/utils/test_common.py
+++ b/test/unit/utils/test_common.py
@@ -1283,7 +1283,7 @@ class CreateStopWritesSummaryTests(asynctest.TestCase):
                     "1.1.1.1": {
                         ("ns1", "set1"): {
                             "memory_data_bytes": "10",
-                            "device_data_bytes": "0",
+                            "device_data_bytes": "100000",
                         }
                     }
                 },
@@ -1308,6 +1308,7 @@ class CreateStopWritesSummaryTests(asynctest.TestCase):
                     "1.1.1.1": {
                         ("ns1", "set1"): {
                             "memory_data_bytes": "100",
+                            "device_data_bytes": "100000",
                         }
                     }
                 },
@@ -1365,6 +1366,55 @@ class CreateStopWritesSummaryTests(asynctest.TestCase):
                     "1.1.1.1": {
                         ("ns1", "set1", "device_data_bytes"): {
                             "metric": "device_data_bytes",
+                            "config": "stop-writes-size",
+                            "stop_writes": True,
+                            "metric_usage": 100,
+                            "metric_threshold": 100,
+                            "namespace": "ns1",
+                            "set": "set1",
+                        },
+                    }
+                },
+            ),
+            # stop_writes is not triggered by set.data_used_bytes
+            create_tc(
+                set_stats={
+                    "1.1.1.1": {
+                        ("ns1", "set1"): {
+                            "data_used_bytes": "10",
+                            "device_data_bytes": "0",
+                        }
+                    }
+                },
+                set_config={"1.1.1.1": {("ns1", "set1"): {"stop-writes-size": "100"}}},
+                expected={
+                    "1.1.1.1": {
+                        ("ns1", "set1", "data_used_bytes"): {
+                            "metric": "data_used_bytes",
+                            "config": "stop-writes-size",
+                            "stop_writes": False,
+                            "metric_usage": 10,
+                            "metric_threshold": 100,
+                            "namespace": "ns1",
+                            "set": "set1",
+                        },
+                    }
+                },
+            ),
+            # stop_writes is triggered by set.data_used_bytes
+            create_tc(
+                set_stats={
+                    "1.1.1.1": {
+                        ("ns1", "set1"): {
+                            "data_used_bytes": "100",
+                        }
+                    }
+                },
+                set_config={"1.1.1.1": {("ns1", "set1"): {"stop-writes-size": "100"}}},
+                expected={
+                    "1.1.1.1": {
+                        ("ns1", "set1", "data_used_bytes"): {
+                            "metric": "data_used_bytes",
                             "config": "stop-writes-size",
                             "stop_writes": True,
                             "metric_usage": 100,

--- a/test/unit/view/test_view.py
+++ b/test/unit/view/test_view.py
@@ -759,21 +759,21 @@ class CliViewTest(unittest.TestCase):
         expected = f"""Cluster  ({terminal.fg_red()}Migrations in Progress{terminal.fg_clear()})
 =================================
 
-   1.   Cluster Name       :  test-cluster
-   2.   Server Version     :  7.0.0.0
-   3.   OS Version         :  Linux 4.15.0-106-generic
-   4.   Cluster Size       :  1
-   5.   Devices            :  Total 2, per-node 2
-   6.   Pmem Index         :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
-   7.   Flash Index        :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
-   8.   Shmem Index        :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
-   9.   Memory             :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B) includes data, pindex, and sindex
-   10.  Memory             :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   11.  Device             :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   12.  Pmem               :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   13.  License Usage      :  Latest (2023-10-04T20:35:42+00:00): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
-   14.  Active Namespaces  :  2 of 2
-   15.  Active Features    :  Compression, Depression
+   1.   Cluster Name             :  test-cluster
+   2.   Server Version           :  7.0.0.0
+   3.   OS Version               :  Linux 4.15.0-106-generic
+   4.   Cluster Size             :  1
+   5.   Devices                  :  Total 2, per-node 2
+   6.   Pmem Index               :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   7.   Flash Index              :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   8.   Shmem Index              :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   9.   Memory                   :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B) includes data, pindex, and sindex
+   10.  Memory                   :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   11.  Device                   :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   12.  Pmem                     :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   13.  License Usage            :  Latest (2023-10-04T20:35:42+00:00): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
+   14.  Active Namespaces        :  2 of 2
+   15.  Active Features          :  Compression, Depression
 
 """
 
@@ -935,37 +935,37 @@ class CliViewTest(unittest.TestCase):
 
    {terminal.fg_red()}test{terminal.fg_clear()}
    ====
-   1.   Devices            :  Total 2, per-node 2
-   2.   Pmem Index         :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
-   3.   Flash Index        :  Total 2.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
-   4.   Shmem Index        :  Total 3.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
-   5.   Memory             :  Total 4.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B) includes data, pindex, and sindex
-   6.   Memory             :  Total 5.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   7.   Device             :  Total 6.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   8.   Pmem               :  Total 7.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   9.   License Usage      :  Latest (2023-10-04T20:35:42+00:00): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
-   10.  Replication Factor :  1
+   1.   Devices                  :  Total 2, per-node 2
+   2.   Pmem Index               :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   3.   Flash Index              :  Total 2.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   4.   Shmem Index              :  Total 3.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   5.   Memory                   :  Total 4.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B) includes data, pindex, and sindex
+   6.   Memory                   :  Total 5.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   7.   Device                   :  Total 6.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   8.   Pmem                     :  Total 7.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   9.   License Usage            :  Latest (2023-10-04T20:35:42+00:00): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
+   10.  Replication Factor       :  1
    11.  Post-Write-Queue Hit-Rate:  1.000  
-   12.  Rack-aware         :  True
-   13.  Master Objects     :  2.000  
-   14.  Compression-ratio  :  0.5
+   12.  Rack-aware               :  True
+   13.  Master Objects           :  2.000  
+   14.  Compression-ratio        :  0.5
 
    {terminal.fg_red()}bar{terminal.fg_clear()}
    ===
-   1.   Devices            :  Total 2, per-node 2 (number differs across nodes)
-   2.   Pmem Index         :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
-   3.   Flash Index        :  Total 2.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
-   4.   Shmem Index        :  Total 3.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
-   5.   Memory             :  Total 4.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B) includes data, pindex, and sindex
-   6.   Memory             :  Total 5.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   7.   Device             :  Total 6.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   8.   Pmem               :  Total 7.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   9.   License Usage      :  Latest (2023-10-04T20:35:42+00:00): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
-   10.  Replication Factor :  1
+   1.   Devices                  :  Total 2, per-node 2 (number differs across nodes)
+   2.   Pmem Index               :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   3.   Flash Index              :  Total 2.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   4.   Shmem Index              :  Total 3.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   5.   Memory                   :  Total 4.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B) includes data, pindex, and sindex
+   6.   Memory                   :  Total 5.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   7.   Device                   :  Total 6.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   8.   Pmem                     :  Total 7.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   9.   License Usage            :  Latest (2023-10-04T20:35:42+00:00): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
+   10.  Replication Factor       :  1
    11.  Post-Write-Queue Hit-Rate:  1.000  
-   12.  Rack-aware         :  False
-   13.  Master Objects     :  2.000  
-   14.  Compression-ratio  :  0.5
+   12.  Rack-aware               :  False
+   13.  Master Objects           :  2.000  
+   14.  Compression-ratio        :  0.5
 """
 
         actual = CliView._summary_namespace_list_view(ns_data)

--- a/test/unit/view/test_view.py
+++ b/test/unit/view/test_view.py
@@ -770,7 +770,7 @@ class CliViewTest(unittest.TestCase):
    10.  Memory             :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
    11.  Device             :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
    12.  Pmem               :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   13.  License Usage      :  Latest (2023-10-04 13:35:42): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
+   13.  License Usage      :  Latest (2023-10-04T13:35:42): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
    14.  Active Namespaces  :  2 of 2
    15.  Active Features    :  Compression, Depression
 
@@ -938,7 +938,7 @@ class CliViewTest(unittest.TestCase):
    6.   Memory             :  Total 5.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
    7.   Device             :  Total 6.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
    8.   Pmem               :  Total 7.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   9.   License Usage      :  Latest (2023-10-04 13:35:42): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
+   9.   License Usage      :  Latest (2023-10-04T13:35:42): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
    10.  Replication Factor :  1
    11.  Post-Write-Queue Hit-Rate:  1.000  
    12.  Rack-aware         :  True
@@ -955,7 +955,7 @@ class CliViewTest(unittest.TestCase):
    6.   Memory             :  Total 5.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
    7.   Device             :  Total 6.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
    8.   Pmem               :  Total 7.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   9.   License Usage      :  Latest (2023-10-04 13:35:42): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
+   9.   License Usage      :  Latest (2023-10-04T13:35:42): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
    10.  Replication Factor :  1
    11.  Post-Write-Queue Hit-Rate:  1.000  
    12.  Rack-aware         :  False

--- a/test/unit/view/test_view.py
+++ b/test/unit/view/test_view.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import unittest
-from mock import MagicMock, call, create_autospec, patch
+from mock import MagicMock, call, patch
+from lib.utils.common import SummaryClusterDict, SummaryNamespacesDict
 
-from lib.view import templates
+from lib.view import templates, terminal
 from lib.view.view import CliView
 from lib.view.sheet.const import SheetStyle
 from lib.live_cluster.client.node import ASInfoResponseError
@@ -174,7 +176,7 @@ class CliViewTest(unittest.TestCase):
             self.cluster_mock,
             flip=True,
             timestamp="test-stamp",
-            **{"for": "ba", "with": ["foo"]}
+            **{"for": "ba", "with": ["foo"]},
         )
 
         self.cluster_mock.get_node_names.assert_called_with(["foo"])
@@ -205,7 +207,7 @@ class CliViewTest(unittest.TestCase):
             self.cluster_mock,
             failed_practices,
             timestamp=timestamp,
-            **{"with": ["bar"]}
+            **{"with": ["bar"]},
         )
 
         self.cluster_mock.get_node_names.assert_called_with(["bar"])
@@ -245,7 +247,7 @@ class CliViewTest(unittest.TestCase):
             self.cluster_mock,
             jobs_data,
             timestamp=timestamp,
-            **{"trid": ["1", "3", "5"], "like": ["foo"], "with": ["bar"]}
+            **{"trid": ["1", "3", "5"], "like": ["foo"], "with": ["bar"]},
         )
 
         self.cluster_mock.get_node_names.assert_called_with(["bar"])
@@ -679,3 +681,293 @@ class CliViewTest(unittest.TestCase):
             sources,
             common=common,
         )
+
+    def test_summary_cluster_list_view(self):
+        cluster_data: SummaryClusterDict = {
+            "active_features": ["Compression"],
+            "ns_count": 1,
+            "license_data": {"latest": 0},
+            "migrations_in_progress": True,
+            "cluster_name": ["test-cluster"],
+            "server_version": ["7.0.0.0"],
+            "os_version": ["Linux 4.15.0-106-generic"],
+            "cluster_size": [1],
+            "device_count": 2,
+            "device_count_per_node": 2,
+            "device_count_same_across_nodes": True,
+            "pmem_index": {
+                "total": 1,
+                "used": 2,
+                "avail": 3,
+                "used_pct": 4,
+                "avail_pct": 5,
+            },
+            "flash_index": {
+                "total": 1,
+                "used": 2,
+                "avail": 3,
+                "used_pct": 4,
+                "avail_pct": 5,
+            },
+            "shmem_index": {
+                "total": 1,
+                "used": 2,
+                "avail": 3,
+                "used_pct": 4,
+                "avail_pct": 5,
+            },
+            "memory_data_and_indexes": {
+                "total": 1,
+                "used": 2,
+                "avail": 3,
+                "used_pct": 4,
+                "avail_pct": 5,
+            },
+            "memory": {
+                "total": 1,
+                "used": 2,
+                "avail": 3,
+                "used_pct": 4,
+                "avail_pct": 5,
+            },
+            "device": {
+                "total": 1,
+                "used": 2,
+                "avail": 3,
+                "used_pct": 4,
+                "avail_pct": 5,
+            },
+            "pmem": {
+                "total": 1,
+                "used": 2,
+                "avail": 3,
+                "used_pct": 4,
+                "avail_pct": 5,
+            },
+            "license_data": {
+                "latest_time": datetime.datetime.fromtimestamp(1696451742),  # TODO
+                "latest": 2,
+                "min": 3,
+                "max": 4,
+                "avg": 5,
+            },
+            "active_ns": 2,
+            "ns_count": 2,
+            "active_features": ["Compression", "Depression"],
+        }
+        expected = f"""Cluster  ({terminal.fg_red()}Migrations in Progress{terminal.fg_clear()})
+=================================
+
+   1.   Cluster Name       :  test-cluster
+   2.   Server Version     :  7.0.0.0
+   3.   OS Version         :  Linux 4.15.0-106-generic
+   4.   Cluster Size       :  1
+   5.   Devices            :  Total 2, per-node 2
+   6.   Pmem Index         :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   7.   Flash Index        :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   8.   Shmem Index        :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   9.   Memory             :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B) includes data, pindex, and sindex
+   10.  Memory             :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   11.  Device             :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   12.  Pmem               :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   13.  License Usage      :  Latest (2023-10-04 13:35:42): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
+   14.  Active Namespaces  :  2 of 2
+   15.  Active Features    :  Compression, Depression
+
+"""
+
+        actual = CliView._summary_cluster_list_view(cluster_data)
+        actual_str = []
+
+        for line in actual:
+            lines = str(line).split("\n")
+            actual_str.extend(lines)
+
+        self.assertListEqual(actual_str, expected.split("\n"))
+
+    def test_summary_namespace_list_view(self):
+        ns_data: SummaryNamespacesDict = {
+            "test": {
+                "devices_total": 2,
+                "devices_per_node": 2,
+                "device_count_same_across_nodes": True,
+                "repl_factor": [1],
+                "master_objects": 2,
+                "migrations_in_progress": True,
+                "rack_aware": True,
+                "pmem_index": {
+                    "total": 1,
+                    "used": 2,
+                    "avail": 3,
+                    "used_pct": 4,
+                    "avail_pct": 5,
+                },
+                "flash_index": {
+                    "total": 2,
+                    "used": 2,
+                    "avail": 3,
+                    "used_pct": 4,
+                    "avail_pct": 5,
+                },
+                "shmem_index": {
+                    "total": 3,
+                    "used": 2,
+                    "avail": 3,
+                    "used_pct": 4,
+                    "avail_pct": 5,
+                },
+                "memory_data_and_indexes": {
+                    "total": 4,
+                    "used": 2,
+                    "avail": 3,
+                    "used_pct": 4,
+                    "avail_pct": 5,
+                },
+                "memory": {
+                    "total": 5,
+                    "used": 2,
+                    "avail": 3,
+                    "used_pct": 4,
+                    "avail_pct": 5,
+                },
+                "device": {
+                    "total": 6,
+                    "used": 2,
+                    "avail": 3,
+                    "used_pct": 4,
+                    "avail_pct": 5,
+                },
+                "pmem": {
+                    "total": 7,
+                    "used": 2,
+                    "avail": 3,
+                    "used_pct": 4,
+                    "avail_pct": 5,
+                },
+                "license_data": {
+                    "latest_time": datetime.datetime.fromtimestamp(1696451742),
+                    "latest": 2,
+                    "min": 3,
+                    "max": 4,
+                    "avg": 5,
+                },
+                "cache_read_pct": 1,
+                "rack_aware": True,
+                "master_objects": 2,
+                "compression_ratio": 0.5,
+            },
+            "bar": {
+                "devices_total": 2,
+                "devices_per_node": 2,
+                "device_count_same_across_nodes": False,
+                "repl_factor": [1],
+                "master_objects": 2,
+                "migrations_in_progress": False,
+                "pmem_index": {
+                    "total": 1,
+                    "used": 2,
+                    "avail": 3,
+                    "used_pct": 4,
+                    "avail_pct": 5,
+                },
+                "flash_index": {
+                    "total": 2,
+                    "used": 2,
+                    "avail": 3,
+                    "used_pct": 4,
+                    "avail_pct": 5,
+                },
+                "shmem_index": {
+                    "total": 3,
+                    "used": 2,
+                    "avail": 3,
+                    "used_pct": 4,
+                    "avail_pct": 5,
+                },
+                "memory_data_and_indexes": {
+                    "total": 4,
+                    "used": 2,
+                    "avail": 3,
+                    "used_pct": 4,
+                    "avail_pct": 5,
+                },
+                "memory": {
+                    "total": 5,
+                    "used": 2,
+                    "avail": 3,
+                    "used_pct": 4,
+                    "avail_pct": 5,
+                },
+                "device": {
+                    "total": 6,
+                    "used": 2,
+                    "avail": 3,
+                    "used_pct": 4,
+                    "avail_pct": 5,
+                },
+                "pmem": {
+                    "total": 7,
+                    "used": 2,
+                    "avail": 3,
+                    "used_pct": 4,
+                    "avail_pct": 5,
+                },
+                "license_data": {
+                    "latest_time": datetime.datetime.fromtimestamp(1696451742),
+                    "latest": 2,
+                    "min": 3,
+                    "max": 4,
+                    "avg": 5,
+                },
+                "cache_read_pct": 1,
+                "rack_aware": False,
+                "master_objects": 2,
+                "compression_ratio": 0.5,
+            },
+        }
+        expected = f"""Namespaces
+==========
+
+   {terminal.fg_red()}test{terminal.fg_clear()}
+   ====
+   1.   Devices            :  Total 2, per-node 2
+   2.   Pmem Index         :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   3.   Flash Index        :  Total 2.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   4.   Shmem Index        :  Total 3.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   5.   Memory             :  Total 4.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B) includes data, pindex, and sindex
+   6.   Memory             :  Total 5.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   7.   Device             :  Total 6.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   8.   Pmem               :  Total 7.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   9.   License Usage      :  Latest (2023-10-04 13:35:42): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
+   10.  Replication Factor :  1
+   11.  Post-Write-Queue Hit-Rate:  1.000  
+   12.  Rack-aware         :  True
+   13.  Master Objects     :  2.000  
+   14.  Compression-ratio  :  0.5
+
+   {terminal.fg_red()}bar{terminal.fg_clear()}
+   ===
+   1.   Devices            :  Total 2, per-node 2 (number differs across nodes)
+   2.   Pmem Index         :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   3.   Flash Index        :  Total 2.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   4.   Shmem Index        :  Total 3.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   5.   Memory             :  Total 4.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B) includes data, pindex, and sindex
+   6.   Memory             :  Total 5.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   7.   Device             :  Total 6.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   8.   Pmem               :  Total 7.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   9.   License Usage      :  Latest (2023-10-04 13:35:42): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
+   10.  Replication Factor :  1
+   11.  Post-Write-Queue Hit-Rate:  1.000  
+   12.  Rack-aware         :  False
+   13.  Master Objects     :  2.000  
+   14.  Compression-ratio  :  0.5
+"""
+
+        actual = CliView._summary_namespace_list_view(ns_data)
+        actual_str = []
+
+        for line in actual:
+            lines = str(line).split("\n")
+            actual_str.extend(lines)
+
+        self.assertListEqual(actual_str, expected.split("\n"))

--- a/test/unit/view/test_view.py
+++ b/test/unit/view/test_view.py
@@ -686,7 +686,6 @@ class CliViewTest(unittest.TestCase):
         cluster_data: SummaryClusterDict = {
             "active_features": ["Compression"],
             "ns_count": 1,
-            "license_data": {"latest": 0},
             "migrations_in_progress": True,
             "cluster_name": ["test-cluster"],
             "server_version": ["7.0.0.0"],
@@ -745,7 +744,9 @@ class CliViewTest(unittest.TestCase):
                 "avail_pct": 5,
             },
             "license_data": {
-                "latest_time": datetime.datetime.fromtimestamp(1696451742),  # TODO
+                "latest_time": datetime.datetime.fromtimestamp(
+                    1696451742, tz=datetime.timezone.utc
+                ),
                 "latest": 2,
                 "min": 3,
                 "max": 4,
@@ -770,7 +771,7 @@ class CliViewTest(unittest.TestCase):
    10.  Memory             :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
    11.  Device             :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
    12.  Pmem               :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   13.  License Usage      :  Latest (2023-10-04T13:35:42): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
+   13.  License Usage      :  Latest (2023-10-04T20:35:42+00:00): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
    14.  Active Namespaces  :  2 of 2
    15.  Active Features    :  Compression, Depression
 
@@ -845,7 +846,9 @@ class CliViewTest(unittest.TestCase):
                     "avail_pct": 5,
                 },
                 "license_data": {
-                    "latest_time": datetime.datetime.fromtimestamp(1696451742),
+                    "latest_time": datetime.datetime.fromtimestamp(
+                        1696451742, tz=datetime.timezone.utc
+                    ),
                     "latest": 2,
                     "min": 3,
                     "max": 4,
@@ -913,7 +916,9 @@ class CliViewTest(unittest.TestCase):
                     "avail_pct": 5,
                 },
                 "license_data": {
-                    "latest_time": datetime.datetime.fromtimestamp(1696451742),
+                    "latest_time": datetime.datetime.fromtimestamp(
+                        1696451742, tz=datetime.timezone.utc
+                    ),
                     "latest": 2,
                     "min": 3,
                     "max": 4,
@@ -938,7 +943,7 @@ class CliViewTest(unittest.TestCase):
    6.   Memory             :  Total 5.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
    7.   Device             :  Total 6.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
    8.   Pmem               :  Total 7.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   9.   License Usage      :  Latest (2023-10-04T13:35:42): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
+   9.   License Usage      :  Latest (2023-10-04T20:35:42+00:00): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
    10.  Replication Factor :  1
    11.  Post-Write-Queue Hit-Rate:  1.000  
    12.  Rack-aware         :  True
@@ -955,7 +960,7 @@ class CliViewTest(unittest.TestCase):
    6.   Memory             :  Total 5.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
    7.   Device             :  Total 6.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
    8.   Pmem               :  Total 7.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   9.   License Usage      :  Latest (2023-10-04T13:35:42): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
+   9.   License Usage      :  Latest (2023-10-04T20:35:42+00:00): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
    10.  Replication Factor :  1
    11.  Post-Write-Queue Hit-Rate:  1.000  
    12.  Rack-aware         :  False


### PR DESCRIPTION
This PR includes:
- A redesign of the `info namespace usage` table to incorporate new `storage-engine.memory` design
- Updates to `summary` to incorporate new `storage-engine.memory` design
- An update to all healthchecks that use removed/renamed stats and configs
- Updates to the unique data usage calculation