### PR TITLE
feat: TOOLS-3053 implement role name validation in ManageACLCreateRoleController

### DIFF
--- a/lib/live_cluster/manage_controller.py
+++ b/lib/live_cluster/manage_controller.py
@@ -563,6 +563,9 @@ class ManageACLCreateRoleController(ManageACLRolesLeafCommandController):
         role_name = line.pop(0)
         privilege = None
         allowlist = self.mods["allow"]
+        
+        if not util.is_valid_role_name(role_name):
+            return
 
         # Can't use util.get_arg_and_delete_from_mods because of conflict
         # between read modifier and read privilege

--- a/lib/utils/util.py
+++ b/lib/utils/util.py
@@ -707,6 +707,25 @@ def write_to_file(file, data):
     return f.close()
 
 
+def is_valid_role_name(role_name: str) -> bool:
+    """
+    A valid role name can include only Latin lowercase and uppercase letters with 
+    no diacritical marks (a-z, A-Z), digits 0-9, underscores (_), hyphens (-), and dollar signs ($). 
+    
+    Raises:
+        ValueError: If the role name contains illegal characters.
+    """
+        
+    pattern = r'^[a-zA-Z0-9_\-$]+$'
+    if not re.match(pattern, role_name):
+        # Find all illegal characters
+        illegal_chars = set(re.findall(r'[^a-zA-Z0-9_\-$]', role_name))
+        logger.error(f'The role "{role_name}" contains illegal characters {", ".join(sorted(illegal_chars))}')
+        return False
+    
+    return True
+
+
 def is_valid_ip_port(key):
     """
     It returns True if key matches with either "IP:port" or "[ipv6]:port" format.

--- a/lib/utils/util.py
+++ b/lib/utils/util.py
@@ -710,17 +710,20 @@ def write_to_file(file, data):
 def is_valid_role_name(role_name: str) -> bool:
     """
     A valid role name can include only Latin lowercase and uppercase letters with 
-    no diacritical marks (a-z, A-Z), digits 0-9, underscores (_), hyphens (-), and dollar signs ($). 
+    no diacritical marks (a-z, A-Z), digits 0-9, underscores (_), hyphens (-), and dollar signs ($).
     
-    Raises:
-        ValueError: If the role name contains illegal characters.
+    Args:
+        role_name: The role name to validate
+        
+    Returns:
+        bool: True if the role name is valid, False otherwise
     """
         
     pattern = r'^[a-zA-Z0-9_\-$]+$'
     if not re.match(pattern, role_name):
         # Find all illegal characters
         illegal_chars = set(re.findall(r'[^a-zA-Z0-9_\-$]', role_name))
-        logger.error(f'The role "{role_name}" contains illegal characters {", ".join(sorted(illegal_chars))}')
+        logger.error(f'Invalid role name "{role_name}": contains illegal characters {", ".join(sorted(illegal_chars))}')
         return False
     
     return True

--- a/test/unit/utils/test_util.py
+++ b/test/unit/utils/test_util.py
@@ -146,3 +146,19 @@ class UtilTest(asynctest.TestCase):
         self.assertEqual(
             result, expected, "deep_merge_dicts did not return the expected result"
         )
+
+    def test_is_valid_role_name(self):
+        # Valid role names
+        self.assertTrue(util.is_valid_role_name("valid_role"))
+        self.assertTrue(util.is_valid_role_name("Valid-Role"))
+        self.assertTrue(util.is_valid_role_name("role$123"))
+        self.assertTrue(util.is_valid_role_name("read-write"))
+        self.assertTrue(util.is_valid_role_name("sys_admin"))
+        
+        # Invalid role names
+        self.assertFalse(util.is_valid_role_name("invalid role"))  # contains space
+        self.assertFalse(util.is_valid_role_name("invalid@role"))  # contains @
+        self.assertFalse(util.is_valid_role_name("role,with,commas"))  # contains commas
+        self.assertFalse(util.is_valid_role_name("role;with;semicolons"))  # contains semicolons
+        self.assertFalse(util.is_valid_role_name(""))  # empty string
+        self.assertFalse(util.is_valid_role_name("truncate,sys-admin,sindex-admin,read-write,read-write-udf;"))  # complex invalid case


### PR DESCRIPTION
# Role Name Validation Enhancement

## Description
Added validation for role names to ensure they only contain allowed characters. This helps prevent potential issues with invalid role names in the system.

## Changes
- Added `is_valid_role_name()` function in `lib/utils/util.py` that validates role names against a regex pattern
- Added comprehensive test cases in `test/unit/utils/test_util.py`

## Validation Rules
A valid role name can only contain:
- Latin lowercase and uppercase letters (a-z, A-Z)
- Digits (0-9)
- Underscores (_)
- Hyphens (-)
- Dollar signs ($)

## Test Coverage
Added test cases for:
- Valid role names (e.g., "valid_role", "Valid-Role", "role$123")
- Invalid role names with:
  - Spaces
  - Special characters (@, ,, ;)
  - Empty strings
  - Complex invalid cases

## Impact
This change helps maintain data integrity by ensuring role names follow the correct format before they are used in the system.


# Note
I have added this change to manage acl `create role` command and not other commands like `grant role` or `create user grant roles`, where it should be assumed that the role is already present. It requires enforcement from Server.
