### PR TITLE
feat: TOOLS-3054 add auth mode field to user info and templates

### DIFF
--- a/lib/live_cluster/client/info.py
+++ b/lib/live_cluster/client/info.py
@@ -716,6 +716,7 @@ async def _query_users(
                 read_info = None
                 write_info = None
                 connections = None
+                auth_mode = None
 
                 for _ in range(field_count):
                     field_len, field_type, offset = _unpack_admin_field_header(
@@ -732,6 +733,9 @@ async def _query_users(
                     elif field_type == ASField.ROLES:
                         roles, offset = _unpack_admin_roles(rsp_buf, offset)
                         user_roles.extend(roles)
+
+                    elif field_type == ASField.AUTH_MODE:
+                        auth_mode, offset = _unpack_string(rsp_buf, offset, field_len)
 
                     elif field_type == ASField.READ_INFO:
                         read_info, offset = _unpack_admin_read_write_info(
@@ -763,6 +767,9 @@ async def _query_users(
 
                     for name, value in zip(READ_WRITE_INFO_VALUES, write_info):
                         users_dict[user_name]["write-info"][name] = value
+
+                if auth_mode:
+                    users_dict[user_name]["auth-mode"] = auth_mode
 
                 if connections:
                     users_dict[user_name]["connections"] = connections

--- a/lib/live_cluster/client/types.py
+++ b/lib/live_cluster/client/types.py
@@ -50,6 +50,7 @@ class ASField(IntEnum):
     CLEAR_PASSWORD = 4
     SESSION_TOKEN = 5
     SESSION_TTL = 6
+    AUTH_MODE = 7
     ROLES = 10
     ROLE = 11
     PRIVILEGES = 12

--- a/lib/view/templates.py
+++ b/lib/view/templates.py
@@ -2034,15 +2034,6 @@ show_users = Sheet(
     (
         Field("User", Projectors.String("data", None, for_each_key=True)),
         Field(
-            "Auth Mode",
-            Projectors.Func(
-                FieldType.string,
-                turn_empty_to_none,
-                Projectors.Identity("data", "auth-mode"),
-            ),
-            align=FieldAlignment.right,
-        ),
-        Field(
             "Roles",
             Projectors.Func(
                 FieldType.undefined,
@@ -2077,6 +2068,15 @@ show_users = Sheet(
                     ),
                 ),
             ),
+        ),
+        Field(
+            "Auth Mode",
+            Projectors.Func(
+                FieldType.string,
+                turn_empty_to_none,
+                Projectors.Identity("data", "auth-mode"),
+            ),
+            align=FieldAlignment.right,
         ),
     ),
     from_source="data",
@@ -2189,15 +2189,6 @@ def create_quota_tps_subgroup(
 show_users_stats = Sheet(
     (
         Field("User", Projectors.String("data", None, for_each_key=True)),
-        Field(
-            "Auth Mode",
-            Projectors.Func(
-                FieldType.string,
-                turn_empty_to_none,
-                Projectors.Identity("data", "auth-mode"),
-            ),
-            align=FieldAlignment.right,
-        ),
         node_field,
         Field(
             "Connections",

--- a/lib/view/templates.py
+++ b/lib/view/templates.py
@@ -2034,6 +2034,15 @@ show_users = Sheet(
     (
         Field("User", Projectors.String("data", None, for_each_key=True)),
         Field(
+            "Auth Mode",
+            Projectors.Func(
+                FieldType.string,
+                turn_empty_to_none,
+                Projectors.Identity("data", "auth-mode"),
+            ),
+            align=FieldAlignment.right,
+        ),
+        Field(
             "Roles",
             Projectors.Func(
                 FieldType.undefined,
@@ -2180,6 +2189,15 @@ def create_quota_tps_subgroup(
 show_users_stats = Sheet(
     (
         Field("User", Projectors.String("data", None, for_each_key=True)),
+        Field(
+            "Auth Mode",
+            Projectors.Func(
+                FieldType.string,
+                turn_empty_to_none,
+                Projectors.Identity("data", "auth-mode"),
+            ),
+            align=FieldAlignment.right,
+        ),
         node_field,
         Field(
             "Connections",


### PR DESCRIPTION
With this PR, it enables a new column for show users called Auth Mode.

<img width="359" alt="Screenshot 2025-06-05 at 4 54 30 PM" src="https://github.com/user-attachments/assets/352e0bb3-0449-4708-9f72-7d6720ff1004" />


The same will be available in CollectInfo Mode

<img width="1010" alt="Screenshot 2025-06-05 at 4 57 58 PM" src="https://github.com/user-attachments/assets/38143214-a467-4961-b864-bae22daa5916" />


Update. the column is moved to the end.

