### PR TITLE
fix:TOOLS-3061 Improve data reception handling in _receive_data function

### DIFF
--- a/lib/live_cluster/client/info.py
+++ b/lib/live_cluster/client/info.py
@@ -134,14 +134,14 @@ def _unpack_protocol_header(buf, offset=0):
 
 async def _receive_data(reader: asyncio.StreamReader, sz):
     pos = 0
-    data = b""
+    chunks = []
     while pos < sz:
         chunk = await reader.read(sz - pos)
         if chunk == b"":
             raise ConnectionResetError("Connection closed by server.")
-        data += chunk
+        chunks.append(chunk)
         pos += len(chunk)
-    return data
+    return b"".join(chunks)
 
 
 ####### Password hashing ######

--- a/lib/live_cluster/client/info.py
+++ b/lib/live_cluster/client/info.py
@@ -134,14 +134,14 @@ def _unpack_protocol_header(buf, offset=0):
 
 async def _receive_data(reader: asyncio.StreamReader, sz):
     pos = 0
-    chunks = []
+    data = []
     while pos < sz:
         chunk = await reader.read(sz - pos)
         if chunk == b"":
             raise ConnectionResetError("Connection closed by server.")
-        chunks.append(chunk)
+        data.append(chunk)
         pos += len(chunk)
-    return b"".join(chunks)
+    return b"".join(data)
 
 
 ####### Password hashing ######

--- a/lib/live_cluster/client/info.py
+++ b/lib/live_cluster/client/info.py
@@ -134,15 +134,13 @@ def _unpack_protocol_header(buf, offset=0):
 
 async def _receive_data(reader: asyncio.StreamReader, sz):
     pos = 0
-    data = None
+    data = b""
     while pos < sz:
         chunk = await reader.read(sz - pos)
-        if pos == 0:
-            data = chunk
-        else:
-            data += chunk
+        if chunk == b"":
+            raise ConnectionResetError("Connection closed by server.")
+        data += chunk
         pos += len(chunk)
-
     return data
 
 


### PR DESCRIPTION
This PR updates the _receive_data function in lib/live_cluster/client/info.py to correctly handle cases where the server closes the connection before all expected data is received. Previously, if the server closed the connection early, the function could enter an infinite loop, causing client operations to hang indefinitely.

### Details
- Added a check for chunk == b"" (EOF) in the data reading loop.
- If EOF is encountered before all expected bytes are read, the function now raises a ConnectionResetError with a clear message.
- This ensures that:
     - The client does not hang if the server disconnects unexpectedly.
     - asyncio.wait_for timeouts are honored.
- Partial reads due to connection closure are treated as errors, not as empty or partial responses.

### Impact
- All network protocol handlers that use _receive_data now robustly handle server disconnects.
- No impact on the handling of valid empty responses (zero-length payloads), which are still returned as b"".
- No impact on file reading or other unrelated code.

### Testing
- Verified that the client raises an exception if the server closes the connection before sending all expected data.
- Confirmed that normal and empty responses are handled as before.