### PR TITLE
fix: TOOLS-3012 standardise error handling string for manage roster

### DIFF
--- a/lib/live_cluster/client/constants.py
+++ b/lib/live_cluster/client/constants.py
@@ -12,7 +12,7 @@ class ErrorsMsgs:
     DC_NODE_ADD_FAIL = "Failed to add node to XDR datacenter"
     DC_NODE_REMOVE_FAIL = "Failed to remove node from XDR datacenter"
     INVALID_REWIND = 'Invalid rewind. Must be int or "all"'
-    INFO_SERVER_ERROR_RESPONSE = 'Failed to execute info command - server error'
+    INFO_SERVER_ERROR_RESPONSE = 'Server returned an error response for info command'
 
 
 DEFAULT_CONFIG_PATH = "/etc/aerospike/aerospike.conf"

--- a/lib/live_cluster/client/node.py
+++ b/lib/live_cluster/client/node.py
@@ -2401,9 +2401,6 @@ class Node(AsyncObject):
         resp = await self._info(req)
 
         if "error" in resp.lower():
-            if "cluster not specified size" in resp or "unstable cluster" in resp:
-                raise ASInfoClusterStableError(resp)
-
             raise ASInfoResponseError(
                 ErrorsMsgs.INFO_SERVER_ERROR_RESPONSE, resp
             )

--- a/lib/live_cluster/manage_controller.py
+++ b/lib/live_cluster/manage_controller.py
@@ -31,7 +31,6 @@ from lib.utils import constants, util, version
 from lib.base_controller import CommandHelp, ModifierHelp, ShellException
 from lib.utils.lookup_dict import PrefixDict
 from .client import (
-    ASInfoClusterStableError,
     ASInfoResponseError,
     ASInfoError,
     ASProtocolError,
@@ -2719,10 +2718,11 @@ class ManageReviveController(ManageLeafCommandController):
 class ManageRosterLeafCommandController(ManageLeafCommandController):
     def _check_and_log_cluster_stable(self, stable_data):
         cluster_key = None
-        warning_str = "The cluster is unstable. It is advised that you do not manage the roster. Run 'info network' for more information."
+        warning_str = "It is advised that you do not manage the roster. Run 'info network' for more information."
 
         for resp in stable_data.values():
-            if isinstance(resp, ASInfoClusterStableError):
+            if isinstance(resp, ASInfoResponseError):
+                logger.error(resp)
                 logger.warning(warning_str)
                 return False
 

--- a/test/unit/live_cluster/client/test_node.py
+++ b/test/unit/live_cluster/client/test_node.py
@@ -2053,34 +2053,6 @@ class NodeTest(asynctest.TestCase):
         )
 
     async def test_info_cluster_stable_with_errors(self):
-        self.info_mock.return_value = "ERROR::cluster not specified size"
-        expected = ASInfoResponseError(ErrorsMsgs.INFO_SERVER_ERROR_RESPONSE, "ERROR::cluster not specified size")
-
-        actual = await self.node.info_cluster_stable(cluster_size=3, namespace="bar")
-
-        self.info_mock.assert_called_with(
-            "cluster-stable:size=3;namespace=bar", self.ip
-        )
-        self.assertEqual(
-            actual,
-            expected,
-            "info_cluster_stable did not return the expected result",
-        )
-
-        self.info_mock.return_value = "ERROR::unstable cluster"
-        expected = ASInfoResponseError(ErrorsMsgs.INFO_SERVER_ERROR_RESPONSE, "ERROR::unstable cluster")
-
-        actual = await self.node.info_cluster_stable(cluster_size=3, namespace="bar")
-
-        self.info_mock.assert_called_with(
-            "cluster-stable:size=3;namespace=bar", self.ip
-        )
-        self.assertEqual(
-            actual,
-            expected,
-            "info_cluster_stable did not return the expected result",
-        )
-
         self.info_mock.return_value = "ERROR::foo"
         expected = ASInfoResponseError(
            ErrorsMsgs.INFO_SERVER_ERROR_RESPONSE, "ERROR::foo"

--- a/test/unit/live_cluster/client/test_node.py
+++ b/test/unit/live_cluster/client/test_node.py
@@ -34,13 +34,14 @@ from lib.live_cluster.client.types import (
     ASProtocolExcFactory,
     ASResponse,
 )
+
+from lib.live_cluster.client.constants import ErrorsMsgs
 from test.unit import util
 from lib.utils import constants
 from lib.live_cluster.client.assocket import ASSocket
 from lib.live_cluster.client.node import _SysCmd, Node
 from lib.live_cluster.client import (
     ASINFO_RESPONSE_OK,
-    ASInfoClusterStableError,
     ASInfoConfigError,
     ASInfoResponseError,
 )
@@ -2053,7 +2054,7 @@ class NodeTest(asynctest.TestCase):
 
     async def test_info_cluster_stable_with_errors(self):
         self.info_mock.return_value = "ERROR::cluster not specified size"
-        expected = ASInfoResponseError("Server returned an error response for info command", "ERROR::cluster not specified size")
+        expected = ASInfoResponseError(ErrorsMsgs.INFO_SERVER_ERROR_RESPONSE, "ERROR::cluster not specified size")
 
         actual = await self.node.info_cluster_stable(cluster_size=3, namespace="bar")
 
@@ -2067,7 +2068,7 @@ class NodeTest(asynctest.TestCase):
         )
 
         self.info_mock.return_value = "ERROR::unstable cluster"
