### PR TITLE
fix: TOOLS-3097 Improve CLI Error Handling: Reject Unknown Subcommands for info Command

### DIFF
--- a/lib/collectinfo_analyzer/info_controller.py
+++ b/lib/collectinfo_analyzer/info_controller.py
@@ -20,6 +20,7 @@ from lib.collectinfo_analyzer.get_controller import (
 from lib.utils import constants, util, version
 
 from .collectinfo_command_controller import CollectinfoCommandController
+from lib.base_controller import ShellException
 
 Modifiers = constants.Modifiers
 ModifierUsageHelp = constants.ModifierUsage
@@ -38,6 +39,11 @@ class InfoController(CollectinfoCommandController):
 
     @CommandHelp("Displays network, namespace, and xdr summary information.")
     async def _do_default(self, line):
+        if line:
+            raise ShellException(
+                f"info: '{line[0]}' is not a valid subcommand. See 'help info' for available subcommands."
+            )
+
         self.do_network(line)
         # needs to be awaited since the base class is async
         await self.controller_map["namespace"]()(line[:])

--- a/lib/collectinfo_analyzer/info_controller.py
+++ b/lib/collectinfo_analyzer/info_controller.py
@@ -39,6 +39,13 @@ class InfoController(CollectinfoCommandController):
 
     @CommandHelp("Displays network, namespace, and xdr summary information.")
     async def _do_default(self, line):
+        # If no subcommand is provided, show the default info summary with network, namespace, and xdr information
+        # For unknown subcommands (e.g., 'info random'), we explicitly reject them rather than falling back to
+        # the default info summary because:
+        #  1. It's confusing for users - they expect either a valid result or a clear error
+        #  2. It can mislead users into thinking their command was valid when it wasn't
+        #  3. It produces inconsistent output - sometimes partial info would be shown
+        #  4. It makes debugging harder - typos wouldn't be caught and reported
         if line:
             raise ShellException(
                 f"info: '{line[0]}' is not a valid subcommand. See 'help info' for available subcommands."

--- a/lib/live_cluster/info_controller.py
+++ b/lib/live_cluster/info_controller.py
@@ -20,6 +20,7 @@ from lib.live_cluster.get_controller import (
 from lib.utils import util, version, constants
 from lib.base_controller import CommandHelp, ModifierHelp
 from .live_cluster_command_controller import LiveClusterCommandController
+from lib.base_controller import ShellException
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +55,11 @@ class InfoController(LiveClusterCommandController):
         # 'info namespace object', but since it is not correct command it should print output for partial correct
         # command, in this case it should print data for 'info'. To keep consistent output format, we are passing empty
         # list as line.
+        if line:
+            raise ShellException(
+                f"info: '{line[0]}' is not a valid subcommand. See 'help info' for available subcommands."
+            )
+        
         results = await asyncio.gather(
             self.do_network(line),
             self.controller_map["namespace"](get_futures=True)([]),

--- a/lib/live_cluster/info_controller.py
+++ b/lib/live_cluster/info_controller.py
@@ -49,17 +49,18 @@ class InfoController(LiveClusterCommandController):
 
     @CommandHelp("Displays network, namespace, and xdr summary information")
     async def _do_default(self, line):
-        # We are not using line for any of subcommand, but if user enters 'info object' or 'info usage' then it will
-        # give error for unexpected format. We can catch this inside InfoNamespaceController but in that case
-        # it will show incomplete output, for ex. 'info object' will print output of 'info network', 'info xdr' and
-        # 'info namespace object', but since it is not correct command it should print output for partial correct
-        # command, in this case it should print data for 'info'. To keep consistent output format, we are passing empty
-        # list as line.
+        # If no subcommand is provided, show the default info summary with network, namespace, and xdr information
+        # For unknown subcommands (e.g., 'info random'), we explicitly reject them rather than falling back to
+        # the default info summary because:
+        #  1. It's confusing for users - they expect either a valid result or a clear error
+        #  2. It can mislead users into thinking their command was valid when it wasn't
+        #  3. It produces inconsistent output - sometimes partial info would be shown
+        #  4. It makes debugging harder - typos wouldn't be caught and reported
         if line:
             raise ShellException(
                 f"info: '{line[0]}' is not a valid subcommand. See 'help info' for available subcommands."
             )
-        
+       
         results = await asyncio.gather(
             self.do_network(line),
             self.controller_map["namespace"](get_futures=True)([]),

--- a/test/e2e/live_cluster/test_info.py
+++ b/test/e2e/live_cluster/test_info.py
@@ -226,6 +226,17 @@ class TestInfo(asynctest.TestCase):
         self.assertTrue(exp_heading in actual_heading)
         self.assertEqual(exp_header, actual_header)
 
+    async def test_info_unknown_subcommand(self):
+        """
+        This test asserts that an unknown subcommand to 'info' returns a clear error.
+        """
+        with self.assertRaises(Exception) as context:
+            await test_util.capture_separate_and_parse_output(self.rc, ["info", "random"])
+        self.assertIn(
+            "info: 'random' is not a valid subcommand. See 'help info' for available subcommands.",
+            str(context.exception)
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR improves the user experience for the `info` command in both live-cluster and collectinfo modes by explicitly rejecting unknown subcommands. Previously, entering an invalid subcommand (e.g., `info random`) would fall back to the default `info`, which could confuse users. Now, the CLI immediately returns a clear error message indicating the subcommand is invalid and suggests using help info for available options.

Additionally, an end-to-end test has been added to verify that unknown subcommands to info produce the correct error and do not show the default summary. This change ensures more predictable and user-friendly CLI behavior, aligning with standard practices in modern command-line tools.