### PR TITLE
fix: manage acl quotas help text

### DIFF
--- a/lib/live_cluster/manage_controller.py
+++ b/lib/live_cluster/manage_controller.py
@@ -844,7 +844,7 @@ class ManageACLAllowListRoleController(ManageLeafCommandController):
         ),
         ModifierHelp("write", "Quota for write transaction (TPS)."),
     ),
-    usage="<role> [read <read-quota>]|[write <write-quota>]",
+    usage="role <role> [read <read-quota>]|[write <write-quota>]",
     short_msg="Change the read and write quotes for a role",
 )
 class ManageACLQuotasRoleController(ManageACLRolesLeafCommandController):


### PR DESCRIPTION
Fixes the acl quotas help text

Link to Docs https://aerospike.com/docs/tools/asadm/live_cluster_mode_guide#updating-the-quotas-of-a-role