### PR TITLE
fix: TOOLS-2986 string match should support older 7.2 version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,17 +12,14 @@ jobs:
         with:
           submodules: true
       - name: Get Python version from Pipfile
-        run: echo "PYTHON_VERSION=$(grep "python_full_version" Pipfile | cut -d ' ' -f 3  - | tr -d '"')" >> $GITHUB_ENV
+        run: echo "PYTHON_VERSION=$(grep "python_version" Pipfile | cut -d ' ' -f 3  - | tr -d '"')" >> $GITHUB_ENV
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
       - name: Install dependencies
         run: |
           python -m pip install pipenv
-          pipenv --python /usr/bin/python
           pipenv install --dev
       - name: Build
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install pipenv
-          pipenv install --dev
+          pipenv install --dev --python ${{ env.PYTHON_VERSION }}
       - name: Build
         run: |
           make

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,12 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - name: Install dependencies
         run: |
           python -m pip install pipenv
-          pipenv install --dev --python ${{ env.PYTHON_VERSION }}
+          pipenv install --dev
       - name: Build
         run: |
           make

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - name: Install dependencies
         run: |
           python -m pip install pipenv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,11 +17,10 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
       - name: Install dependencies
         run: |
           python -m pip install pipenv
+          pipenv --python /usr/bin/python
           pipenv install --dev
       - name: Build
         run: |

--- a/lib/live_cluster/client/node.py
+++ b/lib/live_cluster/client/node.py
@@ -2401,7 +2401,16 @@ class Node(AsyncObject):
         resp = await self._info(req)
 
         if "error" in resp.lower():
-            if "cluster not specified size" in resp or "unstable cluster" in resp:
+            # check if any of these array is present in resp.lower()
+            unstable_cluster_error_strs = [
+                # Before https://github.com/citrusleaf/aerospike-server/commit/450922b89fcc12ad9ff85842a89997e2eb3a7a9f
+                "cluster-not-specified-size",
+                "unstable-cluster",
+                # After 
+                "cluster not specified size", 
+                "unstable cluster",
+            ]
+            if any([err in resp.lower() for err in unstable_cluster_error_strs]):
                 raise ASInfoClusterStableError(resp)
 
             raise ASInfoResponseError(

--- a/lib/live_cluster/client/node.py
+++ b/lib/live_cluster/client/node.py
@@ -2401,7 +2401,6 @@ class Node(AsyncObject):
         resp = await self._info(req)
 
         if "error" in resp.lower():
-            # check if any of these array is present in resp.lower()
             unstable_cluster_error_strs = [
                 # Before https://github.com/citrusleaf/aerospike-server/commit/450922b89fcc12ad9ff85842a89997e2eb3a7a9f
                 "cluster-not-specified-size",


### PR DESCRIPTION
With this PR https://github.com/aerospike/aerospike-admin/pull/329, we updated the server error response strings `unstable-cluster` to `unstable cluster`, which dropped the support for the server running before 7.2 https://aerospike.atlassian.net/browse/AER-6764


This PR enables back support for older error string too so that asadm remains compatible with 7.1 version and before.