### PR TITLE
fix: TOOLS-3065 Refine validation for mutually exclusive modifiers for sindex-create

### DIFF
--- a/lib/live_cluster/manage_controller.py
+++ b/lib/live_cluster/manage_controller.py
@@ -1341,10 +1341,15 @@ class ManageSIndexCreateController(ManageLeafCommandController):
                 )
 
         # Validate mutually exclusive modifiers - ctx (including ctx_base64) and exp_base64
-        if (ctx_list or cdt_ctx_base64) and exp_base64 is not None:
-            raise ShellException(
-                "Cannot use both 'ctx' and 'exp_base64' modifiers together. Use either 'ctx' to specify how to index into a CDT, or 'exp_base64' to specify an expression to be evaluated."
-            )
+        if exp_base64 is not None:
+            if ctx_list:
+                raise ShellException(
+                    "Cannot use both 'ctx' and 'exp_base64' modifiers together. Use either 'ctx' to specify how to index into a CDT, or 'exp_base64' to specify an expression to be evaluated."
+                )
+            elif cdt_ctx_base64:
+                raise ShellException(
+                    "Cannot use both 'ctx_base64' and 'exp_base64' modifiers together. Use either 'ctx_base64' to specify how to index into a CDT, or 'exp_base64' to specify an expression to be evaluated."
+                )
         
         # Validate required modifiers - exactly one of 'bin' or 'exp_base64' is required
         if not exp_base64 and not bin_name:

--- a/test/unit/live_cluster/test_manage_controller.py
+++ b/test/unit/live_cluster/test_manage_controller.py
@@ -1878,7 +1878,7 @@ class ManageSIndexCreateControllerTest(asynctest.TestCase):
 
         await self.assertAsyncRaisesRegex(
             ShellException,
-            "Cannot use both 'ctx' and 'exp_base64' modifiers together",
+            "Cannot use both 'ctx_base64' and 'exp_base64' modifiers together",
             self.controller.execute(line),
         )
 


### PR DESCRIPTION
Improves the validation logic to separately check for conflicts between 'ctx' and 'exp_base64', and 'ctx_base64' and 'exp_base64', providing more precise error messages for each case.

More on this https://aerospike.atlassian.net/browse/TOOLS-3065?focusedCommentId=165372