### PR TITLE
fix: TOOLS-2978 & TOOLS-2977 federal edition in build col

### DIFF
--- a/lib/utils/util.py
+++ b/lib/utils/util.py
@@ -687,18 +687,17 @@ def find_delimiter_in(value):
     return ";"
 
 
-def convert_edition_to_shortform(edition):
-    """Convert edition to shortform Enterprise or Community or Federal or N/E"""
-
-    if "enterprise" in edition.lower():
-        return "Enterprise"
-
-    if "community" in edition.lower():
-        return "Community"
+def convert_edition_to_shortform(edition: str) -> str:
+    """Convert edition to shortform: Enterprise, Community, Federal, or N/E"""
+    edition_lower = edition.lower()
     
-    if "federal" in edition.lower():
+    if "enterprise" in edition_lower:
+        return "Enterprise"
+    elif "community" in edition_lower:
+        return "Community"
+    elif "federal" in edition_lower:
         return "Federal"
-
+    
     return "N/E"
 
 

--- a/lib/utils/util.py
+++ b/lib/utils/util.py
@@ -701,6 +701,12 @@ def convert_edition_to_shortform(edition):
         or "community" in edition.lower()
     ):
         return "Community"
+    
+    if (
+        edition.lower() in ["federal", "false", "ee"]
+        or "federal" in edition.lower()
+    ):
+        return "Federal"
 
     return "N/E"
 

--- a/lib/utils/util.py
+++ b/lib/utils/util.py
@@ -688,24 +688,15 @@ def find_delimiter_in(value):
 
 
 def convert_edition_to_shortform(edition):
-    """Convert edition to shortform Enterprise or Community or N/E"""
+    """Convert edition to shortform Enterprise or Community or Federal or N/E"""
 
-    if (
-        edition.lower() in ["enterprise", "true", "ee"]
-        or "enterprise" in edition.lower()
-    ):
+    if "enterprise" in edition.lower():
         return "Enterprise"
 
-    if (
-        edition.lower() in ["community", "false", "ce"]
-        or "community" in edition.lower()
-    ):
+    if "community" in edition.lower():
         return "Community"
     
-    if (
-        edition.lower() in ["federal", "false", "ee"]
-        or "federal" in edition.lower()
-    ):
+    if "federal" in edition.lower():
         return "Federal"
 
     return "N/E"


### PR DESCRIPTION
Build column should have F- for Federal edition

Fixes: TOOLS-2977 & TOOLS-2977

Simplifying the logic, Info Edition Calls to Server will not have true / false or CE / EE. Valid responses are 
- Aerospike Federal Edition build 6.4.0.15
- Aerospike Enterprise Edition
- Aeropsike Community Edition