### PR TITLE
fix: update user metrics help text in CLI view

### DIFF
--- a/lib/view/view.py
+++ b/lib/view/view.py
@@ -1070,7 +1070,7 @@ class CliView(object):
                 templates.show_users,
                 title,
                 sources,
-                description="To see individual users metrics run 'show user statistics'",
+                description="To see individual users metrics run 'show users statistics <username>'",
             )
         )
 

--- a/test/unit/view/test_view.py
+++ b/test/unit/view/test_view.py
@@ -654,7 +654,7 @@ class CliViewTest(unittest.TestCase):
             templates.show_users,
             "Users (test-stamp)",
             dict(data=formatted_users),
-            description="To see individual users metrics run 'show user statistics'",
+            description="To see individual users metrics run 'show users statistics <username>'",
         )
 
     def test_show_users_stats(self):


### PR DESCRIPTION
Clarifies the description for viewing individual user metrics by specifying the correct command syntax: 'show users statistics <username>'.