### PR TITLE
feat: TOOLS-3059 Replace deprecated id / ns from info calls with namespace

### DIFF
--- a/asinfo/run_asinfo_test.sh
+++ b/asinfo/run_asinfo_test.sh
@@ -31,7 +31,7 @@ if ! run_test ${asinfo_cmd} ${output_substring} ; then
 	exit 1
 fi
 
-asinfo_cmd="get-config:context=namespace;id=test"
+asinfo_cmd="get-config:context=namespace;namespace=test"
 output_substring="default-ttl"
 if ! run_test ${asinfo_cmd} ${output_substring} ; then
 	echo "Error while running asinfo command: ${asinfo_cmd}"

--- a/lib/live_cluster/client/node.py
+++ b/lib/live_cluster/client/node.py
@@ -1567,7 +1567,7 @@ class Node(AsyncObject):
 
             new_param = delimiter.join([subcontext, param])
 
-        req = "set-config:context=namespace;id={};{}={}".format(
+        req = "set-config:context=namespace;namespace={};{}={}".format(
             namespace, new_param, value
         )
 
@@ -1693,7 +1693,7 @@ class Node(AsyncObject):
     @async_return_exceptions
     async def info_single_namespace_config(self, namespace):
         return client_util.info_to_dict(
-            await self._info("get-config:context=namespace;id=%s" % namespace)
+            await self._info("get-config:context=namespace;namespace=%s" % namespace)
         )
 
     @async_return_exceptions
@@ -2579,7 +2579,7 @@ class Node(AsyncObject):
         if index_type:
             command += "indextype={};".format(index_type)
 
-        command += "ns={};".format(namespace)
+        command += "namespace={};".format(namespace)
 
         if set_:
             command += "set={};".format(set_)
@@ -2614,9 +2614,9 @@ class Node(AsyncObject):
         command = ""
 
         if set_ is None:
-            command = "sindex-delete:ns={};indexname={}".format(namespace, index_name)
+            command = "sindex-delete:namespace={};indexname={}".format(namespace, index_name)
         else:
-            command = "sindex-delete:ns={};set={};indexname={}".format(
+            command = "sindex-delete:namespace={};set={};indexname={}".format(
                 namespace, set_, index_name
             )
 

--- a/test/e2e/lib.py
+++ b/test/e2e/lib.py
@@ -527,7 +527,7 @@ def populate_db(set_name: str):
 
 def create_sindex(name, type_, ns, bin, set_: str | None = None):
     global CLIENT
-    req = "sindex-create:ns={};indexname={};indexdata={},{}".format(
+    req = "sindex-create:namespace={};indexname={};indexdata={},{}".format(
         ns, name, bin, type_
     )
 

--- a/test/e2e/live_cluster/test_show.py
+++ b/test/e2e/live_cluster/test_show.py
@@ -38,8 +38,8 @@ def print_header(actual_header):
 class TestShowLatenciesDefault(asynctest.TestCase):
     """
     TODO: enable-micro benchmarks
-    asinfo -v 'set-config:context=namespace;id=test;enable-benchmarks-write=true' -Uadmin -Padmin
-    asinfo -v 'set-config:context=namespace;id=test;enable-benchmarks-read=true' -Uadmin -Padmin
+    asinfo -v 'set-config:context=namespace;namespace=test;enable-benchmarks-write=true' -Uadmin -Padmin
+    asinfo -v 'set-config:context=namespace;namespace=test;enable-benchmarks-read=true' -Uadmin -Padmin
     """
 
     async def setUp(self):

--- a/test/test_asinfo.sh
+++ b/test/test_asinfo.sh
@@ -50,7 +50,7 @@ if ! run_test ${asinfo_cmd} ${output_substring} ; then
 	exit 1
 fi
 
-asinfo_cmd="get-config:context=namespace;id=test"
+asinfo_cmd="get-config:context=namespace;namespace=test"
 output_substring="default-ttl"
 if ! run_test ${asinfo_cmd} ${output_substring} ; then
 	echo "Error while running asinfo command: ${asinfo_cmd}"

--- a/test/unit/live_cluster/client/test_node.py
+++ b/test/unit/live_cluster/client/test_node.py
@@ -1316,7 +1316,7 @@ class NodeTest(asynctest.TestCase):
         )
 
         self.info_mock.assert_called_with(
-            "set-config:context=namespace;id=buff;foo=bar;set=test-set", self.ip
+            "set-config:context=namespace;namespace=buff;foo=bar;set=test-set", self.ip
         )
         self.assertEqual(actual, ASINFO_RESPONSE_OK)
 
@@ -1327,7 +1327,7 @@ class NodeTest(asynctest.TestCase):
         )
 
         self.info_mock.assert_called_with(
-            "set-config:context=namespace;id=buff;foo=bar", self.ip
+            "set-config:context=namespace;namespace=buff;foo=bar", self.ip
         )
         self.assertEqual(actual, ASINFO_RESPONSE_OK)
 
@@ -1338,7 +1338,7 @@ class NodeTest(asynctest.TestCase):
         )
 
         self.info_mock.assert_called_with(
-            "set-config:context=namespace;id=buff;geo2dsphere-within-foo=bar", self.ip
+            "set-config:context=namespace;namespace=buff;geo2dsphere-within-foo=bar", self.ip
         )
         self.assertEqual(actual, ASINFO_RESPONSE_OK)
 
