### PR TITLE
fix:TOOLS-2984 removed {namespace} from benchmarks-fabric in latencies

### DIFF
--- a/lib/live_cluster/client/node.py
+++ b/lib/live_cluster/client/node.py
@@ -2067,13 +2067,13 @@ class Node(AsyncObject):
                     return data
             micro_benchmarks = [
                 "proxy",
-                "benchmarks-fabric",
                 "benchmarks-ops-sub",
                 "benchmarks-read",
                 "benchmarks-write",
                 "benchmarks-udf",
                 "benchmarks-udf-sub",
                 "benchmarks-batch-sub",
+                "benchmarks-fabric"
             ]
             cmd_latencies += [
                 "latencies:hist=%s" % (optional) if optional == "benchmarks-fabric" else "latencies:hist={%s}-%s" % (ns, optional)

--- a/lib/live_cluster/client/node.py
+++ b/lib/live_cluster/client/node.py
@@ -2073,13 +2073,15 @@ class Node(AsyncObject):
                 "benchmarks-udf",
                 "benchmarks-udf-sub",
                 "benchmarks-batch-sub",
-                "benchmarks-fabric"
             ]
             cmd_latencies += [
-                "latencies:hist=%s" % (optional) if optional == "benchmarks-fabric" else "latencies:hist={%s}-%s" % (ns, optional)
+                "latencies:hist={%s}-%s" % (ns, optional)
                 for ns in namespaces
                 for optional in micro_benchmarks
             ]
+            
+            # TOOLS-2984: benchmarks-fabric is not at namespace-level
+            cmd_latencies.append("latencies:hist=benchmarks-fabric")
 
         hist_info = []
         for cmd in cmd_latencies:

--- a/lib/live_cluster/client/node.py
+++ b/lib/live_cluster/client/node.py
@@ -2067,7 +2067,7 @@ class Node(AsyncObject):
                     return data
             micro_benchmarks = [
                 "proxy",
-                "benchmark-fabric",
+                "benchmarks-fabric",
                 "benchmarks-ops-sub",
                 "benchmarks-read",
                 "benchmarks-write",
@@ -2076,7 +2076,7 @@ class Node(AsyncObject):
                 "benchmarks-batch-sub",
             ]
             cmd_latencies += [
-                "latencies:hist={%s}-%s" % (ns, optional)
+                "latencies:hist=%s" % (optional) if optional == "benchmarks-fabric" else "latencies:hist={%s}-%s" % (ns, optional)
                 for ns in namespaces
                 for optional in micro_benchmarks
             ]

--- a/test/unit/live_cluster/client/test_node.py
+++ b/test/unit/live_cluster/client/test_node.py
@@ -1747,7 +1747,7 @@ class NodeTest(asynctest.TestCase):
         self.info_mock.assert_any_call("latencies:", self.ip)
         self.info_mock.assert_any_call("latencies:hist={test}-proxy", self.ip)
         self.info_mock.assert_any_call(
-            "latencies:hist={test}-benchmark-fabric", self.ip
+            "latencies:hist=benchmarks-fabric", self.ip
         )
         self.info_mock.assert_any_call(
             "latencies:hist={test}-benchmarks-ops-sub", self.ip


### PR DESCRIPTION
- remove {ns} from benchmarks-fabric.
- enabled only when verbose show latencies i.e show latencies -v