### PR TITLE
chore: increase node socket pool cap to 16 tools-3039

### DIFF
--- a/lib/live_cluster/client/node.py
+++ b/lib/live_cluster/client/node.py
@@ -381,7 +381,7 @@ class Node(AsyncObject):
         logger.debug("%s:%s init socket pool", self.ip, self.port)
         self.socket_pool: dict[int, set[ASSocket]] = {}
         self.socket_pool[self.port] = set()
-        self.socket_pool_max_size = 3
+        self.socket_pool_max_size = 16
 
     def _is_any_my_ip(self, ips):
         if not ips:


### PR DESCRIPTION
see details in tools-3039. Idea is to adjust max socket cap to better align with async info request workloads.