-        expected = ASInfoResponseError("Server returned an error response for info command", "ERROR::unstable cluster")
+        expected = ASInfoResponseError(ErrorsMsgs.INFO_SERVER_ERROR_RESPONSE, "ERROR::unstable cluster")
 
         actual = await self.node.info_cluster_stable(cluster_size=3, namespace="bar")
 
@@ -2082,7 +2083,7 @@ class NodeTest(asynctest.TestCase):
 
         self.info_mock.return_value = "ERROR::foo"
         expected = ASInfoResponseError(
-            "Server returned an error response for info command", "ERROR::foo"
+           ErrorsMsgs.INFO_SERVER_ERROR_RESPONSE, "ERROR::foo"
         )
 
         actual = await self.node.info_cluster_stable(namespace="bar")

--- a/test/unit/live_cluster/client/test_node.py
+++ b/test/unit/live_cluster/client/test_node.py
@@ -2053,7 +2053,7 @@ class NodeTest(asynctest.TestCase):
 
     async def test_info_cluster_stable_with_errors(self):
         self.info_mock.return_value = "ERROR::cluster not specified size"
-        expected = ASInfoClusterStableError("ERROR::cluster not specified size")
+        expected = ASInfoResponseError("Server returned an error response for info command", "ERROR::cluster not specified size")
 
         actual = await self.node.info_cluster_stable(cluster_size=3, namespace="bar")
 
@@ -2067,7 +2067,7 @@ class NodeTest(asynctest.TestCase):
         )
 
         self.info_mock.return_value = "ERROR::unstable cluster"
-        expected = ASInfoClusterStableError("ERROR::unstable cluster")
+        expected = ASInfoResponseError("Server returned an error response for info command", "ERROR::unstable cluster")
 
         actual = await self.node.info_cluster_stable(cluster_size=3, namespace="bar")
 
@@ -2082,7 +2082,7 @@ class NodeTest(asynctest.TestCase):
 
         self.info_mock.return_value = "ERROR::foo"
         expected = ASInfoResponseError(
-            "Failed to execute info command - server error", "ERROR::foo"
+            "Server returned an error response for info command", "ERROR::foo"
         )
 
         actual = await self.node.info_cluster_stable(namespace="bar")

--- a/test/unit/live_cluster/test_manage_controller.py
+++ b/test/unit/live_cluster/test_manage_controller.py
@@ -2710,18 +2710,17 @@ class ManageRosterLeafCommandControllerTest(asynctest.TestCase):
 
             if tc.output is False:
                 self.logger_mock.warning.assert_called_with(
-                    "The cluster is unstable. It is advised that you do not manage the roster. Run 'info network' for more information."
+                    "It is advised that you do not manage the roster. Run 'info network' for more information."
                 )
                 
-            self.assertRaises(
-                ASInfoResponseError,
-                self.controller._check_and_log_cluster_stable,
-                {
-                    "1.1.1.1": "ABC",
-                    "2.2.2.2": "ABC",
-                    "3.3.3.3": ASInfoResponseError("", "foo"),
-                },
-            )
+        self.assertEqual(
+            False,
+            self.controller._check_and_log_cluster_stable({
+                "1.1.1.1": "ABC",
+                "2.2.2.2": "ABC",
+                "3.3.3.3": ASInfoResponseError("", "foo"),
+            })
+        )
 
     def test_check_and_log_nodes_in_observed(self):
         class test_case:


### PR DESCRIPTION
- removes special string handling