### PR TITLE
fix: update Python setup action to version 5

### DIFF
--- a/.github/workflows/mac-artifact.yml
+++ b/.github/workflows/mac-artifact.yml
@@ -61,7 +61,7 @@ jobs:
           echo ${{ steps.system-info.outputs.kernel-release }}
           echo ${{ steps.system-info.outputs.platform }}
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: "pipenv"


### PR DESCRIPTION
actions/setup-python@v3 is deprecated and faling like 

```
Run actions/setup-python@v3
  with:
    python-version: 3.11
    cache: pip
    token: ***
  env:
    PYTHON_VERSION: 3.11
Successfully setup CPython (3.11.12)
/opt/hostedtoolcache/Python/3.11.12/x64/bin/pip cache dir
/home/runner/.cache/pip
Error: Cache service responded with 422
```

https://github.com/aerospike/aerospike-admin/actions/runs/14567722852/job/40859551963