### PR TITLE
refactor: TOOLS-3060 add debug log for decoded user agent

### DIFF
--- a/lib/live_cluster/show_controller.py
+++ b/lib/live_cluster/show_controller.py
@@ -1916,6 +1916,7 @@ class ShowUserAgentsController(LiveClusterCommandController):
                     
                     # Decode base64 user agent
                     decoded_ua = b64decode(user_agent).decode('utf-8')
+                    logger.debug(f"Decoded user agent for {node}: {decoded_ua}")
                     # Split by comma to get format-version, client-version, and app-id
                     ua_parts = decoded_ua.split(',')
                     


### PR DESCRIPTION
A debug log statement was added to output the decoded user agent for each node, aiding in troubleshooting and monitoring user agent decoding.