### PR TITLE
fix: TOOLS-3106 Fixed asadm 7.1 Aerospike Version Compatibility for Admin Port Detection

### DIFF
--- a/lib/live_cluster/client/client_util.py
+++ b/lib/live_cluster/client/client_util.py
@@ -15,6 +15,9 @@
 import re
 import itertools
 import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def info_to_dict(
@@ -30,6 +33,7 @@ def info_to_dict(
         return {}
 
     if isinstance(value, Exception):
+        logger.debug(value, exc_info=True)
         return value  # TODO: Should not need to handle exception after we switch from info to _info
 
     stat_dict = {}
@@ -68,7 +72,8 @@ def info_to_dict(
             value = [v[1] for v in g[1]]
             value = ",".join(sorted(value)) if len(value) > 1 else value[0]
             stat_dict[g[0]] = value
-        except Exception:
+        except Exception as e:
+            logger.debug(e, exc_info=True)
             # NOTE: 3.0 had a bug in stats at least prior to 3.0.44. This will
             # ignore that bug.
 
@@ -127,6 +132,7 @@ def info_colon_to_dict(value):
 
 def info_to_list(value, delimiter=";", max_split=0):
     if isinstance(value, Exception):
+        logger.debug(value, exc_info=True)
         return []
     return re.split(delimiter, value, maxsplit=max_split)
 
@@ -219,6 +225,7 @@ def flatten(list1):
     Example: [(("172.17.0.1",3000,None),), (("2001:db8:85a3::8a2e",6666,None), ("172.17.0.3",3004,None))]
     """
     if isinstance(list1, Exception):
+        logger.debug("could not flatten list: %s", list1)
         return []
 
     f_list = []
@@ -241,5 +248,6 @@ def remove_suffix(input_string, suffix):
         if not input_string.endswith(suffix):
             return input_string
         return input_string[0 : input_string.rfind(suffix)]
-    except Exception:
+    except Exception as e:
+        logger.debug(e, exc_info=True)
         return input_string

--- a/lib/live_cluster/client/client_util.py
+++ b/lib/live_cluster/client/client_util.py
@@ -218,6 +218,8 @@ def flatten(list1):
     Format: [((node1 endpoint1 tuple), (node1 endpoint2 tuple), ..., (node1 endpointm tuple)), ....]
     Example: [(("172.17.0.1",3000,None),), (("2001:db8:85a3::8a2e",6666,None), ("172.17.0.3",3004,None))]
     """
+    if isinstance(list1, Exception):
+        return []
 
     f_list = []
     for i in list1:

--- a/lib/live_cluster/client/node.py
+++ b/lib/live_cluster/client/node.py
@@ -394,9 +394,16 @@ class Node(AsyncObject):
     async def _node_connect(self):
         connection_info_call = "connection"
         try:
-            connection_info = await self._info_cinfo(connection_info_call, self.ip, self.port, disable_cache=True)
+            connection_info = await self._info_cinfo(
+                connection_info_call, self.ip, self.port, disable_cache=True
+            )
         except ASInfoError as e:
-            logger.debug("Connection info command not available for node %s:%s %s", self.ip, self.port, e)
+            logger.debug(
+                "Connection info command not available for node %s:%s %s",
+                self.ip,
+                self.port,
+                e,
+            )
             connection_info = None
 
         # Info calls for node id, features
@@ -418,7 +425,11 @@ class Node(AsyncObject):
         commands += [info_address_call] + peers_info_calls
         results = await self._info_cinfo(commands, self.ip, disable_cache=True)
         service_addresses = self._info_service_helper(results[info_address_call])
-        peers = self._aggregate_peers([results[call] for call in peers_info_calls]) if peers_info_calls else []
+        peers = (
+            self._aggregate_peers([results[call] for call in peers_info_calls])
+            if peers_info_calls
+            else []
+        )
         return results["node"], service_addresses, results["features"], peers
 
     async def connect(self, address, port):
@@ -681,13 +692,24 @@ class Node(AsyncObject):
         Sets user agent on the Aerospike connection socket.
         """
         if self.user_agent is None:
-            logger.debug("user agent is available thus is not setting it for node %s:%s", self.ip, self.port)
+            logger.debug(
+                "user agent is available thus is not setting it for node %s:%s",
+                self.ip,
+                self.port,
+            )
             return
         try:
             user_agent_b64 = base64.b64encode(self.user_agent.encode()).decode()
-            await self._info_cinfo(f"user-agent-set:value={user_agent_b64}", disable_cache=True)
+            await self._info_cinfo(
+                f"user-agent-set:value={user_agent_b64}", disable_cache=True
+            )
         except ASInfoError as e:
-            logger.debug("user agent set command not available for node %s:%s got error %s", self.ip, self.port, e)
+            logger.debug(
+                "user agent set command not available for node %s:%s got error %s",
+                self.ip,
+                self.port,
+                e,
+            )
 
     async def _get_connection(self, ip, port) -> ASSocket | None:
         sock = None
@@ -832,7 +854,7 @@ class Node(AsyncObject):
                 command,
                 id(sock),
                 ex,
-                command
+                command,
             )
             raise ex
 

--- a/lib/live_cluster/client/node.py
+++ b/lib/live_cluster/client/node.py
@@ -693,7 +693,7 @@ class Node(AsyncObject):
         """
         if self.user_agent is None:
             logger.debug(
-                "user agent is available thus is not setting it for node %s:%s",
+                "user agent string not set for node %s:%s",
                 self.ip,
                 self.port,
             )

--- a/lib/live_cluster/client/node.py
+++ b/lib/live_cluster/client/node.py
@@ -399,7 +399,7 @@ class Node(AsyncObject):
             )
         except ASInfoError as e:
             logger.debug(
-                "Connection info command not available for node %s:%s %s",
+                "unable to get connection info for node %s:%s error:%s",
                 self.ip,
                 self.port,
                 e,
@@ -693,7 +693,7 @@ class Node(AsyncObject):
         """
         if self.user_agent is None:
             logger.debug(
-                "user agent string not set for node %s:%s",
+                "user agent string not available for node %s:%s",
                 self.ip,
                 self.port,
             )
@@ -705,7 +705,7 @@ class Node(AsyncObject):
             )
         except ASInfoError as e:
             logger.debug(
-                "user agent set command not available for node %s:%s got error %s",
+                "unable to set user agent for node %s:%s got error %s",
                 self.ip,
                 self.port,
                 e,

--- a/lib/live_cluster/client/node.py
+++ b/lib/live_cluster/client/node.py
@@ -392,36 +392,34 @@ class Node(AsyncObject):
         return False
 
     async def _node_connect(self):
-        # Get node id, features and admin port
-        commands = ["node", "features", "connection"]
-        results = await self._info_cinfo(commands, self.ip, disable_cache=True)
-        node_id = results["node"]
-        features = results["features"]
+        connection_info_call = "connection"
+        try:
+            connection_info = await self._info_cinfo(connection_info_call, self.ip, self.port, disable_cache=True)
+        except ASInfoError as e:
+            logger.debug("Connection info command not available for node %s:%s %s", self.ip, self.port, e)
+            connection_info = None
+
+        # Info calls for node id, features
+        commands = ["node", "features"]
 
         # Check if the node is an admin node
-        if self._is_admin_port_enabled(results["connection"]):
-            logger.debug("admin port is enabled for node %s", node_id)
+        if self._is_admin_port_enabled(connection_info):
+            logger.debug("admin port is enabled for ip %s", self.ip)
             self.is_admin_node = True
-
-            admin_info_call = self._get_admin_info_call()
-            admin_info_response = await self._info_cinfo(
-                admin_info_call, self.ip, disable_cache=True
-            )
-            admin_addresses = self._info_service_helper(admin_info_response)
-            logger.debug(
-                "admin address discovered for node %s: %s", node_id, admin_addresses
-            )
+            # use admin info call instead of service info call
+            info_address_call = self._get_admin_info_call()
             # disable peer discovery for admin node
-            return node_id, admin_addresses, features, []
+            peers_info_calls = []
+        else:
+            # Get service addresses and peers info calls for non-admin node
+            info_address_call = self._get_service_info_call()
+            peers_info_calls = self._get_info_peers_list_calls()
 
-        peers_info_calls = self._get_info_peers_list_calls()
-        service_info_call = self._get_service_info_call()
-
-        commands = [service_info_call] + peers_info_calls
+        commands += [info_address_call] + peers_info_calls
         results = await self._info_cinfo(commands, self.ip, disable_cache=True)
-        service_addresses = self._info_service_helper(results[service_info_call])
-        peers = self._aggregate_peers([results[call] for call in peers_info_calls])
-        return node_id, service_addresses, features, peers
+        service_addresses = self._info_service_helper(results[info_address_call])
+        peers = self._aggregate_peers([results[call] for call in peers_info_calls]) if peers_info_calls else []
+        return results["node"], service_addresses, results["features"], peers
 
     async def connect(self, address, port):
         try:
@@ -682,9 +680,14 @@ class Node(AsyncObject):
         """
         Sets user agent on the Aerospike connection socket.
         """
-        if self.user_agent is not None:
+        if self.user_agent is None:
+            logger.debug("user agent is available thus is not setting it for node %s:%s", self.ip, self.port)
+            return
+        try:
             user_agent_b64 = base64.b64encode(self.user_agent.encode()).decode()
-            await self._info(f"user-agent-set:value={user_agent_b64}")
+            await self._info_cinfo(f"user-agent-set:value={user_agent_b64}", disable_cache=True)
+        except ASInfoError as e:
+            logger.debug("user agent set command not available for node %s:%s got error %s", self.ip, self.port, e)
 
     async def _get_connection(self, ip, port) -> ASSocket | None:
         sock = None
@@ -823,12 +826,13 @@ class Node(AsyncObject):
                 await sock.close()
 
             logger.debug(
-                "%s:%s info cmd '%s' and sock %s raised %s for",
+                "%s:%s info cmd '%s' and sock %s raised %s for %s",
                 self.ip,
                 self.port,
                 command,
                 id(sock),
                 ex,
+                command
             )
             raise ex
 

--- a/test/unit/live_cluster/client/test_cluster.py
+++ b/test/unit/live_cluster/client/test_cluster.py
@@ -53,16 +53,13 @@ class ClusterTest(asynctest.TestCase):
             cmd = args[0]
 
             # First call - admin port detection
-            if cmd == ["node", "features", "connection"]:
+            if cmd == "connection": 
+                return "admin:false"
+
+            if cmd == ["node", "features", "service-clear-std", "peers-clear-std"]:
                 return {
                     "node": return_value,
                     "features": "batch-index;blob-bits;cdt-list;cdt-map;cluster-stable;float;geo;",
-                    "connection": "admin=false",  # Admin port disabled by default
-                }
-
-            # Second call - service and peers info for regular nodes
-            if cmd == ["service-clear-std", "peers-clear-std"]:
-                return {
                     "service-clear-std": (
                         str(ip)
                         + ":"
@@ -638,12 +635,16 @@ class ClusterTest(asynctest.TestCase):
             ip = args[1] if len(args) > 1 else "127.0.0.1"
 
             # First call - admin port detection (enabled for this test)
-            if cmd == ["node", "features", "connection"]:
+            if cmd == "connection":
+                return "admin=true"
+            if cmd == ["node", "features", "admin-clear-std"]:
                 return {
                     "node": "ADMIN000000000",
                     "features": "batch-index;blob-bits;cdt-list;cdt-map;cluster-stable;float;geo;",
-                    "connection": "admin=true",  # This makes it an admin node
+                    "admin-clear-std": "127.0.0.1:3003",
                 }
+            if cmd == "node":
+                return "ADMIN000000000"
             # Second call - admin service info for admin nodes
             elif cmd == ["service-clear-admin"]:
                 return {

--- a/test/unit/live_cluster/client/test_cluster.py
+++ b/test/unit/live_cluster/client/test_cluster.py
@@ -53,7 +53,7 @@ class ClusterTest(asynctest.TestCase):
             cmd = args[0]
 
             # First call - admin port detection
-            if cmd == "connection": 
+            if cmd == "connection":
                 return "admin:false"
 
             if cmd == ["node", "features", "service-clear-std", "peers-clear-std"]:

--- a/test/unit/live_cluster/client/test_node.py
+++ b/test/unit/live_cluster/client/test_node.py
@@ -213,7 +213,12 @@ class NodeInitTest(asynctest.TestCase):
             # First call - admin port detection
             if args[0] == "connection":
                 return "admin=false"
-            elif args[0] == ["node", "features", "service-clear-std", "peers-clear-std"]:
+            elif args[0] == [
+                "node",
+                "features",
+                "service-clear-std",
+                "peers-clear-std",
+            ]:
                 return {
                     "node": "A0",
                     "features": "batch-index;blob-bits;cdt-list;cdt-map;cluster-stable;float;geo;",

--- a/test/unit/live_cluster/client/test_node.py
+++ b/test/unit/live_cluster/client/test_node.py
@@ -92,15 +92,12 @@ class NodeInitTest(asynctest.TestCase):
         def info_side_effect(*args, **kwargs):
             cmd = args[0]
             # First call - admin port detection
-            if cmd == ["node", "features", "connection"]:
+            if cmd == "connection":
+                return "admin=false"
+            if cmd == ["node", "features", "service-clear-std", "peers-clear-std"]:
                 return {
                     "node": "A00000000000000",
                     "features": "features",
-                    "connection": "admin=false",  # Admin port disabled
-                }
-            # Second call - service and peers info for regular nodes
-            elif cmd == ["service-clear-std", "peers-clear-std"]:
-                return {
                     "service-clear-std": "192.3.3.3:4567",
                     "peers-clear-std": "2,3000,[[1A0,,[3.126.208.136]]]",
                 }
@@ -145,15 +142,12 @@ class NodeInitTest(asynctest.TestCase):
         def info_side_effect(*args, **kwargs):
             cmd = args[0]
             # First call - admin port detection
-            if cmd == ["node", "features", "connection"]:
+            if cmd == "connection":
+                return "admin=false"
+            if cmd == ["node", "features", "service-clear-std", "peers-clear-std"]:
                 return {
                     "node": "A00000000000000",
                     "features": "features",
-                    "connection": "admin=false",  # Admin port disabled
-                }
-            # Second call - service and peers info for regular nodes
-            elif cmd == ["service-clear-std", "peers-clear-std"]:
-                return {
                     "service-clear-std": "192.3.3.3:4567",
                     "peers-clear-std": "2,3000,[[1A0,,[3.126.208.136]]]",
                 }
@@ -217,18 +211,17 @@ class NodeInitTest(asynctest.TestCase):
 
         def side_effect_info(*args, **kwargs):
             # First call - admin port detection
-            if args[0] == ["node", "features", "connection"]:
+            if args[0] == "connection":
+                return "admin=false"
+            elif args[0] == ["node", "features", "service-clear-std", "peers-clear-std"]:
                 return {
                     "node": "A0",
                     "features": "batch-index;blob-bits;cdt-list;cdt-map;cluster-stable;float;geo;",
-                    "connection": "admin=false",  # Admin port disabled
-                }
-            # Second call - service and peers info for regular nodes
-            elif args[0] == ["service-clear-std", "peers-clear-std"]:
-                return {
                     "service-clear-std": "1.1.1.1:3000;172.17.0.1:3000;172.17.1.1:3000",
                     "peers-clear-std": "10,3000,[[BB9050011AC4202,,[172.17.0.1]],[BB9070011AC4202,,[[2001:db8:85a3::8a2e]:6666]]]",
                 }
+            else:
+                self.fail()
 
         as_socket_mock_used_for_login.info.side_effect = side_effect_info
 
@@ -237,8 +230,8 @@ class NodeInitTest(asynctest.TestCase):
         # Login and the node connection info calls
         as_socket_mock_used_for_login.info.assert_has_calls(
             [
-                call(["node", "features", "connection"]),
-                call(["service-clear-std", "peers-clear-std"]),
+                call("connection"),
+                call(["node", "features", "service-clear-std", "peers-clear-std"]),
             ],
         )
 


### PR DESCRIPTION
### Summary
This PR fixes a compatibility issue where asadm v4 was incompatible with Aerospike versions below 7.1 due to the "connection" info command not being available in older versions.

### Problem
- The "connection" info command was introduced in Aerospike 8.1
- **Before 7.1**: Invalid commands are ignored (not included in response)
- **7.1-8.0**: Invalid commands return error strings
- The code was making a combined info call `["node", "features", "connection"]` and trying to access the 'connection' key
- On versions below 7.1, this caused either missing key errors or error string values, breaking node initialization

### Solution
- **Separate connection probe**: First make a standalone "connection" info call to detect admin port status
- **Graceful fallback**: If the "connection" command is not available or returns an error, treat the node as non-admin
- **Combined info call**: Only include available commands in the combined call based on what was successfully probed
- **Backward compatibility**: Maintains full compatibility with Aerospike versions below 7.1

### Changes
- Modified `_node_connect()` to first probe for "connection" command availability
- If "connection" command fails or returns an error, proceed as if admin port is disabled (non-admin node)
- Only include "connection" in combined calls if it was successfully probed
- Improved error handling to prevent KeyError when accessing missing keys
