### PR TITLE
fix: TOOLS-2984 update outdated hist info cmd from latencies

### DIFF
--- a/lib/live_cluster/client/node.py
+++ b/lib/live_cluster/client/node.py
@@ -2065,9 +2065,11 @@ class Node(AsyncObject):
                     namespaces = (await self._info("namespaces")).split(";")
                 except Exception:
                     return data
+
             micro_benchmarks = [
                 "proxy",
-                "benchmark-fabric",
+                "read-touch",
+                "re-repl",
                 "benchmarks-ops-sub",
                 "benchmarks-read",
                 "benchmarks-write",
@@ -2075,6 +2077,7 @@ class Node(AsyncObject):
                 "benchmarks-udf-sub",
                 "benchmarks-batch-sub",
             ]
+
             cmd_latencies += [
                 "latencies:hist={%s}-%s" % (ns, optional)
                 for ns in namespaces

--- a/test/unit/live_cluster/client/test_node.py
+++ b/test/unit/live_cluster/client/test_node.py
@@ -1743,11 +1743,14 @@ class NodeTest(asynctest.TestCase):
 
         _ = await self.node.info_latencies(verbose=True)
 
-        self.assertEqual(self.info_mock.call_count, 10)
+        self.assertEqual(self.info_mock.call_count, 11)
         self.info_mock.assert_any_call("latencies:", self.ip)
         self.info_mock.assert_any_call("latencies:hist={test}-proxy", self.ip)
         self.info_mock.assert_any_call(
-            "latencies:hist={test}-benchmark-fabric", self.ip
+            "latencies:hist={test}-read-touch", self.ip
+        )
+        self.info_mock.assert_any_call(
+            "latencies:hist={test}-re-repl", self.ip
         )
         self.info_mock.assert_any_call(
             "latencies:hist={test}-benchmarks-ops-sub", self.ip


### PR DESCRIPTION
asadm runs following when run `show latencies`

 - "latencies:"     -> this covers
    - "latencies:hist={namespace}-read"
    - "latencies:hist={namespace}-write"
    - "latencies:hist={namespace}-udf"
    - "latencies:hist={namespace}-batch_sub_read"
    - "latencies:hist={namespace}-batch_sub_write"
    - "latencies:hist={namespace}-batch_sub_udf"
    - "latencies:hist={namespace}-pi_query"
    - "latencies:hist={namespace}-si_query"
      

& Runs following when run show latencies -v
- "latencies:"  
- "latencies:hist={namespace}-proxy"
- "latencies:hist={namespace}-benchmark-fabric"   INVALID COMMAND - doesn't exist on namespace level
- "latencies:hist={namespace}-benchmarks-ops-sub"
- "latencies:hist={namespace}-benchmarks-read"
- "latencies:hist={namespace}-benchmarks-write"
- "latencies:hist={namespace}-benchmarks-udf"
- "latencies:hist={namespace}-benchmarks-udf-sub"
- "latencies:hist={namespace}-benchmarks-batch-sub"



So Added following to the histograms removed {namespace}-benchmark-fabric & added missing histograms at namespace level
- "latencies:hist={namespace}-read-touch"
- "latencies:hist={namespace}-re-repl"


{ns}-read-touch was introduced in 7.1 and thus, if asadm is run against older version, it handles errors from the server for bad hist names.
