### PR TITLE
fix: TOOLS-3003 strip/trim semi colon from resp for asinfo

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           submodules: true
       - name: Get Python version from Pipfile
-        run: echo "PYTHON_VERSION=$(grep "python_full_version" Pipfile | cut -d ' ' -f 3  - | tr -d '"')" >> $GITHUB_ENV
+        run: echo "PYTHON_VERSION=$(grep "python_version" Pipfile | cut -d ' ' -f 3  - | tr -d '"')" >> $GITHUB_ENV
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v3
         with:

--- a/lib/view/view.py
+++ b/lib/view/view.py
@@ -1357,6 +1357,7 @@ class CliView(object):
                 print("\n")
             else:
                 if isinstance(value, str):
+                    value = value.strip(';')
                     delimiter = util.find_delimiter_in(value)
                     value = value.split(delimiter)
 


### PR DESCRIPTION
Server error response in certain cases are like :
objects=0:tombstones=0:data_used_bytes=0:truncate_lut=0:sindexes=0:index_populating=false:truncating=false:default-read-touch-ttl-pct=0:default-ttl=0:disable-eviction=true:enable-index=true:stop-writes-count=0:stop-writes-size=0;

where semicolon comes at the end. The delimiting logic has a higer precedence for semicolon and thus is not able to separate new lines by : double colon.