### PR TITLE
feat: TOOLS-3055 - use the admin port instead of service port based on flag

### DIFF
--- a/asadm.py
+++ b/asadm.py
@@ -106,7 +106,7 @@ class AerospikeShell(cmd.Cmd, AsyncObject):
         execute_only_mode=False,
         privileged_mode=False,
         timeout=1,
-        use_seed_node=False,
+        use_seed_address=False,
     ):
         # indicates shell created successfully and connected to cluster/collectinfo/logfile
         self.connected = True
@@ -177,7 +177,7 @@ class AerospikeShell(cmd.Cmd, AsyncObject):
                     only_connect_seed,
                     timeout=timeout,
                     asadm_version=admin_version,
-                    use_seed_node=use_seed_node,
+                    use_seed_address=use_seed_address,
                 )
 
                 if not self.ctrl.cluster.get_live_nodes():
@@ -254,8 +254,6 @@ class AerospikeShell(cmd.Cmd, AsyncObject):
         for command in commands:
             if command != "help":
                 self.commands.add(command)
-
-        self.use_seed_node = use_seed_node
 
     async def active_stop_writes(self, cluster: Cluster):
         """
@@ -762,6 +760,11 @@ async def main():
     ):
         logger.critical("TLS is required for authentication mode: " + cli_args.auth)
 
+    if cli_args.use_seed_address and not cli_args.single_node:
+        logger.critical(
+            "--use-seed-address can only be used with --single-node. Please enable --single-node or remove --use-seed-address."
+        )
+
     ssl_context = parse_tls_input(cli_args)
 
     if cli_args.asinfo_mode:
@@ -808,7 +811,7 @@ async def main():
         execute_only_mode=execute_only_mode,
         privileged_mode=cli_args.enable,
         timeout=cli_args.timeout,
-        use_seed_node=cli_args.use_seed_node,
+        use_seed_address=cli_args.use_seed_address,
     )  # type: ignore
 
     use_yappi = False

--- a/asadm.py
+++ b/asadm.py
@@ -106,6 +106,7 @@ class AerospikeShell(cmd.Cmd, AsyncObject):
         execute_only_mode=False,
         privileged_mode=False,
         timeout=1,
+        use_seed_node=False,
     ):
         # indicates shell created successfully and connected to cluster/collectinfo/logfile
         self.connected = True
@@ -176,6 +177,7 @@ class AerospikeShell(cmd.Cmd, AsyncObject):
                     only_connect_seed,
                     timeout=timeout,
                     asadm_version=admin_version,
+                    use_seed_node=use_seed_node,
                 )
 
                 if not self.ctrl.cluster.get_live_nodes():
@@ -252,6 +254,8 @@ class AerospikeShell(cmd.Cmd, AsyncObject):
         for command in commands:
             if command != "help":
                 self.commands.add(command)
+
+        self.use_seed_node = use_seed_node
 
     async def active_stop_writes(self, cluster: Cluster):
         """
@@ -788,6 +792,7 @@ async def main():
     if not execute_only_mode:
         readline.set_completer_delims(" \t\n;")
 
+
     shell: AerospikeShell = await AerospikeShell(
         admin_version,
         seeds,
@@ -803,6 +808,7 @@ async def main():
         execute_only_mode=execute_only_mode,
         privileged_mode=cli_args.enable,
         timeout=cli_args.timeout,
+        use_seed_node=cli_args.use_seed_node,
     )  # type: ignore
 
     use_yappi = False

--- a/lib/live_cluster/client/cluster.py
+++ b/lib/live_cluster/client/cluster.py
@@ -54,6 +54,7 @@ class Cluster(AsyncObject):
         ssl_context: SSL.Context | None = None,
         only_connect_seed=False,
         timeout=1,
+        use_seed_node=False,
     ):
         """
         Want to be able to support multiple nodes on one box (for testing)
@@ -88,6 +89,7 @@ class Cluster(AsyncObject):
         # crawl the cluster search for nodes in addition to the seed nodes.
         self.last_cluster_refresh_time = 0
         self.only_connect_seed = only_connect_seed
+        self.use_seed_node = use_seed_node
         await self._refresh_cluster()
 
         # to avoid same label (NODE column) for multiple nodes we need to keep track
@@ -584,9 +586,10 @@ class Cluster(AsyncObject):
                 user=self.user,
                 password=self.password,
                 auth_mode=self.auth_mode,
+                ssl_context=self.ssl_context,
                 consider_alumni=self.use_services_alumni,
                 use_services_alt=self.use_services_alt,
-                ssl_context=self.ssl_context,
+                use_seed_node=self.use_seed_node,
             )  # type: ignore
 
             if not new_node:

--- a/lib/live_cluster/client/cluster.py
+++ b/lib/live_cluster/client/cluster.py
@@ -54,7 +54,7 @@ class Cluster(AsyncObject):
         ssl_context: SSL.Context | None = None,
         only_connect_seed=False,
         timeout=1,
-        use_seed_node=False,
+        use_seed_address=False,
     ):
         """
         Want to be able to support multiple nodes on one box (for testing)
