### PR TITLE
chore: INFRA-103  Pin Snyk CLI action version in workflow

### DIFF
--- a/.github/workflows/snyk-test.yml
+++ b/.github/workflows/snyk-test.yml
@@ -9,7 +9,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Setup snyk CLI
-        uses: snyk/actions/setup@master
+        uses: snyk/actions/setup@cdb760004ba9ea4d525f2e043745dfe85bb9077e
+        with: 
+          snyk-version: v1.1297.3
       - name: Get Python version from Pipfile
         working-directory: ${{ steps.working-dir.outputs.value }}
         run: |


### PR DESCRIPTION
Updated the Snyk CLI GitHub Action to use a specific commit hash and set the Snyk version to v1.1297.3 for improved reliability and reproducibility.