### PR TITLE
fix: TOOLS-3053 validate role names for manage acl command

### DIFF
--- a/lib/live_cluster/manage_controller.py
+++ b/lib/live_cluster/manage_controller.py
@@ -269,6 +269,11 @@ class ManageACLCreateUserController(ManageLeafCommandController):
 
         if self.warn and not self.prompt_challenge():
             return
+        
+        resp = await self.cluster.admin_query_roles(nodes="principal")
+        valid_roles = list(resp.values())[0].keys()
+        if not util.validate_roles(roles, valid_roles):
+            return
 
         result = await self.cluster.admin_create_user(
             username, password, roles, nodes="principal"
@@ -445,6 +450,11 @@ class ManageACLGrantUserController(ManageLeafCommandController):
 
         if self.warn and not self.prompt_challenge():
             return
+        
+        resp = await self.cluster.admin_query_roles(nodes="principal")
+        valid_roles = list(resp.values())[0].keys()
+        if not util.validate_roles(roles, valid_roles):
+            return
 
         result = await self.cluster.admin_grant_roles(
             username, roles, nodes="principal"
@@ -480,6 +490,11 @@ class ManageACLRevokeUserController(ManageLeafCommandController):
         roles = self.mods["roles"]
 
         if self.warn and not self.prompt_challenge():
+            return
+        
+        resp = await self.cluster.admin_query_roles(nodes="principal")
+        valid_roles = list(resp.values())[0].keys()
+        if not util.validate_roles(roles, valid_roles):
             return
 
         result = await self.cluster.admin_revoke_roles(
@@ -639,6 +654,11 @@ class ManageACLDeleteRoleController(ManageLeafCommandController):
 
         if self.warn and not self.prompt_challenge():
             return
+        
+        resp = await self.cluster.admin_query_roles(nodes="principal")
+        valid_roles = list(resp.values())[0].keys()
+        if not util.validate_roles([role_name], valid_roles):
+            return
 
         result = await self.cluster.admin_delete_role(role_name, nodes="principal")
         result = list(result.values())[0]
@@ -678,6 +698,11 @@ class ManageACLGrantRoleController(ManageLeafCommandController):
 
         if len(self.mods["set"]) and not len(self.mods["ns"]):
             logger.error("A set must be accompanied by a namespace.")
+            return
+        
+        resp = await self.cluster.admin_query_roles(nodes="principal")
+        valid_roles = list(resp.values())[0].keys()
+        if not util.validate_roles([role_name], valid_roles):
             return
 
         if len(self.mods["ns"]):
@@ -741,6 +766,11 @@ class ManageACLRevokeRoleController(ManageLeafCommandController):
 
         if self.warn and not self.prompt_challenge():
             return
+        
+        resp = await self.cluster.admin_query_roles(nodes="principal")
+        valid_roles = list(resp.values())[0].keys()
+        if not util.validate_roles([role_name], valid_roles):
+            return
 
         result = await self.cluster.admin_delete_privileges(
             role_name, [privilege], nodes="principal"
@@ -803,6 +833,11 @@ class ManageACLAllowListRoleController(ManageLeafCommandController):
             return
 
         if self.warn and not self.prompt_challenge():
+            return
+        
+        resp = await self.cluster.admin_query_roles(nodes="principal")
+        valid_roles = list(resp.values())[0].keys()
+        if not util.validate_roles([role_name], valid_roles):
             return
 
         result = None
@@ -919,6 +954,11 @@ class ManageACLQuotasRoleController(ManageACLRolesLeafCommandController):
             return
 
         if self.warn and not self.prompt_challenge():
+            return
+
+        resp = await self.cluster.admin_query_roles(nodes="principal")
+        valid_roles = list(resp.values())[0].keys()
+        if not util.validate_roles([role], valid_roles):
             return
 
         result = await self.cluster.admin_set_quotas(

--- a/lib/live_cluster/manage_controller.py
+++ b/lib/live_cluster/manage_controller.py
@@ -654,11 +654,6 @@ class ManageACLDeleteRoleController(ManageLeafCommandController):
 
         if self.warn and not self.prompt_challenge():
             return
-        
-        resp = await self.cluster.admin_query_roles(nodes="principal")
-        valid_roles = list(resp.values())[0].keys()
-        if not util.validate_roles([role_name], valid_roles):
-            return
 
         result = await self.cluster.admin_delete_role(role_name, nodes="principal")
         result = list(result.values())[0]
@@ -698,11 +693,6 @@ class ManageACLGrantRoleController(ManageLeafCommandController):
 
         if len(self.mods["set"]) and not len(self.mods["ns"]):
             logger.error("A set must be accompanied by a namespace.")
-            return
-        
-        resp = await self.cluster.admin_query_roles(nodes="principal")
-        valid_roles = list(resp.values())[0].keys()
-        if not util.validate_roles([role_name], valid_roles):
             return
 
         if len(self.mods["ns"]):
@@ -766,11 +756,6 @@ class ManageACLRevokeRoleController(ManageLeafCommandController):
 
         if self.warn and not self.prompt_challenge():
             return
-        
-        resp = await self.cluster.admin_query_roles(nodes="principal")
-        valid_roles = list(resp.values())[0].keys()
-        if not util.validate_roles([role_name], valid_roles):
-            return
 
         result = await self.cluster.admin_delete_privileges(
             role_name, [privilege], nodes="principal"
@@ -833,11 +818,6 @@ class ManageACLAllowListRoleController(ManageLeafCommandController):
             return
 
         if self.warn and not self.prompt_challenge():
-            return
-        
-        resp = await self.cluster.admin_query_roles(nodes="principal")
-        valid_roles = list(resp.values())[0].keys()
-        if not util.validate_roles([role_name], valid_roles):
             return
 
         result = None
@@ -954,11 +934,6 @@ class ManageACLQuotasRoleController(ManageACLRolesLeafCommandController):
             return
 
         if self.warn and not self.prompt_challenge():
-            return
-
-        resp = await self.cluster.admin_query_roles(nodes="principal")
-        valid_roles = list(resp.values())[0].keys()
-        if not util.validate_roles([role], valid_roles):
             return
 
         result = await self.cluster.admin_set_quotas(

--- a/lib/utils/util.py
+++ b/lib/utils/util.py
@@ -783,6 +783,27 @@ def str_to_bytes(data: Union[bytes, str]) -> bytes:
     return str.encode(data, "utf-8")
 
 
+def validate_roles(roles: list[str], valid_role_names: list[str]) -> bool:
+    """
+    Checks if all roles in `roles` are present in `valid_role_names`.
+    If not, returns False.
+    Returns True if all roles are valid, otherwise False.
+    """
+    
+    invalid_roles = [role for role in roles if role not in valid_role_names]
+    if invalid_roles:
+        logger.error(
+            "Invalid %s: %s. Valid %s are: %s",
+            "roles" if len(roles) > 1 else "role",
+            ", ".join(invalid_roles),
+            "roles" if len(valid_role_names) > 1 else "role",
+            ", ".join(valid_role_names)
+        )
+        return False
+    
+    return True
+
+
 ItemsType = TypeVar("ItemsType")
 
 

--- a/lib/utils/util.py
+++ b/lib/utils/util.py
@@ -792,12 +792,18 @@ def validate_roles(roles: list[str], valid_role_names: list[str]) -> bool:
     
     invalid_roles = [role for role in roles if role not in valid_role_names]
     if invalid_roles:
-        logger.error(
-            "Invalid %s: %s. Valid %s are: %s",
-            "roles" if len(roles) > 1 else "role",
-            ", ".join(invalid_roles),
+        valid_roles = "" if len(valid_role_names) == 0 else "Valid %s are: %s" % (
             "roles" if len(valid_role_names) > 1 else "role",
             ", ".join(valid_role_names)
+        )
+        invalid_roles = "" if len(invalid_roles) == 0 else "Invalid %s: %s" % (
+            "roles" if len(roles) > 1 else "role",
+            ", ".join(invalid_roles)
+        )
+        logger.error(
+            "%s. %s",
+            invalid_roles,
+            valid_roles
         )
         return False
     

--- a/test/e2e/live_cluster/test_show.py
+++ b/test/e2e/live_cluster/test_show.py
@@ -856,13 +856,13 @@ class TestShowUsers(asynctest.TestCase):
                 "bar",
                 "roles",
                 *exp_roles,
-                "to-remove",
+                "read",
             ],
         )
         time.sleep(0.25)
         await util.capture_stdout(
             self.rc.execute,
-            ["manage", "acl", "revoke", "user", exp_user, "roles", "to-remove"],
+            ["manage", "acl", "revoke", "user", exp_user, "roles", "read"],
         )
         time.sleep(0.25)
 

--- a/test/unit/live_cluster/test_manage_controller.py
+++ b/test/unit/live_cluster/test_manage_controller.py
@@ -244,6 +244,9 @@ class ManageACLCreateUserControllerTest(asynctest.TestCase):
     async def test_no_roles_and_no_password(self):
         getpass_mock = patch("lib.live_cluster.manage_controller.getpass").start()
         getpass_mock.return_value = "pass"
+        self.cluster_mock.admin_query_roles.return_value = {
+            "principal": {}
+        }
         self.cluster_mock.admin_create_user.return_value = {
             "principal_ip": ASResponse.OK
         }
@@ -262,6 +265,13 @@ class ManageACLCreateUserControllerTest(asynctest.TestCase):
         self.cluster_mock.admin_create_user.return_value = {
             "principal_ip": ASResponse.OK
         }
+        self.cluster_mock.admin_query_roles.return_value = {
+            "principal": {
+                "role1": {"privileges": ["read", "write"], "whitelist": ["1.1.1.1", "2.2.2.2"]}, 
+                "role2": {"privileges": ["read", "write"], "whitelist": []},
+                "role3": {"privileges": ["read", "write"], "whitelist": []}
+            }
+        }
 
         await self.controller.execute(
             ["test-user", "password", "pass", "roles", "role1", "role2", "role3"]
@@ -279,6 +289,13 @@ class ManageACLCreateUserControllerTest(asynctest.TestCase):
         self.cluster_mock.admin_create_user.return_value = {
             "principal_ip": ASResponse.OK
         }
+        self.cluster_mock.admin_query_roles.return_value = {
+            "principal": {
+                "role1": {"privileges": ["read", "write"], "whitelist": ["1.1.1.1", "2.2.2.2"]}, 
+                "role2": {"privileges": ["read", "write"], "whitelist": []},
+                "role3": {"privileges": ["read", "write"], "whitelist": []}
+            }
+        }
 
         await self.controller.execute(
             ["test-user", "password", "pass", "role", "role1", "role2", "role3"]
@@ -295,6 +312,12 @@ class ManageACLCreateUserControllerTest(asynctest.TestCase):
         as_error = ASProtocolError(ASResponse.USER_ALREADY_EXISTS, "test-message")
         line = "test-user password pass"
         self.cluster_mock.get_expected_principal.return_value = "principal"
+        self.cluster_mock.admin_query_roles.return_value = {
+            "principal": {
+                "test-role": {"privileges": ["read", "write"], "whitelist": ["1.1.1.1", "2.2.2.2"]}, 
+                "test-role2": {"privileges": ["read", "write"], "whitelist": []}
+            }
+        }
         self.cluster_mock.admin_create_user.return_value = {"principal_ip": as_error}
 
         await self.controller.execute(line.split())
@@ -309,6 +332,11 @@ class ManageACLCreateUserControllerTest(asynctest.TestCase):
         as_error = IOError("test-message")
         line = "test-user password pass"
         self.cluster_mock.get_expected_principal.return_value = "principal"
+        self.cluster_mock.admin_query_roles.return_value = {
+            "principal": {
+                "test-role": {"privileges": ["read", "write"], "whitelist": ["1.1.1.1", "2.2.2.2"]}, 
+            }
+        }
         self.cluster_mock.admin_create_user.return_value = {"principal_ip": as_error}
 
         await test_util.assert_exception_async(
@@ -688,6 +716,11 @@ class ManageACLQuotasControllerTest(asynctest.TestCase):
         self.cluster_mock.admin_set_quotas.return_value = {
             "principal_ip": ASResponse.OK
         }
+        self.cluster_mock.admin_query_roles.return_value = {
+            "principal": {
+                "test-role": {"privileges": ["read", "write"], "whitelist": ["1.1.1.1", "2.2.2.2"]}, 
+            }
+        }
 
         await self.controller.execute(line.split())
 
@@ -701,6 +734,11 @@ class ManageACLQuotasControllerTest(asynctest.TestCase):
         line = "role test-role read 100"
         self.cluster_mock.admin_set_quotas.return_value = {
             "principal_ip": ASResponse.OK
+        }
+        self.cluster_mock.admin_query_roles.return_value = {
+            "principal": {
+                "test-role": {"privileges": ["read", "write"], "whitelist": ["1.1.1.1", "2.2.2.2"]}, 
+            }
         }
 
         await self.controller.execute(line.split())
@@ -716,6 +754,11 @@ class ManageACLQuotasControllerTest(asynctest.TestCase):
         self.cluster_mock.admin_set_quotas.return_value = {
             "principal_ip": ASResponse.OK
         }
+        self.cluster_mock.admin_query_roles.return_value = {
+            "principal": {
+                "test-role": {"privileges": ["read", "write"], "whitelist": ["1.1.1.1", "2.2.2.2"]}, 
+            }
+        }
 
         await self.controller.execute(line.split())
 
@@ -729,6 +772,11 @@ class ManageACLQuotasControllerTest(asynctest.TestCase):
         self.cluster_mock.admin_set_quotas.return_value = {
             "principal_ip": ASResponse.OK
         }
+        self.cluster_mock.admin_query_roles.return_value = {
+            "principal": {
+                "read": {"privileges": ["read"], "whitelist": []},
+            }
+        }
 
         await self.controller.execute(line.split())
 
@@ -741,6 +789,11 @@ class ManageACLQuotasControllerTest(asynctest.TestCase):
         self.cluster_mock.admin_set_quotas.return_value = {
             "principal_ip": ASResponse.OK
         }
+        self.cluster_mock.admin_query_roles.return_value = {
+            "principal": {
+                "write": {"privileges": ["write"], "whitelist": []},
+            }
+        }
 
         await self.controller.execute(line.split())
 
@@ -752,6 +805,11 @@ class ManageACLQuotasControllerTest(asynctest.TestCase):
         line = "role write read 100"
         self.cluster_mock.admin_set_quotas.return_value = {
             "principal_ip": ASResponse.OK
+        }
+        self.cluster_mock.admin_query_roles.return_value = {
+            "principal": {
+                "write": {"privileges": ["write"], "whitelist": []},
+            }
         }
 
         await self.controller.execute(line.split())
@@ -782,6 +840,11 @@ class ManageACLQuotasControllerTest(asynctest.TestCase):
         as_error = ASProtocolError(ASResponse.RATE_QUOTA_EXCEEDED, "test-message")
         line = "role test-role write 100 read 100"
         self.cluster_mock.admin_set_quotas.return_value = {"principal_ip": as_error}
+        self.cluster_mock.admin_query_roles.return_value = {
+            "principal": {
+                "test-role": {"privileges": ["write", "test-role"], "whitelist": []},
+            }
+        }
 
         await self.controller.execute(line.split())
 
@@ -795,6 +858,11 @@ class ManageACLQuotasControllerTest(asynctest.TestCase):
         as_error = IOError("test-message")
         line = "role test-role write 100 read 100"
         self.cluster_mock.admin_set_quotas.return_value = {"principal_ip": as_error}
+        self.cluster_mock.admin_query_roles.return_value = {
+            "principal": {
+                "test-role": {"privileges": ["read", "write"], "whitelist": ["1.1.1.1", "2.2.2.2"]}, 
+            }
+        }
 
         await test_util.assert_exception_async(
             self, ShellException, "test-message", self.controller.execute, line.split()

--- a/test/unit/utils/test_util.py
+++ b/test/unit/utils/test_util.py
@@ -146,3 +146,23 @@ class UtilTest(asynctest.TestCase):
         self.assertEqual(
             result, expected, "deep_merge_dicts did not return the expected result"
         )
+
+    def test_validate_roles(self):
+        valid_roles = ["admin", "user_1", "role-2", "A_B-C123", "X", "x_y-z", "123", "A1_B2-C3"]
+        # All valid
+        self.assertTrue(util.validate_roles(["admin", "user_1"], valid_roles))
+        self.assertTrue(util.validate_roles(["role-2", "A_B-C123"], valid_roles))
+        self.assertTrue(util.validate_roles(["X", "x_y-z", "123", "A1_B2-C3"], valid_roles))
+        # Single valid role
+        self.assertTrue(util.validate_roles(["admin"], valid_roles))
+        self.assertTrue(util.validate_roles(["A1_B2-C3"], valid_roles))
+        # Empty list (should be valid)
+        self.assertTrue(util.validate_roles([], valid_roles))
+        # One invalid (not in valid_roles)
+        self.assertFalse(util.validate_roles(["admin", "invalid"], valid_roles))
+        # One invalid (bad format)
+        self.assertFalse(util.validate_roles(["admin", "bad role"], valid_roles))
+        # All invalid (bad format)
+        self.assertFalse(util.validate_roles(["bad role", "bad,role"], valid_roles))
+        # All invalid (not in valid_roles)
+        self.assertFalse(util.validate_roles(["foo", "bar"], valid_roles))


### PR DESCRIPTION
This PR introduces robust validation for role names and role existence throughout the Aerospike Admin tool, ensuring that only valid and existing roles can be used in user and role management commands. It also adds comprehensive unit tests to cover a wide range of valid and invalid scenarios.

- Centralized all role validation in util.validate_roles.
   - Role names must now be:
   - Validation checks both the format and existence of roles.
   - Clear, context-aware error messages are logged for invalid roles or names.
- All relevant manage commands (user creation, role assignment, role creation, etc.) now use the centralized validation.
   - The list of valid roles is dynamically fetched from the cluster before validation.
- Added and expanded unit tests in test/unit/utils/test_util.py & test_manage_controller:
   - Valid role names (including edge cases)
   - Roles not present in the valid roles list
   - Logging/error message assertions