### PR TITLE
fix: TOOLS-3035 add macOS resource fork file handling in log_util

### DIFF
--- a/lib/utils/log_util.py
+++ b/lib/utils/log_util.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import platform
 
 DATE_SEG = 0
 DATE_SEPARATOR = "-"
@@ -86,6 +87,10 @@ def get_dirs(path=""):
     except Exception:
         return []
 
+def _is_macos_resource_fork(filename):
+    """Check if a file is a macOS resource fork file (starts with '._')"""
+    # skip processing Apple resource fork files https://en.wikipedia.org/wiki/AppleSingle_and_AppleDouble_formats
+    return "darwin" in platform.system().lower() and os.path.basename(filename).startswith('._')
 
 def get_all_files(dir_path=""):
     fname_list = []
@@ -94,7 +99,9 @@ def get_all_files(dir_path=""):
     try:
         for root, sub_dir, files in os.walk(dir_path):
             for fname in files:
-                fname_list.append(os.path.join(root, fname))
+                # Skip macOS resource fork files
+                if not _is_macos_resource_fork(fname):
+                    fname_list.append(os.path.join(root, fname))
     except Exception:
         pass
 

--- a/test/unit/collectinfo_analyzer/test_log_handler.py
+++ b/test/unit/collectinfo_analyzer/test_log_handler.py
@@ -1,0 +1,69 @@
+# Copyright 2025 Aerospike, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import os
+import tempfile
+import shutil
+from mock import patch, MagicMock
+from lib.utils import log_util
+
+class LogUtilTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    @patch("platform.system")
+    def test_get_all_files_on_darwin(self, mock_system):
+        # Simulate macOS platform
+        mock_system.return_value = "Darwin"
+        
+        # Create test files
+        regular_file = os.path.join(self.temp_dir, "test.log")
+        resource_fork_file = os.path.join(self.temp_dir, "._test.log")
+        
+        with open(regular_file, "w") as f:
+            f.write("log content")
+        with open(resource_fork_file, "w") as f:
+            f.write("resource fork content")
+
+        # Test get_all_files method
+        files = log_util.get_all_files(self.temp_dir)
+        
+        # Assert resource fork file is excluded on Darwin
+        self.assertIn("test.log", [os.path.basename(f) for f in files])
+        self.assertNotIn("._test.log", [os.path.basename(f) for f in files])
+
+    @patch("platform.system")
+    def test_get_all_files_on_linux(self, mock_system):
+        # Simulate Linux platform
+        mock_system.return_value = "Linux"
+        
+        # Create test files
+        regular_file = os.path.join(self.temp_dir, "test.log")
+        resource_fork_file = os.path.join(self.temp_dir, "._test.log")
+        
+        with open(regular_file, "w") as f:
+            f.write("log content")
+        with open(resource_fork_file, "w") as f:
+            f.write("resource fork content")
+
+        # Test get_all_files method
+        files = log_util.get_all_files(self.temp_dir)
+        
+        # Assert both files are included on Linux
+        self.assertIn("test.log", [os.path.basename(f) for f in files])
+        self.assertIn("._test.log", [os.path.basename(f) for f in files]) 

--- a/test/unit/collectinfo_analyzer/test_log_handler.py
+++ b/test/unit/collectinfo_analyzer/test_log_handler.py
@@ -16,7 +16,7 @@ import unittest
 import os
 import tempfile
 import shutil
-from mock import patch, MagicMock
+from mock import patch
 from lib.utils import log_util
 
 class LogUtilTest(unittest.TestCase):


### PR DESCRIPTION
On Mac, while extracting the collect_info.tgz, the file system generates forked files 
- more on it https://en.wikipedia.org/wiki/AppleSingle_and_AppleDouble_formats

An example
/collectinfo/77105/tmp/collect_info_20250408_064020/._20250408_064020_ascinfo.json

Contents
```
b'\x00\x05\x16\x07\x00\x02\x00\x00Mac OS X        \x00\x02\x00\x00\x00\t\x00\x00\x002\x00\x00\x00q\x00\x00\x00\x02\x00\x00\x00\xa3\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00ATTR\x00\x00\x00\x00\x00\x00\x00\xa3\x00\x00\x00\x98\x00\x00\x00\x0b\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x98\x00\x00\x00\x0b\x00\x00\x15com.apple.provenance\x00\x01\x02\x00Y\x86\xbc\xbe\xab\xe64\xc7
```

Thus when the logic here https://github.com/aerospike/aerospike-admin/blob/18336baa326cbe38a3efd34957df35b69abdf8f2/lib/collectinfo_analyzer/collectinfo_handler/collectinfo_parser/collectinfo_parser.py#L44 parse the JSON for the file resembling like 20250408_064020_ascinfo.json because of the prefix, it failes with Error
```
ERROR: Expecting value: line 1 column 1 (char 0)
Traceback (most recent call last):
  File "/Users/achandra/Code/aerospike-admin/asadm.py", line 153, in __init__
    self.ctrl = CollectinfoRootController(
  File "/Users/achandra/Code/aerospike-admin/lib/collectinfo_analyzer/collectinfo_root_controller.py", line 38, in __init__
    CollectinfoRootController.log_handler = CollectinfoLogHandler(clinfo_path)
  File "/Users/achandra/Code/aerospike-admin/lib/collectinfo_analyzer/collectinfo_handler/log_handler.py", line 69, in __init__
    raise e
  File "/Users/achandra/Code/aerospike-admin/lib/collectinfo_analyzer/collectinfo_handler/log_handler.py", line 66, in __init__
    self._add_cinfo_log_files(cinfo_path)
  File "/Users/achandra/Code/aerospike-admin/lib/collectinfo_analyzer/collectinfo_handler/log_handler.py", line 329, in _add_cinfo_log_files
    cinfo_log = CollectinfoLog(cinfo_path, files)
  File "/Users/achandra/Code/aerospike-admin/lib/collectinfo_analyzer/collectinfo_handler/collectinfo_log.py", line 497, in __init__
    collectinfo_parser.parse_collectinfo_files(
  File "/Users/achandra/Code/aerospike-admin/lib/collectinfo_analyzer/collectinfo_handler/collectinfo_parser/collectinfo_parser.py", line 66, in parse_collectinfo_files
    cinfo_map = json.loads(str_content, object_hook=_stringify)
  File "/Users/achandra/.pyenv/versions/3.10.14/lib/python3.10/json/__init__.py", line 359, in loads
    return cls(**kw).decode(s)
  File "/Users/achandra/.pyenv/versions/3.10.14/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/Users/achandra/.pyenv/versions/3.10.14/lib/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

Fix
* Implemented a check to skip processing macOS resource fork files in get_all_files function.
* Added a helper function _is_macos_resource_fork to identify these files based on their naming convention.