### PR TITLE
fix: Add 'Auth Mode' to expected user table headers in tests

### DIFF
--- a/test/e2e/live_cluster/test_show.py
+++ b/test/e2e/live_cluster/test_show.py
@@ -659,6 +659,7 @@ class TestShowUsers(asynctest.TestCase):
             "Roles",
             "Read Quota",
             "Write Quota",
+            "Auth Mode"
         ]
 
         (
@@ -687,6 +688,7 @@ class TestShowUsers(asynctest.TestCase):
             "Roles",
             "Read Quota",
             "Write Quota",
+            "Auth Mode"
         ]
 
         _, _, _, _, num_records = await test_util.capture_separate_and_parse_output(
@@ -782,6 +784,7 @@ class TestShowUsers(asynctest.TestCase):
             "Roles",
             "Read Quota",
             "Write Quota",
+            "Auth Mode"
         ]
 
         _, _, _, _, num_records = await test_util.capture_separate_and_parse_output(
@@ -842,6 +845,7 @@ class TestShowUsers(asynctest.TestCase):
             "Roles",
             "Read Quota",
             "Write Quota",
+            "Auth Mode"
         ]
 
         await util.capture_stdout(

--- a/test/e2e/live_cluster/test_show.py
+++ b/test/e2e/live_cluster/test_show.py
@@ -733,6 +733,7 @@ class TestShowUsers(asynctest.TestCase):
             "Roles",
             "Read Quota",
             "Write Quota",
+            "Auth Mode"
         ]
 
         _, _, _, _, num_records = await test_util.capture_separate_and_parse_output(

--- a/test/e2e/live_cluster/test_show.py
+++ b/test/e2e/live_cluster/test_show.py
@@ -681,6 +681,7 @@ class TestShowUsers(asynctest.TestCase):
             "--",
             "0",
             "0",
+            "password,PKI"
         ]
         exp_title = "Users"
         exp_header = [
@@ -726,6 +727,7 @@ class TestShowUsers(asynctest.TestCase):
             ",".join(exp_roles),
             "0",
             "0",
+            "password,PKI"
         ]
         exp_title = "Users"
         exp_header = [


### PR DESCRIPTION
Updated the expected headers in TestShowUsers to include 'Auth Mode' for improved test coverage and alignment with current output.