### PR TITLE
fix: TOOLS-2656 exact node ID matches with another node ID with the s…

### DIFF
--- a/lib/live_cluster/client/cluster.py
+++ b/lib/live_cluster/client/cluster.py
@@ -430,9 +430,12 @@ class Cluster(AsyncObject):
         # Me must now look for exact matches.
 
         # Can't use "if not in self.node_lookup" here because we need to check for
-        # exact matches. Unless using node id than this condition requires they provide ip:port.
-        if node in self.node_lookup.keys():
-            return self.node_lookup[node]
+        # exact matches. Unless using node id than this condition requires they provide
+        # ip:port.
+        try:
+            return [self.node_lookup.get_exact(node)]
+        except KeyError:
+            pass
 
         node_matches = self.node_lookup[node]
         match = None

--- a/lib/utils/lookup_dict.py
+++ b/lib/utils/lookup_dict.py
@@ -149,6 +149,12 @@ class LookupDict(Generic[ValueType]):
         keys = self.get_key(k)
         return [self._kv[key] for key in keys]
 
+    def get_exact(self, k) -> ValueType:
+        if k in self._kv:
+            return self._kv[k]
+
+        raise KeyError("Unable to find key '%s'" % (k))
+
     def remove(self, k):
         keys = self.get_key(k)
 

--- a/test/unit/live_cluster/client/test_cluster.py
+++ b/test/unit/live_cluster/client/test_cluster.py
@@ -198,6 +198,11 @@ class ClusterTest(asynctest.TestCase):
             n = await self.get_info_mock("A0000000000000" + str(i), ip=ip, port=port)
             cl.update_node(n)
 
+        n = await self.get_info_mock("A", ip="1.1.1.1", port=3000)
+        cl.update_node(n)
+        n = await self.get_info_mock("AB", ip="2.2.2.2", port=3000)
+        cl.update_node(n)
+
         expected = [
             "192.168.0.1:3000",
             "192.168.0.1:3001",
@@ -273,6 +278,15 @@ class ClusterTest(asynctest.TestCase):
         ]
 
         actual = cl.get_node("183.168.0.1")
+        actual = map(lambda x: x.key, actual)
+
+        self.assertCountEqual(expected, actual)
+
+        expected = [
+            "1.1.1.1:3000",
+        ]
+
+        actual = cl.get_node("A")
         actual = map(lambda x: x.key, actual)
 
         self.assertCountEqual(expected, actual)


### PR DESCRIPTION
…ame prefix