### PR TITLE
test Pyinstaller

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -24,7 +24,7 @@ asyncssh = "*"
 
 [dev-packages]
 parameterized = "*"
-pyinstaller = "==6.11.1"
+pyinstaller = "==6.15.0"
 black = "25.1.0"
 flake8 = "7.3.0"
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d987eae7b5453c7c57bf7c3ed917d8379467433cdb524485ac7656582662135b"
+            "sha256": "9bc3725c79d83d3b827bade3f52eb00db6386d3388a4fc22e948e5b21ff96048"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1588,22 +1588,22 @@
         },
         "pyinstaller": {
             "hashes": [
-                "sha256:0d6475559c4939f0735122989611d7f739ed3bf02f666ce31022928f7a7e4fda",
-                "sha256:208c0ef6dab0837a0a273ea32d1a3619a208e3d1fe3fec3785eea71a77fd00ce",
-                "sha256:2e8365276c5131c9bef98e358fbc305e4022db8bedc9df479629d6414021956a",
-                "sha256:32c742a24fe65d0702958fadf4040f76de85859c26bec0008766e5dbabc5b68f",
-                "sha256:35e6b8077d240600bb309ed68bb0b1453fd2b7ab740b66d000db7abae6244423",
-                "sha256:44e36172de326af6d4e7663b12f71dbd34e2e3e02233e181e457394423daaf03",
-                "sha256:491dfb4d9d5d1d9650d9507daec1ff6829527a254d8e396badd60a0affcb72ef",
-                "sha256:6d12c45a29add78039066a53fb05967afaa09a672426072b13816fe7676abfc4",
-                "sha256:7ac83c0dc0e04357dab98c487e74ad2adb30e7eb186b58157a8faf46f1fa796f",
-                "sha256:ad84abf465bcda363c1d54eafa76745d77b6a8a713778348377dc98d12a452f7",
-                "sha256:ddc0fddd75f07f7e423da1f0822e389a42af011f9589e0269b87e0d89aa48c1f",
-                "sha256:e21c7806e34f40181e7606926a14579f848bfb1dc52cbca7eea66eccccbfe977"
+                "sha256:18f743069849dbaee3e10900385f35795a5743eabab55e99dcc42f204e40a0db",
+                "sha256:22193489e6a22435417103f61e7950363bba600ef36ec3ab1487303668c81092",
+                "sha256:60da8f1b5071766b45c0f607d8bc3d7e59ba2c3b262d08f2e4066ba65f3544a2",
+                "sha256:9f00c71c40148cd1e61695b2c6f1e086693d3bcf9bfa22ab513aa4254c3b966f",
+                "sha256:a48fc4644ee4aa2aa2a35e7b51f496f8fbd7eecf6a2150646bbf1613ad07bc2d",
+                "sha256:b4df862adae7cf1f08eff53c43ace283822447f7f528f72e4f94749062712f15",
+                "sha256:b9ebf16ed0f99016ae8ae5746dee4cb244848a12941539e62ce2eea1df5a3f95",
+                "sha256:c33e6302bc53db2df1104ed5566bd980b3e0ee7f18416a6e3caa908c12a54542",
+                "sha256:cbcc8eb77320c60722030ac875883b564e00768fe3ff1721c7ba3ad0e0a277e9",
+                "sha256:cbea297e16eeda30b41c300d6ec2fd2abea4dbd8d8a32650eeec36431c94fcd9",
+                "sha256:eb902d0fed3bb1f8b7190dc4df5c11f3b59505767e0d56d1ed782b853938bbf3",
+                "sha256:f43c035621742cf2d19b84308c60e4e44e72c94786d176b8f6adcde351b5bd98"
             ],
             "index": "pypi",
-            "markers": "python_version < '3.14' and python_version >= '3.8'",
-            "version": "==6.11.1"
+            "markers": "python_version < '3.15' and python_version >= '3.8'",
+            "version": "==6.15.0"
         },
         "pyinstaller-hooks-contrib": {
             "hashes": [


### PR DESCRIPTION
This pull request updates two dependencies in the `Pipfile` to keep the project up-to-date and secure.

Dependency version upgrades:

* Upgraded `aiohttp` from version 3.11.14 to 3.12.15 to include the latest bug fixes and improvements.
* Upgraded `pyinstaller` from version 6.11.1 to 6.15.0 for the latest features and compatibility.