### PR TITLE
fix: TOOLS-2986 manage roster command fix

### DIFF
--- a/lib/live_cluster/client/constants.py
+++ b/lib/live_cluster/client/constants.py
@@ -12,7 +12,7 @@ class ErrorsMsgs:
     DC_NODE_ADD_FAIL = "Failed to add node to XDR datacenter"
     DC_NODE_REMOVE_FAIL = "Failed to remove node from XDR datacenter"
     INVALID_REWIND = 'Invalid rewind. Must be int or "all"'
-    UNABLE_TO_DETERMINE_CLUSTER_STABILITY = "Failed to check cluster stability"
+    INFO_SERVER_ERROR_RESPONSE = 'Failed to execute info command - server error'
 
 
 DEFAULT_CONFIG_PATH = "/etc/aerospike/aerospike.conf"

--- a/lib/live_cluster/client/node.py
+++ b/lib/live_cluster/client/node.py
@@ -2401,11 +2401,11 @@ class Node(AsyncObject):
         resp = await self._info(req)
 
         if "error" in resp.lower():
-            if "cluster-not-specified-size" in resp or "unstable-cluster" in resp:
+            if "cluster not specified size" in resp or "unstable cluster" in resp:
                 raise ASInfoClusterStableError(resp)
 
             raise ASInfoResponseError(
-                ErrorsMsgs.UNABLE_TO_DETERMINE_CLUSTER_STABILITY, resp
+                ErrorsMsgs.INFO_SERVER_ERROR_RESPONSE, resp
             )
 
         return resp

--- a/test/unit/live_cluster/client/test_node.py
+++ b/test/unit/live_cluster/client/test_node.py
@@ -2052,8 +2052,8 @@ class NodeTest(asynctest.TestCase):
         )
 
     async def test_info_cluster_stable_with_errors(self):
-        self.info_mock.return_value = "ERROR::cluster-not-specified-size"
-        expected = ASInfoClusterStableError("ERROR::cluster-not-specified-size")
+        self.info_mock.return_value = "ERROR::cluster not specified size"
+        expected = ASInfoClusterStableError("ERROR::cluster not specified size")
 
         actual = await self.node.info_cluster_stable(cluster_size=3, namespace="bar")
 
@@ -2066,8 +2066,8 @@ class NodeTest(asynctest.TestCase):
             "info_cluster_stable did not return the expected result",
         )
 
-        self.info_mock.return_value = "ERROR::unstable-cluster"
-        expected = ASInfoClusterStableError("ERROR::unstable-cluster")
+        self.info_mock.return_value = "ERROR::unstable cluster"
+        expected = ASInfoClusterStableError("ERROR::unstable cluster")
 
         actual = await self.node.info_cluster_stable(cluster_size=3, namespace="bar")
 
@@ -2082,7 +2082,7 @@ class NodeTest(asynctest.TestCase):
 
         self.info_mock.return_value = "ERROR::foo"
         expected = ASInfoResponseError(
-            "Failed to check cluster stability", "ERROR::foo"
+            "Failed to execute info command - server error", "ERROR::foo"
         )
 
         actual = await self.node.info_cluster_stable(namespace="bar")


### PR DESCRIPTION
manage roster command was broken due to error standardization

The `unstable-cluster` string was changed `unstable cluster` which had to be handled.