@@ -1347,7 +1347,7 @@ class NodeTest(asynctest.TestCase):
         )
 
         self.info_mock.assert_called_with(
-            "set-config:context=namespace;id=buff;mounts-size-limit=50", self.ip
+            "set-config:context=namespace;namespace=buff;mounts-size-limit=50", self.ip
         )
         self.assertEqual(actual, ASINFO_RESPONSE_OK)
 
@@ -1442,7 +1442,7 @@ class NodeTest(asynctest.TestCase):
 
         actual = await self.node.info_get_config("namespace", "test")
         self.info_mock.assert_called_with(
-            "get-config:context=namespace;id=test", self.ip
+            "get-config:context=namespace;namespace=test", self.ip
         )
         self.assertDictEqual(expected, actual)
 
@@ -1462,8 +1462,8 @@ class NodeTest(asynctest.TestCase):
 
         self.info_mock.assert_has_calls(
             [
-                call("get-config:context=namespace;id=test", self.ip),
-                call("get-config:context=namespace;id=bar", self.ip),
+                call("get-config:context=namespace;namespace=test", self.ip),
+                call("get-config:context=namespace;namespace=bar", self.ip),
             ]  # type: ignore
         )
 
@@ -3437,7 +3437,7 @@ class NodeTest(asynctest.TestCase):
     async def test_info_sindex_create_success(self):
         self.info_mock.return_value = "OK"
         expected_call = (
-            "sindex-create:indexname=iname;ns=ns;indexdata=data1,data2".format()
+            "sindex-create:indexname=iname;namespace=ns;indexdata=data1,data2".format()
         )
 
         actual = await self.node.info_sindex_create("iname", "ns", "data1", "data2")
@@ -3446,7 +3446,7 @@ class NodeTest(asynctest.TestCase):
         self.assertEqual(actual, ASINFO_RESPONSE_OK)
 
         self.info_mock.return_value = "OK"
-        expected_call = "sindex-create:indexname=iname;indextype=itype;ns=ns;set=set;context=khAB;indexdata=data1,data2"
+        expected_call = "sindex-create:indexname=iname;indextype=itype;namespace=ns;set=set;context=khAB;indexdata=data1,data2"
 
         actual = await self.node.info_sindex_create(
             "iname",
@@ -3471,7 +3471,7 @@ class NodeTest(asynctest.TestCase):
 
     async def test_info_sindex_delete_success(self):
         self.info_mock.return_value = "OK"
-        expected_call = "sindex-delete:ns={};indexname={}".format(
+        expected_call = "sindex-delete:namespace={};indexname={}".format(
             "ns",
             "iname",
         )
@@ -3482,7 +3482,7 @@ class NodeTest(asynctest.TestCase):
         self.assertEqual(actual, ASINFO_RESPONSE_OK)
 
         self.info_mock.return_value = "OK"
-        expected_call = "sindex-delete:ns={};set={};indexname={}".format(
+        expected_call = "sindex-delete:namespace={};set={};indexname={}".format(
             "ns",
             "set",
             "iname",

--- a/test/unit/live_cluster/client/test_node.py
+++ b/test/unit/live_cluster/client/test_node.py
@@ -1305,7 +1305,7 @@ class NodeTest(asynctest.TestCase):
         actual = await self.node.info_set_config_namespace("foo", "bar", "buff")
 
         self.info_mock.assert_called_with(
-            "set-config:context=namespace;id=buff;foo=bar", self.ip
+            "set-config:context=namespace;namespace=buff;foo=bar", self.ip
         )
         self.assertEqual(actual, ASINFO_RESPONSE_OK)
 


### PR DESCRIPTION
namespace to be used instead of id / ns in info calls.  id / ns is deprecated from 7.2