### PR TITLE
fix: collectinfo ss syntax

### DIFF
--- a/lib/utils/common.py
+++ b/lib/utils/common.py
@@ -2983,7 +2983,7 @@ def get_system_commands(port=3000) -> list[list[str]]:
             "netstat -ant | grep %d | grep ESTABLISHED | wc -l" % (port),
         ],
         [
-            "ss -ant state listen sport = :%d or dport = :%d |  wc -l" % (port, port),
+            "ss -ant state listening sport = :%d or dport = :%d |  wc -l" % (port, port),
             "netstat -ant | grep %d | grep LISTEN | wc -l" % (port),
         ],
         ['arp -n|grep ether|tr -s [:blank:] | cut -d" " -f5 |sort|uniq -c'],


### PR DESCRIPTION
TCP state listen was in the manpage until 2017, but ss doesn't know such state
https://github.com/iproute2/iproute2/commit/ae4e21c93f81c8d612e4c72df44c2a1dc971a863

another related issue is that `ss` always prints a header even if no results are available, this results in the whole command returning a number that's by 1 higher than wanted every time. This is not an issue with the netstat commands because the grep filters the header out.
I didn't fix it in this PR because the `-H` flag was introduced in [iproute2 4.7](https://github.com/iproute2/iproute2/commit/7a4559f67c8c4dcd6d8d361018ac239090713b69) (Ubuntu 18.04, CentOS 7) and I don't know what distribution compatibility you are targeting.