@@ -89,7 +89,7 @@ class Cluster(AsyncObject):
         # crawl the cluster search for nodes in addition to the seed nodes.
         self.last_cluster_refresh_time = 0
         self.only_connect_seed = only_connect_seed
-        self.use_seed_node = use_seed_node
+        self.use_seed_address = use_seed_address
         await self._refresh_cluster()
 
         # to avoid same label (NODE column) for multiple nodes we need to keep track
@@ -589,7 +589,7 @@ class Cluster(AsyncObject):
                 ssl_context=self.ssl_context,
                 consider_alumni=self.use_services_alumni,
                 use_services_alt=self.use_services_alt,
-                use_seed_node=self.use_seed_node,
+                use_seed_address=self.use_seed_address,
             )  # type: ignore
 
             if not new_node:

--- a/lib/live_cluster/client/node.py
+++ b/lib/live_cluster/client/node.py
@@ -393,7 +393,12 @@ class Node(AsyncObject):
         return False
 
     async def _node_connect(self):
-        # If use_seed_address is True, we only need to get the node id and features
+        """
+        Connect to the node and retrieve basic information.
+        If use_seed_address is True, only retrieves node ID and features,
+        using the seed address as the only service address and skipping peer discovery.
+        Otherwise, performs full service and peer discovery.
+        """
         if self.use_seed_address:
             commands = ["node", "features"]
             results = await self._info_cinfo(commands, self.ip, disable_cache=True)

--- a/lib/live_cluster/client/node.py
+++ b/lib/live_cluster/client/node.py
@@ -181,6 +181,7 @@ class Node(AsyncObject):
         ssl_context: SSL.Context | None = None,
         consider_alumni=False,
         use_services_alt=False,
