### PR TITLE
fix: TOOLS-2984 show latencies throws error latencies command: unrecognized histogram: {test}-benchmark-fabric

### DIFF
--- a/lib/live_cluster/client/node.py
+++ b/lib/live_cluster/client/node.py
@@ -2067,7 +2067,7 @@ class Node(AsyncObject):
                     return data
             micro_benchmarks = [
                 "proxy",
-                "benchmark-fabric",
+                "benchmarks-fabric",
                 "benchmarks-ops-sub",
                 "benchmarks-read",
                 "benchmarks-write",

--- a/test/unit/live_cluster/client/test_node.py
+++ b/test/unit/live_cluster/client/test_node.py
@@ -1747,7 +1747,7 @@ class NodeTest(asynctest.TestCase):
         self.info_mock.assert_any_call("latencies:", self.ip)
         self.info_mock.assert_any_call("latencies:hist={test}-proxy", self.ip)
         self.info_mock.assert_any_call(
-            "latencies:hist={test}-benchmark-fabric", self.ip
+            "latencies:hist={test}-benchmarks-fabric", self.ip
         )
         self.info_mock.assert_any_call(
             "latencies:hist={test}-benchmarks-ops-sub", self.ip


### PR DESCRIPTION
the command is benchmarks-fabric instead of benchmark-fabric