### PR TITLE
build: Deprecate macos-12 Github-action

### DIFF
--- a/.github/workflows/mac-artifact.yml
+++ b/.github/workflows/mac-artifact.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-12, macos-14]  
+        os: [macos-13, macos-14, macos-15]  
     runs-on: ${{ matrix.os }}
     steps:
       - name: Get checkout directory


### PR DESCRIPTION
Remove macOS-12 from build as deprecated from gh