+        use_seed_node=False,  # RENAMED ARGUMENT
     ) -> None:
         """
         address -- ip or fqdn for this node
@@ -210,6 +211,8 @@ class Node(AsyncObject):
         self.consider_alumni = consider_alumni
         self.use_services_alt = use_services_alt
         self.peers: list[tuple[Addr_Port_TLSName]] = []
+        
+        self.use_seed_node = use_seed_node
 
         # session token
         self.session_token: bytes | None = None
@@ -431,6 +434,17 @@ class Node(AsyncObject):
             await self.close()
             self._initialize_socket_pool()
             current_host = (self.ip, self.port, self.tls_name)
+
+            print("use_seed_node", self.use_seed_node)
+            if self.use_seed_node:
+                # Do not update self.ip/self.port, do not crawl peers, use only the seed address
+                print("current_host", current_host)
+                print("address", address)
+                print("port", port)
+                self.service_addresses = [current_host]
+                self.ip = address
+                self.port = port
+                return
 
             if not self.service_addresses or current_host not in self.service_addresses:
                 # if asd >= 3.10 and node has only IPv6 address

--- a/lib/live_cluster/live_cluster_root_controller.py
+++ b/lib/live_cluster/live_cluster_root_controller.py
@@ -61,6 +61,7 @@ class LiveClusterRootController(BaseController, AsyncObject):
         only_connect_seed=False,
         timeout=5,
         asadm_version="",
+        use_seed_node=False,
     ):
         BaseController.asadm_version = asadm_version
 
@@ -75,6 +76,7 @@ class LiveClusterRootController(BaseController, AsyncObject):
             ssl_context,
             only_connect_seed,
             timeout=timeout,
+            use_seed_node=use_seed_node,
         )  # type: ignore linter does not understand AsyncObject
 
         # Create Basic Command Controller Object

--- a/lib/live_cluster/live_cluster_root_controller.py
+++ b/lib/live_cluster/live_cluster_root_controller.py
@@ -61,7 +61,7 @@ class LiveClusterRootController(BaseController, AsyncObject):
         only_connect_seed=False,
         timeout=5,
         asadm_version="",
-        use_seed_node=False,
+        use_seed_address=False,
     ):
         BaseController.asadm_version = asadm_version
 
@@ -76,7 +76,7 @@ class LiveClusterRootController(BaseController, AsyncObject):
             ssl_context,
             only_connect_seed,
             timeout=timeout,
-            use_seed_node=use_seed_node,
+            use_seed_address=use_seed_address,
         )  # type: ignore linter does not understand AsyncObject
 
         # Create Basic Command Controller Object

--- a/lib/utils/conf.py
+++ b/lib/utils/conf.py
@@ -76,6 +76,7 @@ _confdefault = {
         "log-analyser": False,
         "log-path": "",
         "pmap": False,
+        "use-seed-node": False,
     },
 }
 
@@ -713,5 +714,7 @@ def get_cli_args():
     # include pmap analysis in collect info file.
     # Usage, `asadm collectinfo --pmap`
     add_fn("--pmap", action="store_true")
+
+    add_fn("--use-seed-node", dest="use_seed_node", action="store_true")
 
     return parser.parse_args()

--- a/lib/utils/conf.py
+++ b/lib/utils/conf.py
@@ -76,7 +76,7 @@ _confdefault = {
         "log-analyser": False,
         "log-path": "",
         "pmap": False,
-        "use-seed-node": False,
+        "use-seed-address": False,
     },
 }
 
@@ -454,6 +454,11 @@ def print_config_help():
         " --single-node        Enable asadm mode to connect only seed node. \n"
         "                      By default asadm connects to all nodes in cluster."
     )
+    print(
+        " --use-seed-address   Enable asadm mode to connect only seed address. \n"
+        "                      By default asadm connects to cluster via service address. \n"
+        "                      Allowed only with --single-node \n"
+    )
     print(" --collectinfo        Start asadm to run against offline collectinfo files.")
     print(" --pmap               Include partition map analysis in collectinfo files.")
     print(
@@ -715,6 +720,6 @@ def get_cli_args():
     # Usage, `asadm collectinfo --pmap`
     add_fn("--pmap", action="store_true")
 
-    add_fn("--use-seed-node", dest="use_seed_node", action="store_true")
+    add_fn("--use-seed-address", dest="use_seed_address", action="store_true")
 
     return parser.parse_args()


### PR DESCRIPTION
# Add --use-seed-address flag to force connection via seed address only

## Overview
This PR introduces a new `--use-seed-address` CLI flag that forces the Aerospike admin tool to connect exclusively through the provided seed address, bypassing service address discovery. This feature is particularly useful in network environments with load balancers, NAT, or complex routing where service address discovery may return unreachable addresses.

## Changes Made

### 1. CLI Argument Addition and Validation
- **Added `--use-seed-address` CLI flag** with proper help text
- **Added validation** to ensure `--use-seed-address` can only be used with `--single-node`
- **Added configuration support** in conf.py

**Files Modified:**
- conf.py - Added CLI argument definition and configuration support
- asadm.py - Added validation logic and parameter passing to shell

### 2. Core Connection Logic Enhancement
- **Modified `Node._node_connect()` method** to handle seed-only connections
- **When `use_seed_address=True`**: Only retrieves node ID and features, skips service/peer discovery
- **When `use_seed_address=False`**: Performs full service and peer discovery (existing behavior)
- **Streamlined logic** to avoid unnecessary network calls in seed-only mode

**Files Modified:**
- node.py - Core connection logic with conditional behavior
- cluster.py - Parameter passing to Node constructor  
- live_cluster_root_controller.py - Controller parameter handling

### 3. Comprehensive Testing
- **Added unit tests** for both seed-only and full discovery modes
- **Tests verify** correct command execution and return values
- **Ensures** proper mocking and validation of connection behavior

**Files Modified:**
- test_node.py - Added `test_node_connect_seed_mode` and `test_node_connect_full_mode`

## Behavior Changes

### Normal Operation (default: `use_seed_address=False`)
1. Connect to seed address
2. Discover service addresses and peers from server  
3. Use discovered service addresses for subsequent connections
4. Build full cluster topology

### With --use-seed-address (requires --single-node)
1. Connect to seed address
2. **Skip service discovery** - only get node ID and features
3. **Skip peer discovery** - return empty peers list
4. **Force all connections** to use only the original seed address
5. **Maintain single-node connection mode**

## Key Implementation Details

### Optimized Connection Logic
The `_node_connect()` method now has conditional logic:

```python
if self.use_seed_address:
    # Minimal commands - no service/peer discovery
    commands = ["node", "features"]
    # Return seed address as the only service address
    return node_id, [(self.ip, self.port, self.tls_name)], features, []
else:
    # Full discovery (existing behavior)
    commands = ["node", service_info_call, "features"] + peers_info_calls
    # Return discovered service addresses and peers
```

### Validation Logic
```python
if cli_args.use_seed_address and not cli_args.single_node:
    logger.critical("--use-seed-address can only be used with --single-node. Please enable --single-node or remove --use-seed-address.")
```

## Use Cases
- **Load Balancers**: Connect through load balancer without switching to backend servers
- **NAT/Firewall**: When only the seed address is accessible
- **Container Environments**: When service discovery returns unreachable internal IPs
- **Network Isolation**: Scenarios requiring explicit address control

## Example Usage
```bash
# Valid usage
asadm --host 192.168.1.100 --single-node --use-seed-address

# Invalid usage (exits with error)
asadm --host 192.168.1.100 --use-seed-address
```

## Backward Compatibility
- **Fully backward compatible** - new flag is opt-in only
- **Default behavior unchanged** when flag is not specified
- **No impact** on existing deployments or scripts

## Testing
- **Unit tests added** for both connection modes
- **Validation logic tested** for CLI argument combinations
- **Maintains existing test coverage** for default behavior