### PR TITLE
fix: TOOLS-3091 Fix ss command syntax in collectinfo

### DIFF
--- a/lib/utils/common.py
+++ b/lib/utils/common.py
@@ -2978,21 +2978,21 @@ def get_system_commands(port=3000) -> list[list[str]]:
         ["uptime"],
         netstat_cmds,
         [
-            "ss -ant state time-wait sport = :%d or dport = :%d | wc -l" % (port, port),
+            "ss -ant state time-wait '( sport = :%d or dport = :%d )' | tail -n +2 | wc -l" % (port, port),
             "netstat -ant | grep %d | grep TIME_WAIT | wc -l" % (port),
         ],
         [
-            "ss -ant state close-wait sport = :%d or dport = :%d | wc -l"
+            "ss -ant state close-wait '( sport = :%d or dport = :%d )' | tail -n +2 | wc -l"
             % (port, port),
             "netstat -ant | grep %d | grep CLOSE_WAIT | wc -l" % (port),
         ],
         [
-            "ss -ant state established sport = :%d or dport = :%d | wc -l"
+            "ss -ant state established '( sport = :%d or dport = :%d )' | tail -n +2 | wc -l"
             % (port, port),
             "netstat -ant | grep %d | grep ESTABLISHED | wc -l" % (port),
         ],
         [
-            "ss -ant state listening sport = :%d or dport = :%d |  wc -l" % (port, port),
+            "ss -ant state listening '( sport = :%d or dport = :%d )' | tail -n +2 | wc -l" % (port, port),
             "netstat -ant | grep %d | grep LISTEN | wc -l" % (port),
         ],
         ['arp -n|grep ether|tr -s [:blank:] | cut -d" " -f5 |sort|uniq -c'],


### PR DESCRIPTION
### Problem
The `ss` commands in the system collectinfo had several issues:

1. **Incorrect syntax**: Missing proper quoting and parentheses around the filter expression `sport = :port or dport = :port`, which could cause shell interpretation issues
2. **Header counting bug**: The `ss` command always prints a header line regardless of whether there are matching results, causing `wc -l` to return a count that's off by 1. This inconsistency made `ss` commands return different counts than their `netstat` alternatives for the same data.

### Solution
Fixed all `ss` commands used for counting network connections by:

1. **Proper syntax**: Added quotes and parentheses around the filter expression: `'( sport = :port or dport = :port )'`
2. **Header suppression**: Added `| tail -n +2` to skip the header line before counting, ensuring accurate results
3. **Backward compatibility**: Used `tail -n +2` instead of the `-H` flag (which requires iproute2 4.7+) to maintain compatibility with older systems

### Changes
Updated the following commands in `get_system_commands()`:
- `ss -ant state time-wait`
- `ss -ant state close-wait` 
- `ss -ant state established`
- `ss -ant state listening`

### Testing
The fix ensures that:
- `ss` commands now return the same count as their `netstat` counterparts
- Commands work correctly on both modern and legacy systems
- No shell interpretation issues occur with the filter expressions

### Example
**Before**: `ss -ant state listening sport = :3000 or dport = :3000 | wc -l` → returns count + 1 (includes header)

**After**: `ss -ant state listening '( sport = :3000 or dport = :3000 )' | tail -n +2 | wc -l` → returns accurate count

This change improves the reliability and consistency of network connection monitoring in the Aerospike admin tool's system 
information collection.


Found with https://github.com/aerospike/aerospike-admin/pull/359