### PR TITLE
feat: TOOLS-3429 Bifurcate index memory reporting in summary; align stop-writes with server

### DIFF
--- a/lib/health/query.py
+++ b/lib/health/query.py
@@ -331,17 +331,12 @@ ASSERT(warn, True, "Low namespace disk available pct.", "OPERATIONS", WARNING,
 				"Namespace disk available pct check.");
     
 SET CONSTRAINT VERSION >= 7.1.0;
-index_bytes = select "index_used_bytes" as "stats" from NAMESPACE.STATISTICS save;
-sindex_bytes = select "sindex_used_bytes" as "stats" from NAMESPACE.STATISTICS save;
-set_index_bytes = select "set_index_used_bytes" as "stats" from NAMESPACE.STATISTICS save;
-ixs_memory_used = do index_bytes + sindex_bytes;
-ixs_memory_used = do ixs_memory_used + set_index_bytes;
-stop_used_bytes = select "indexes-memory-budget" as "stats" from NAMESPACE.CONFIG save;
-budget_configured = do stop_used_bytes > 0;
-critical = do ixs_memory_used <= stop_used_bytes;
-ASSERT(critical, True, "High namespace indexes memory usage (stop-write enabled).", "OPERATIONS", CRITICAL,
-				"Listed namespace[s] have higher than normal combined memory usage for primary index, secondary index, and set index. Probable cause - namespace size misconfiguration.",
-				"Critical Namespace indexes memory used check.", budget_configured);
+ixs_used_pct = select "indexes_memory_used_pct" as "stats" from NAMESPACE.STATISTICS save;
+ixs_has_budget = do ixs_used_pct > 0;
+ixs_critical = do ixs_used_pct <= 100;
+ASSERT(ixs_critical, True, "High namespace indexes memory usage (stop-write enabled).", "OPERATIONS", CRITICAL,
+				"Listed namespace[s] have higher than normal combined memory usage for indexes. Probable cause - namespace size misconfiguration.",
+				"Critical Namespace indexes memory used check.", ixs_has_budget);
 
 SET CONSTRAINT VERSION >= 7.0.0;
 sindex_used = select "sindex_used_bytes" as "stats" from NAMESPACE.STATISTICS save;

--- a/lib/health/query.py
+++ b/lib/health/query.py
@@ -331,13 +331,26 @@ ASSERT(warn, True, "Low namespace disk available pct.", "OPERATIONS", WARNING,
 				"Namespace disk available pct check.");
     
 SET CONSTRAINT VERSION >= 7.1.0;
-used_bytes = select "index_used_bytes" as "stats" from NAMESPACE.STATISTICS save;
+index_bytes = select "index_used_bytes" as "stats" from NAMESPACE.STATISTICS save;
+sindex_bytes = select "sindex_used_bytes" as "stats" from NAMESPACE.STATISTICS save;
+set_index_bytes = select "set_index_used_bytes" as "stats" from NAMESPACE.STATISTICS save;
+ixs_memory_used = do index_bytes + sindex_bytes;
+ixs_memory_used = do ixs_memory_used + set_index_bytes;
 stop_used_bytes = select "indexes-memory-budget" as "stats" from NAMESPACE.CONFIG save;
 budget_configured = do stop_used_bytes > 0;
-critical = do used_bytes <= stop_used_bytes;
-ASSERT(critical, True, "High namespace index memory used pct (stop-write enabled).", "OPERATIONS", CRITICAL,
-				"Listed namespace[s] have higher than normal memory usage for indexes. Probable cause - namespace size misconfiguration.",
-				"Critical Namespace index memory used pct check.", budget_configured);
+critical = do ixs_memory_used <= stop_used_bytes;
+ASSERT(critical, True, "High namespace indexes memory usage (stop-write enabled).", "OPERATIONS", CRITICAL,
+				"Listed namespace[s] have higher than normal combined memory usage for primary index, secondary index, and set index. Probable cause - namespace size misconfiguration.",
+				"Critical Namespace indexes memory used check.", budget_configured);
+
+SET CONSTRAINT VERSION >= 7.0.0;
+sindex_used = select "sindex_used_bytes" as "stats" from NAMESPACE.STATISTICS save;
+sindex_budget = select "sindex-type.mounts-budget" as "stats" from NAMESPACE.CONFIG save;
+sindex_budget_configured = do sindex_budget > 0;
+sindex_critical = do sindex_used <= sindex_budget;
+ASSERT(sindex_critical, True, "High namespace sindex mounts usage.", "OPERATIONS", CRITICAL,
+				"Listed namespace[s] have higher than normal sindex mounts usage. Probable cause - namespace size misconfiguration.",
+				"Critical Namespace sindex mounts used check.", sindex_budget_configured);
 
 SET CONSTRAINT VERSION >= 7.0.0;
 used = select "data_used_pct" as "stats" from NAMESPACE.STATISTICS save;

--- a/lib/health/query.py
+++ b/lib/health/query.py
@@ -333,8 +333,8 @@ ASSERT(warn, True, "Low namespace disk available pct.", "OPERATIONS", WARNING,
 SET CONSTRAINT VERSION >= 7.1.0;
 ixs_used_pct = select "indexes_memory_used_pct" as "stats" from NAMESPACE.STATISTICS save;
 ixs_has_budget = do ixs_used_pct > 0;
-ixs_critical = do ixs_used_pct <= 100;
-ASSERT(ixs_critical, True, "High namespace indexes memory usage (stop-write enabled).", "OPERATIONS", CRITICAL,
+ixs_nominal = do ixs_used_pct <= 100;
+ASSERT(ixs_nominal, True, "High namespace indexes memory usage (stop-write enabled).", "OPERATIONS", CRITICAL,
 				"Listed namespace[s] have higher than normal combined memory usage for indexes. Probable cause - namespace size misconfiguration.",
 				"Critical Namespace indexes memory used check.", ixs_has_budget);
 
@@ -342,8 +342,8 @@ SET CONSTRAINT VERSION >= 7.0.0;
 sindex_used = select "sindex_used_bytes" as "stats" from NAMESPACE.STATISTICS save;
 sindex_budget = select "sindex-type.mounts-budget" as "stats" from NAMESPACE.CONFIG save;
 sindex_budget_configured = do sindex_budget > 0;
-sindex_critical = do sindex_used <= sindex_budget;
-ASSERT(sindex_critical, True, "High namespace sindex mounts usage.", "OPERATIONS", CRITICAL,
+sindex_nominal = do sindex_used <= sindex_budget;
+ASSERT(sindex_nominal, True, "High namespace sindex mounts usage.", "OPERATIONS", CRITICAL,
 				"Listed namespace[s] have higher than normal sindex mounts usage. Probable cause - namespace size misconfiguration.",
 				"Critical Namespace sindex mounts used check.", sindex_budget_configured);
 

--- a/lib/utils/common.py
+++ b/lib/utils/common.py
@@ -1189,11 +1189,15 @@ def create_summary(
                 cluster_pmem_index_used += sindex_used
                 ns_pi = summary_dict["NAMESPACES"][ns].get("pmem_index")
                 if ns_pi:
-                    ns_pi["total"] = ns_pi.get("total", 0) + sindex_size
                     ns_pi["used"] = ns_pi.get("used", 0) + sindex_used
-                    if ns_pi.get("total", 0) > 0:
+                    if "total" in ns_pi:
+                        ns_pi["total"] += sindex_size
                         ns_pi["avail"] = ns_pi["total"] - ns_pi["used"]
-                        ns_pi["used_pct"] = (ns_pi["used"] / ns_pi["total"]) * 100.0
+                        ns_pi["used_pct"] = (
+                            (ns_pi["used"] / ns_pi["total"]) * 100.0
+                            if ns_pi["total"]
+                            else 0
+                        )
                         ns_pi["avail_pct"] = 100.0 - ns_pi["used_pct"]
                 elif sindex_size > 0:
                     sindex_avail = sindex_size - sindex_used
@@ -1214,11 +1218,15 @@ def create_summary(
                 cluster_flash_index_used += sindex_used
                 ns_fi = summary_dict["NAMESPACES"][ns].get("flash_index")
                 if ns_fi:
-                    ns_fi["total"] = ns_fi.get("total", 0) + sindex_size
                     ns_fi["used"] = ns_fi.get("used", 0) + sindex_used
-                    if ns_fi.get("total", 0) > 0:
+                    if "total" in ns_fi:
+                        ns_fi["total"] += sindex_size
                         ns_fi["avail"] = ns_fi["total"] - ns_fi["used"]
-                        ns_fi["used_pct"] = (ns_fi["used"] / ns_fi["total"]) * 100.0
+                        ns_fi["used_pct"] = (
+                            (ns_fi["used"] / ns_fi["total"]) * 100.0
+                            if ns_fi["total"]
+                            else 0
+                        )
                         ns_fi["avail_pct"] = 100.0 - ns_fi["used_pct"]
                 elif sindex_size > 0:
                     sindex_avail = sindex_size - sindex_used

--- a/lib/utils/common.py
+++ b/lib/utils/common.py
@@ -1099,7 +1099,7 @@ def create_summary(
             ).values()
         )[0]
 
-        # Index
+        # Primary Index
         index_size = sum(
             util.get_value_from_second_level_of_dict(
                 ns_configs[ns],
@@ -1139,13 +1139,11 @@ def create_summary(
                     "used_pct": index_used_pct,
                 }
             else:
-                # shmem does not require you to configure mounts-budget
                 ns_index_usage = {
                     "used": index_used,
                 }
 
             if index_type == "pmem":
-                # TODO handle the cluster level aggregate
                 cluster_pmem_index_total += index_size
                 cluster_pmem_index_used += index_used
                 summary_dict["NAMESPACES"][ns]["pmem_index"] = ns_index_usage
@@ -1159,6 +1157,110 @@ def create_summary(
                 cluster_shmem_index_used += index_used
                 summary_dict["NAMESPACES"][ns]["shmem_index"] = ns_index_usage
                 summary_dict["NAMESPACES"][ns]["index_type"] = index_type
+
+        # Secondary Index — fold into the matching primary index accumulator
+        # so it appears in the same summary line (mirrors server ixs_memory_used).
+        sindex_type = list(
+            util.get_value_from_second_level_of_dict(
+                ns_stats, ("sindex-type",), default_value="", return_type=str
+            ).values()
+        )[0]
+
+        sindex_size = sum(
+            util.get_value_from_second_level_of_dict(
+                ns_configs[ns],
+                ("sindex-type.mounts-budget",),
+                default_value=0,
+                return_type=int,
+            ).values()
+        )
+        sindex_used = sum(
+            util.get_value_from_second_level_of_dict(
+                ns_stats,
+                ("sindex_used_bytes",),
+                default_value=0,
+                return_type=int,
+            ).values()
+        )
+
+        if sindex_used > 0 or sindex_size > 0:
+            if sindex_type == "pmem":
+                cluster_pmem_index_total += sindex_size
+                cluster_pmem_index_used += sindex_used
+                ns_pi = summary_dict["NAMESPACES"][ns].get("pmem_index")
+                if ns_pi:
+                    ns_pi["total"] = ns_pi.get("total", 0) + sindex_size
+                    ns_pi["used"] = ns_pi.get("used", 0) + sindex_used
+                    if ns_pi.get("total", 0) > 0:
+                        ns_pi["avail"] = ns_pi["total"] - ns_pi["used"]
+                        ns_pi["used_pct"] = (ns_pi["used"] / ns_pi["total"]) * 100.0
+                        ns_pi["avail_pct"] = 100.0 - ns_pi["used_pct"]
+                elif sindex_size > 0:
+                    sindex_avail = sindex_size - sindex_used
+                    sindex_used_pct = (sindex_used / sindex_size) * 100.0
+                    summary_dict["NAMESPACES"][ns]["pmem_index"] = {
+                        "total": sindex_size,
+                        "used": sindex_used,
+                        "avail": sindex_avail,
+                        "used_pct": sindex_used_pct,
+                        "avail_pct": 100.0 - sindex_used_pct,
+                    }
+                else:
+                    summary_dict["NAMESPACES"][ns]["pmem_index"] = {
+                        "used": sindex_used,
+                    }
+            elif sindex_type == "flash":
+                cluster_flash_index_total += sindex_size
+                cluster_flash_index_used += sindex_used
+                ns_fi = summary_dict["NAMESPACES"][ns].get("flash_index")
+                if ns_fi:
+                    ns_fi["total"] = ns_fi.get("total", 0) + sindex_size
+                    ns_fi["used"] = ns_fi.get("used", 0) + sindex_used
+                    if ns_fi.get("total", 0) > 0:
+                        ns_fi["avail"] = ns_fi["total"] - ns_fi["used"]
+                        ns_fi["used_pct"] = (ns_fi["used"] / ns_fi["total"]) * 100.0
+                        ns_fi["avail_pct"] = 100.0 - ns_fi["used_pct"]
+                elif sindex_size > 0:
+                    sindex_avail = sindex_size - sindex_used
+                    sindex_used_pct = (sindex_used / sindex_size) * 100.0
+                    summary_dict["NAMESPACES"][ns]["flash_index"] = {
+                        "total": sindex_size,
+                        "used": sindex_used,
+                        "avail": sindex_avail,
+                        "used_pct": sindex_used_pct,
+                        "avail_pct": 100.0 - sindex_used_pct,
+                    }
+                else:
+                    summary_dict["NAMESPACES"][ns]["flash_index"] = {
+                        "used": sindex_used,
+                    }
+            else:
+                cluster_shmem_index_used += sindex_used
+                ns_si = summary_dict["NAMESPACES"][ns].get("shmem_index")
+                if ns_si:
+                    ns_si["used"] = ns_si.get("used", 0) + sindex_used
+                else:
+                    summary_dict["NAMESPACES"][ns]["shmem_index"] = {
+                        "used": sindex_used,
+                    }
+
+        # Set Index (always RAM) — fold into shmem index
+        set_index_used = sum(
+            util.get_value_from_second_level_of_dict(
+                ns_stats,
+                ("set_index_used_bytes",),
+                default_value=0,
+                return_type=int,
+            ).values()
+        )
+
+        if set_index_used > 0:
+            cluster_shmem_index_used += set_index_used
+            ns_si = summary_dict["NAMESPACES"][ns].get("shmem_index")
+            if ns_si:
+                ns_si["used"] = ns_si.get("used", 0) + set_index_used
+            else:
+                summary_dict["NAMESPACES"][ns]["shmem_index"] = {"used": set_index_used}
 
         storage_engine_type = list(
             util.get_value_from_second_level_of_dict(
@@ -1647,21 +1749,40 @@ def _format_ns_stop_writes_metrics(
                     namespace=ns,
                 )
 
-            metric = "index_used_bytes"
             config = "indexes-memory-budget"
-            usage = util.get_value_from_dict(
-                stats, metric, default_value=None, return_type=int
-            )
             threshold = util.get_value_from_dict(
                 stats, config, default_value=None, return_type=int
             )
 
-            if usage is not None and threshold is not None:
-                sw = _is_stop_writes_cause(usage, threshold, stop_writes)
+            if threshold is not None and threshold > 0:
+                pi_persisted = stats.get("index-type", "") in ("flash", "pmem")
+                si_persisted = stats.get("sindex-type", "") in ("flash", "pmem")
+
+                index_mem_sz = (
+                    0
+                    if pi_persisted
+                    else util.get_value_from_dict(
+                        stats, "index_used_bytes", default_value=0, return_type=int
+                    )
+                )
+                set_index_sz = util.get_value_from_dict(
+                    stats, "set_index_used_bytes", default_value=0, return_type=int
+                )
+                sindex_mem_sz = (
+                    0
+                    if si_persisted
+                    else util.get_value_from_dict(
+                        stats, "sindex_used_bytes", default_value=0, return_type=int
+                    )
+                )
+                ixs_sz = index_mem_sz + set_index_sz + sindex_mem_sz
+
+                metric = "indexes_memory_used"
+                sw = _is_stop_writes_cause(ixs_sz, threshold, stop_writes)
                 _create_stop_writes_entry(
                     stop_writes_metrics[node],
                     metric,
-                    usage,
+                    ixs_sz,
                     sw,
                     threshold,
                     config=config,

--- a/lib/utils/common.py
+++ b/lib/utils/common.py
@@ -651,13 +651,22 @@ class SummaryClusterDict(TypedDict):
     license_data: SummaryClusterLicenseAggDict
     compression_enabled: NotRequired[bool]
     memory_data_and_indexes: NotRequired[SummaryStorageUsageDict]  # pre 7.0
-    memory: NotRequired[SummaryStorageUsageDict]  # post 7.0
-    device: NotRequired[SummaryStorageUsageDict]
-    pmem: NotRequired[SummaryStorageUsageDict]
+    system_memory: NotRequired[SummaryStorageUsageDict]
+    data_memory: NotRequired[SummaryStorageUsageDict]  # post 7.0; storage-engine memory
+    data_device: NotRequired[SummaryStorageUsageDict]
+    data_pmem: NotRequired[SummaryStorageUsageDict]
     data: NotRequired[SummaryStorageUsageDict]  # added for compatibility with 7.0
     pmem_index: NotRequired[SummaryStorageUsageDict]
     flash_index: NotRequired[SummaryStorageUsageDict]
     shmem_index: NotRequired[SummaryStorageUsageDict]
+    pmem_sindex: NotRequired[SummaryStorageUsageDict]
+    flash_sindex: NotRequired[SummaryStorageUsageDict]
+    shmem_sindex: NotRequired[SummaryStorageUsageDict]
+    set_index: NotRequired[SummaryStorageUsageDict]
+    # Combined view of all indexes that share `indexes-memory-budget`:
+    # PI (if not persisted) + SI (if not persisted) + set_index, vs. the budget.
+    # Mirrors server's eval_stop_writes() ixs_sz / indexes_memory_budget.
+    indexes_memory: NotRequired[SummaryStorageUsageDict]
     index: NotRequired[SummaryStorageUsageDict]  # added for compatibility with 7.0
 
 
@@ -675,12 +684,17 @@ class SummaryNamespaceDict(TypedDict):
     compression_enabled: NotRequired[bool]
     cache_read_pct: NotRequired[int]
     memory_data_and_indexes: NotRequired[SummaryStorageUsageDict]  # pre 7.0
-    memory: NotRequired[SummaryStorageUsageDict]  # post 7.0
-    device: NotRequired[SummaryStorageUsageDict]
-    pmem: NotRequired[SummaryStorageUsageDict]
+    data_memory: NotRequired[SummaryStorageUsageDict]  # post 7.0; storage-engine memory
+    data_device: NotRequired[SummaryStorageUsageDict]
+    data_pmem: NotRequired[SummaryStorageUsageDict]
     pmem_index: NotRequired[SummaryStorageUsageDict]
     flash_index: NotRequired[SummaryStorageUsageDict]
     shmem_index: NotRequired[SummaryStorageUsageDict]
+    pmem_sindex: NotRequired[SummaryStorageUsageDict]
+    flash_sindex: NotRequired[SummaryStorageUsageDict]
+    shmem_sindex: NotRequired[SummaryStorageUsageDict]
+    set_index: NotRequired[SummaryStorageUsageDict]
+    indexes_memory: NotRequired[SummaryStorageUsageDict]
 
 
 SummaryNamespacesDict = NamespaceDict[SummaryNamespaceDict]
@@ -957,22 +971,42 @@ def create_summary(
     cluster_flash_index_total = 0
     cluster_flash_index_used = 0
 
+    # Secondary index per storage type (kept separate from primary index)
+    cluster_shmem_sindex_used = 0
+
+    cluster_pmem_sindex_total = 0
+    cluster_pmem_sindex_used = 0
+
+    cluster_flash_sindex_total = 0
+    cluster_flash_sindex_used = 0
+
+    # Set index is always RAM, used-only
+    cluster_set_index_used = 0
+
+    # Combined indexes-memory budget (mirrors server eval_stop_writes ixs_sz).
+    # Sums non-persisted PI + non-persisted SI + set_index against
+    # `indexes-memory-budget`. Only emitted per-namespace when the budget is
+    # configured (>0); otherwise the cap doesn't apply.
+    cluster_indexes_memory_total = 0
+    cluster_indexes_memory_used = 0
+
     cl_nodewise_device_counts = (
         {}
     )  # need nodewise to determine if device count is same across nodes
 
-    # Post 7.0 memory stats. Data only, no index or sindex bytes
-    cluster_memory_total = 0
-    cluster_memory_used = 0
-    cluster_memory_avail = 0
+    # Post 7.0 data stats. Data only, no index or sindex bytes.
+    # data_memory is for storage-engine=memory (data lives in RAM).
+    cluster_data_memory_total = 0
+    cluster_data_memory_used = 0
+    cluster_data_memory_avail = 0
 
-    cluster_device_total = 0
-    cluster_device_used = 0
-    cluster_device_avail = 0
+    cluster_data_device_total = 0
+    cluster_data_device_used = 0
+    cluster_data_device_avail = 0
 
-    cluster_pmem_total = 0
-    cluster_pmem_used = 0
-    cluster_pmem_avail = 0
+    cluster_data_pmem_total = 0
+    cluster_data_pmem_used = 0
+    cluster_data_pmem_avail = 0
 
     compute_license_data_size(
         namespace_stats,
@@ -1104,8 +1138,8 @@ def create_summary(
             util.get_value_from_second_level_of_dict(
                 ns_configs[ns],
                 (
-                    "index-type.mounts-budget",
-                    "index-type.mounts-size-limit",
+                    "index-type.mounts-budget",  # 7.0+
+                    "index-type.mounts-size-limit",  # pre 7.0
                 ),
                 default_value=0,
                 return_type=int,
@@ -1115,9 +1149,10 @@ def create_summary(
             util.get_value_from_second_level_of_dict(
                 ns_stats,
                 (
-                    "index_used_bytes",
-                    "index_pmem_used_bytes",
-                    "index_flash_used_bytes",
+                    "index_used_bytes",  # 7.0+ (consolidated across storage types)
+                    "index_pmem_used_bytes",  # pre 7.0 pmem
+                    "index_flash_used_bytes",  # pre 7.0 flash
+                    "memory_used_index_bytes",  # pre 7.0 in-memory
                 ),
                 default_value=0,
                 return_type=int,
@@ -1158,8 +1193,7 @@ def create_summary(
                 summary_dict["NAMESPACES"][ns]["shmem_index"] = ns_index_usage
                 summary_dict["NAMESPACES"][ns]["index_type"] = index_type
 
-        # Secondary Index — fold into the matching primary index accumulator
-        # so it appears in the same summary line (mirrors server ixs_memory_used).
+        # Secondary Index — separate summary line per storage type.
         sindex_type = list(
             util.get_value_from_second_level_of_dict(
                 ns_stats, ("sindex-type",), default_value="", return_type=str
@@ -1169,7 +1203,10 @@ def create_summary(
         sindex_size = sum(
             util.get_value_from_second_level_of_dict(
                 ns_configs[ns],
-                ("sindex-type.mounts-budget",),
+                (
+                    "sindex-type.mounts-budget",  # 7.0+
+                    "sindex-type.mounts-size-limit",  # pre 7.0
+                ),
                 default_value=0,
                 return_type=int,
             ).values()
@@ -1177,98 +1214,91 @@ def create_summary(
         sindex_used = sum(
             util.get_value_from_second_level_of_dict(
                 ns_stats,
-                ("sindex_used_bytes",),
+                (
+                    "sindex_used_bytes",  # 7.0+ (consolidated across storage types)
+                    "sindex_pmem_used_bytes",  # pre 7.0 pmem
+                    "sindex_flash_used_bytes",  # pre 7.0 flash
+                    "memory_used_sindex_bytes",  # pre 7.0 in-memory
+                ),
                 default_value=0,
                 return_type=int,
             ).values()
         )
 
         if sindex_used > 0 or sindex_size > 0:
-            if sindex_type == "pmem":
-                cluster_pmem_index_total += sindex_size
-                cluster_pmem_index_used += sindex_used
-                ns_pi = summary_dict["NAMESPACES"][ns].get("pmem_index")
-                if ns_pi:
-                    ns_pi["used"] = ns_pi.get("used", 0) + sindex_used
-                    if "total" in ns_pi:
-                        ns_pi["total"] += sindex_size
-                        ns_pi["avail"] = ns_pi["total"] - ns_pi["used"]
-                        ns_pi["used_pct"] = (
-                            (ns_pi["used"] / ns_pi["total"]) * 100.0
-                            if ns_pi["total"]
-                            else 0
-                        )
-                        ns_pi["avail_pct"] = 100.0 - ns_pi["used_pct"]
-                elif sindex_size > 0:
-                    sindex_avail = sindex_size - sindex_used
-                    sindex_used_pct = (sindex_used / sindex_size) * 100.0
-                    summary_dict["NAMESPACES"][ns]["pmem_index"] = {
-                        "total": sindex_size,
-                        "used": sindex_used,
-                        "avail": sindex_avail,
-                        "used_pct": sindex_used_pct,
-                        "avail_pct": 100.0 - sindex_used_pct,
-                    }
-                else:
-                    summary_dict["NAMESPACES"][ns]["pmem_index"] = {
-                        "used": sindex_used,
-                    }
-            elif sindex_type == "flash":
-                cluster_flash_index_total += sindex_size
-                cluster_flash_index_used += sindex_used
-                ns_fi = summary_dict["NAMESPACES"][ns].get("flash_index")
-                if ns_fi:
-                    ns_fi["used"] = ns_fi.get("used", 0) + sindex_used
-                    if "total" in ns_fi:
-                        ns_fi["total"] += sindex_size
-                        ns_fi["avail"] = ns_fi["total"] - ns_fi["used"]
-                        ns_fi["used_pct"] = (
-                            (ns_fi["used"] / ns_fi["total"]) * 100.0
-                            if ns_fi["total"]
-                            else 0
-                        )
-                        ns_fi["avail_pct"] = 100.0 - ns_fi["used_pct"]
-                elif sindex_size > 0:
-                    sindex_avail = sindex_size - sindex_used
-                    sindex_used_pct = (sindex_used / sindex_size) * 100.0
-                    summary_dict["NAMESPACES"][ns]["flash_index"] = {
-                        "total": sindex_size,
-                        "used": sindex_used,
-                        "avail": sindex_avail,
-                        "used_pct": sindex_used_pct,
-                        "avail_pct": 100.0 - sindex_used_pct,
-                    }
-                else:
-                    summary_dict["NAMESPACES"][ns]["flash_index"] = {
-                        "used": sindex_used,
-                    }
+            if sindex_size > 0:
+                sindex_avail = sindex_size - sindex_used
+                sindex_used_pct = (sindex_used / sindex_size) * 100.0
+                ns_sindex_usage: SummaryStorageUsageDict = {
+                    "total": sindex_size,
+                    "avail": sindex_avail,
+                    "used": sindex_used,
+                    "avail_pct": 100.0 - sindex_used_pct,
+                    "used_pct": sindex_used_pct,
+                }
             else:
-                cluster_shmem_index_used += sindex_used
-                ns_si = summary_dict["NAMESPACES"][ns].get("shmem_index")
-                if ns_si:
-                    ns_si["used"] = ns_si.get("used", 0) + sindex_used
-                else:
-                    summary_dict["NAMESPACES"][ns]["shmem_index"] = {
-                        "used": sindex_used,
-                    }
+                ns_sindex_usage = {"used": sindex_used}
 
-        # Set Index (always RAM) — fold into shmem index
+            if sindex_type == "pmem":
+                cluster_pmem_sindex_total += sindex_size
+                cluster_pmem_sindex_used += sindex_used
+                summary_dict["NAMESPACES"][ns]["pmem_sindex"] = ns_sindex_usage
+            elif sindex_type == "flash":
+                cluster_flash_sindex_total += sindex_size
+                cluster_flash_sindex_used += sindex_used
+                summary_dict["NAMESPACES"][ns]["flash_sindex"] = ns_sindex_usage
+            else:
+                cluster_shmem_sindex_used += sindex_used
+                summary_dict["NAMESPACES"][ns]["shmem_sindex"] = {"used": sindex_used}
+
+        # Set Index — always RAM, used-only, its own summary line.
         set_index_used = sum(
             util.get_value_from_second_level_of_dict(
                 ns_stats,
-                ("set_index_used_bytes",),
+                (
+                    "set_index_used_bytes",  # 7.0+
+                    "memory_used_set_index_bytes",  # pre 7.0
+                ),
                 default_value=0,
                 return_type=int,
             ).values()
         )
 
         if set_index_used > 0:
-            cluster_shmem_index_used += set_index_used
-            ns_si = summary_dict["NAMESPACES"][ns].get("shmem_index")
-            if ns_si:
-                ns_si["used"] = ns_si.get("used", 0) + set_index_used
-            else:
-                summary_dict["NAMESPACES"][ns]["shmem_index"] = {"used": set_index_used}
+            cluster_set_index_used += set_index_used
+            summary_dict["NAMESPACES"][ns]["set_index"] = {"used": set_index_used}
+
+        # Combined "Indexes Memory" view — only meaningful when the budget is
+        # configured. Mirrors the server's eval_stop_writes() ixs_sz: persisted
+        # PI/SI components are excluded since they don't draw on RAM.
+        ixs_budget = sum(
+            util.get_value_from_second_level_of_dict(
+                ns_configs[ns],
+                ("indexes-memory-budget",),
+                default_value=0,
+                return_type=int,
+            ).values()
+        )
+        if ixs_budget > 0:
+            pi_persisted = index_type in ("flash", "pmem")
+            si_persisted = sindex_type in ("flash", "pmem")
+            ixs_used = (
+                (0 if pi_persisted else index_used)
+                + (0 if si_persisted else sindex_used)
+                + set_index_used
+            )
+            ixs_used_pct = (ixs_used / ixs_budget) * 100.0
+            ixs_avail = ixs_budget - ixs_used
+            ns_indexes_memory: SummaryStorageUsageDict = {
+                "total": ixs_budget,
+                "used": ixs_used,
+                "used_pct": ixs_used_pct,
+                "avail": ixs_avail,
+                "avail_pct": 100.0 - ixs_used_pct,
+            }
+            summary_dict["NAMESPACES"][ns]["indexes_memory"] = ns_indexes_memory
+            cluster_indexes_memory_total += ixs_budget
+            cluster_indexes_memory_used += ixs_used
 
         storage_engine_type = list(
             util.get_value_from_second_level_of_dict(
@@ -1327,20 +1357,20 @@ def create_summary(
             }
 
             if storage_engine_type == "device":
-                cluster_device_total += data_size_total
-                cluster_device_used += data_size_used
-                cluster_device_avail += data_size_avail
-                summary_dict["NAMESPACES"][ns]["device"] = ns_data_usage
+                cluster_data_device_total += data_size_total
+                cluster_data_device_used += data_size_used
+                cluster_data_device_avail += data_size_avail
+                summary_dict["NAMESPACES"][ns]["data_device"] = ns_data_usage
             elif storage_engine_type == "pmem":
-                cluster_pmem_total += data_size_total
-                cluster_pmem_used += data_size_used
-                cluster_pmem_avail += data_size_avail
-                summary_dict["NAMESPACES"][ns]["pmem"] = ns_data_usage
+                cluster_data_pmem_total += data_size_total
+                cluster_data_pmem_used += data_size_used
+                cluster_data_pmem_avail += data_size_avail
+                summary_dict["NAMESPACES"][ns]["data_pmem"] = ns_data_usage
             elif storage_engine_type == "memory":
-                cluster_memory_total += data_size_total
-                cluster_memory_used += data_size_used
-                cluster_memory_avail += data_size_avail
-                summary_dict["NAMESPACES"][ns]["memory"] = ns_data_usage
+                cluster_data_memory_total += data_size_total
+                cluster_data_memory_used += data_size_used
+                cluster_data_memory_avail += data_size_avail
+                summary_dict["NAMESPACES"][ns]["data_memory"] = ns_data_usage
 
         compression_ratio = max(
             util.get_value_from_second_level_of_dict(
@@ -1467,36 +1497,109 @@ def create_summary(
         }
         summary_dict["CLUSTER"]["shmem_index"] = cluster_shmem_index
 
-    # Post 7.0 memory stats that only include data not sindex or index bytes
-    if cluster_memory_total > 0:
-        cluster_memory_index: SummaryStorageUsageDict = {
-            "total": cluster_memory_total,
-            "avail": cluster_memory_avail,
-            "avail_pct": (cluster_memory_avail / cluster_memory_total) * 100.0,
-            "used": cluster_memory_used,
-            "used_pct": (cluster_memory_used / cluster_memory_total) * 100.0,
-        }
-        summary_dict["CLUSTER"]["memory"] = cluster_memory_index
+    # Secondary index — separate cluster aggregates per storage type.
+    if cluster_pmem_sindex_total > 0 or cluster_pmem_sindex_used > 0:
+        if cluster_pmem_sindex_total > 0:
+            cluster_pmem_sindex_used_pct = (
+                cluster_pmem_sindex_used / cluster_pmem_sindex_total
+            ) * 100.0
+            cluster_pmem_sindex: SummaryStorageUsageDict = {
+                "total": cluster_pmem_sindex_total,
+                "avail": cluster_pmem_sindex_total - cluster_pmem_sindex_used,
+                "avail_pct": 100 - cluster_pmem_sindex_used_pct,
+                "used": cluster_pmem_sindex_used,
+                "used_pct": cluster_pmem_sindex_used_pct,
+            }
+        else:
+            cluster_pmem_sindex = {"used": cluster_pmem_sindex_used}
+        summary_dict["CLUSTER"]["pmem_sindex"] = cluster_pmem_sindex
 
-    if cluster_device_total > 0:
-        cluster_device_index: SummaryStorageUsageDict = {
-            "total": cluster_device_total,
-            "avail": cluster_device_avail,
-            "avail_pct": (cluster_device_avail / cluster_device_total) * 100.0,
-            "used": cluster_device_used,
-            "used_pct": (cluster_device_used / cluster_device_total) * 100.0,
-        }
-        summary_dict["CLUSTER"]["device"] = cluster_device_index
+    if cluster_flash_sindex_total > 0 or cluster_flash_sindex_used > 0:
+        if cluster_flash_sindex_total > 0:
+            cluster_flash_sindex_used_pct = (
+                cluster_flash_sindex_used / cluster_flash_sindex_total
+            ) * 100.0
+            cluster_flash_sindex: SummaryStorageUsageDict = {
+                "total": cluster_flash_sindex_total,
+                "avail": cluster_flash_sindex_total - cluster_flash_sindex_used,
+                "avail_pct": 100 - cluster_flash_sindex_used_pct,
+                "used": cluster_flash_sindex_used,
+                "used_pct": cluster_flash_sindex_used_pct,
+            }
+        else:
+            cluster_flash_sindex = {"used": cluster_flash_sindex_used}
+        summary_dict["CLUSTER"]["flash_sindex"] = cluster_flash_sindex
 
-    if cluster_pmem_total > 0:
-        cluster_pmem_index: SummaryStorageUsageDict = {
-            "total": cluster_pmem_total,
-            "avail": cluster_pmem_avail,
-            "avail_pct": (cluster_pmem_avail / cluster_pmem_total) * 100.0,
-            "used": cluster_pmem_used,
-            "used_pct": (cluster_pmem_used / cluster_pmem_total) * 100.0,
+    if cluster_shmem_sindex_used > 0:
+        summary_dict["CLUSTER"]["shmem_sindex"] = {"used": cluster_shmem_sindex_used}
+
+    if cluster_set_index_used > 0:
+        summary_dict["CLUSTER"]["set_index"] = {"used": cluster_set_index_used}
+
+    if cluster_indexes_memory_total > 0:
+        cluster_ixs_used_pct = (
+            cluster_indexes_memory_used / cluster_indexes_memory_total
+        ) * 100.0
+        summary_dict["CLUSTER"]["indexes_memory"] = {
+            "total": cluster_indexes_memory_total,
+            "used": cluster_indexes_memory_used,
+            "used_pct": cluster_ixs_used_pct,
+            "avail": cluster_indexes_memory_total - cluster_indexes_memory_used,
+            "avail_pct": 100.0 - cluster_ixs_used_pct,
         }
-        summary_dict["CLUSTER"]["pmem"] = cluster_pmem_index
+
+    # System memory: average system_free_mem_pct across nodes; gives the user a
+    # quick "is this machine running out of RAM?" indicator independent of any
+    # per-namespace data/index breakdown.
+    free_pcts = [
+        v
+        for v in (
+            util.get_value_from_dict(
+                node_stats, "system_free_mem_pct", default_value=None, return_type=int
+            )
+            for node_stats in service_stats.values()
+        )
+        if v is not None
+    ]
+    if free_pcts:
+        avg_free_pct = sum(free_pcts) / len(free_pcts)
+        summary_dict["CLUSTER"]["system_memory"] = {
+            "used_pct": 100.0 - avg_free_pct,
+            "avail_pct": float(avg_free_pct),
+        }
+
+    # Post 7.0 data stats; storage-engine memory/device/pmem (no index bytes).
+    if cluster_data_memory_total > 0:
+        cluster_data_memory: SummaryStorageUsageDict = {
+            "total": cluster_data_memory_total,
+            "avail": cluster_data_memory_avail,
+            "avail_pct": (cluster_data_memory_avail / cluster_data_memory_total)
+            * 100.0,
+            "used": cluster_data_memory_used,
+            "used_pct": (cluster_data_memory_used / cluster_data_memory_total) * 100.0,
+        }
+        summary_dict["CLUSTER"]["data_memory"] = cluster_data_memory
+
+    if cluster_data_device_total > 0:
+        cluster_data_device: SummaryStorageUsageDict = {
+            "total": cluster_data_device_total,
+            "avail": cluster_data_device_avail,
+            "avail_pct": (cluster_data_device_avail / cluster_data_device_total)
+            * 100.0,
+            "used": cluster_data_device_used,
+            "used_pct": (cluster_data_device_used / cluster_data_device_total) * 100.0,
+        }
+        summary_dict["CLUSTER"]["data_device"] = cluster_data_device
+
+    if cluster_data_pmem_total > 0:
+        cluster_data_pmem: SummaryStorageUsageDict = {
+            "total": cluster_data_pmem_total,
+            "avail": cluster_data_pmem_avail,
+            "avail_pct": (cluster_data_pmem_avail / cluster_data_pmem_total) * 100.0,
+            "used": cluster_data_pmem_used,
+            "used_pct": (cluster_data_pmem_used / cluster_data_pmem_total) * 100.0,
+        }
+        summary_dict["CLUSTER"]["data_pmem"] = cluster_data_pmem
 
     return summary_dict
 

--- a/lib/utils/common.py
+++ b/lib/utils/common.py
@@ -1127,11 +1127,14 @@ def create_summary(
             }
             summary_dict["NAMESPACES"][ns]["memory_data_and_indexes"] = ns_mem_usage
 
-        index_type = list(
-            util.get_value_from_second_level_of_dict(
-                ns_stats, ("index-type",), default_value="", return_type=str
-            ).values()
-        )[0]
+        index_type = next(
+            iter(
+                util.get_value_from_second_level_of_dict(
+                    ns_stats, ("index-type",), default_value="", return_type=str
+                ).values()
+            ),
+            "",
+        )
 
         # Primary Index
         index_size = sum(
@@ -1194,11 +1197,14 @@ def create_summary(
                 summary_dict["NAMESPACES"][ns]["index_type"] = index_type
 
         # Secondary Index — separate summary line per storage type.
-        sindex_type = list(
-            util.get_value_from_second_level_of_dict(
-                ns_stats, ("sindex-type",), default_value="", return_type=str
-            ).values()
-        )[0]
+        sindex_type = next(
+            iter(
+                util.get_value_from_second_level_of_dict(
+                    ns_stats, ("sindex-type",), default_value="", return_type=str
+                ).values()
+            ),
+            "",
+        )
 
         sindex_size = sum(
             util.get_value_from_second_level_of_dict(
@@ -1869,31 +1875,37 @@ def _format_ns_stop_writes_metrics(
                 pi_persisted = stats.get("index-type", "") in ("flash", "pmem")
                 si_persisted = stats.get("sindex-type", "") in ("flash", "pmem")
 
-                index_mem_sz = (
+                index_mem_used = (
                     0
                     if pi_persisted
                     else util.get_value_from_dict(
                         stats, "index_used_bytes", default_value=0, return_type=int
                     )
                 )
-                set_index_sz = util.get_value_from_dict(
+                set_index_used = util.get_value_from_dict(
                     stats, "set_index_used_bytes", default_value=0, return_type=int
                 )
-                sindex_mem_sz = (
+                sindex_mem_used = (
                     0
                     if si_persisted
                     else util.get_value_from_dict(
                         stats, "sindex_used_bytes", default_value=0, return_type=int
                     )
                 )
-                ixs_sz = index_mem_sz + set_index_sz + sindex_mem_sz
+                ixs_used = index_mem_used + set_index_used + sindex_mem_used
 
+                # Synthetic admin-side metric mirroring the server's
+                # eval_stop_writes() ixs_sz: the sum that the server actually
+                # compares against `indexes-memory-budget`. Not a server-emitted
+                # stat — there is `indexes_memory_used_pct` (a ratio) but no
+                # bytes equivalent, so we compute it here for the stop-writes
+                # entry to expose the threshold in the same units (bytes).
                 metric = "indexes_memory_used"
-                sw = _is_stop_writes_cause(ixs_sz, threshold, stop_writes)
+                sw = _is_stop_writes_cause(ixs_used, threshold, stop_writes)
                 _create_stop_writes_entry(
                     stop_writes_metrics[node],
                     metric,
-                    ixs_sz,
+                    ixs_used,
                     sw,
                     threshold,
                     config=config,

--- a/lib/utils/common.py
+++ b/lib/utils/common.py
@@ -1191,7 +1191,11 @@ def create_summary(
                 cluster_flash_index_used += index_used
                 summary_dict["NAMESPACES"][ns]["flash_index"] = ns_index_usage
                 summary_dict["NAMESPACES"][ns]["index_type"] = index_type
-            elif index_type == "shmem":
+            else:
+                # Default unknown/missing index-type to shmem so the bytes still
+                # render in the PI breakdown and stay consistent with the
+                # sindex branch below and the `Indexes Memory` aggregate (which
+                # also treats unknown as non-persisted).
                 cluster_shmem_index_used += index_used
                 summary_dict["NAMESPACES"][ns]["shmem_index"] = ns_index_usage
                 summary_dict["NAMESPACES"][ns]["index_type"] = index_type
@@ -1306,11 +1310,14 @@ def create_summary(
             cluster_indexes_memory_total += ixs_budget
             cluster_indexes_memory_used += ixs_used
 
-        storage_engine_type = list(
-            util.get_value_from_second_level_of_dict(
-                ns_stats, ("storage-engine",), default_value="", return_type=str
-            ).values()
-        )[0]
+        storage_engine_type = next(
+            iter(
+                util.get_value_from_second_level_of_dict(
+                    ns_stats, ("storage-engine",), default_value="", return_type=str
+                ).values()
+            ),
+            "",
+        )
 
         data_size = util.get_value_from_second_level_of_dict(
             ns_stats,
@@ -1471,30 +1478,36 @@ def create_summary(
         }
         summary_dict["CLUSTER"]["memory_data_and_indexes"] = cluster_memory
 
-    if cluster_pmem_index_total > 0:
-        cluster_pmem_index_size_used_pct = (
-            cluster_pmem_index_used / cluster_pmem_index_total
-        ) * 100.0
-        cluster_pmem_index: SummaryStorageUsageDict = {
-            "total": cluster_pmem_index_total,
-            "avail": cluster_pmem_index_total - cluster_pmem_index_used,
-            "avail_pct": 100 - cluster_pmem_index_size_used_pct,
-            "used": cluster_pmem_index_used,
-            "used_pct": cluster_pmem_index_size_used_pct,
-        }
+    if cluster_pmem_index_total > 0 or cluster_pmem_index_used > 0:
+        if cluster_pmem_index_total > 0:
+            cluster_pmem_index_size_used_pct = (
+                cluster_pmem_index_used / cluster_pmem_index_total
+            ) * 100.0
+            cluster_pmem_index: SummaryStorageUsageDict = {
+                "total": cluster_pmem_index_total,
+                "avail": cluster_pmem_index_total - cluster_pmem_index_used,
+                "avail_pct": 100 - cluster_pmem_index_size_used_pct,
+                "used": cluster_pmem_index_used,
+                "used_pct": cluster_pmem_index_size_used_pct,
+            }
+        else:
+            cluster_pmem_index = {"used": cluster_pmem_index_used}
         summary_dict["CLUSTER"]["pmem_index"] = cluster_pmem_index
 
-    if cluster_flash_index_total > 0:
-        cluster_flash_index_used_pct = (
-            cluster_flash_index_used / cluster_flash_index_total
-        ) * 100.0
-        cluster_flash_index: SummaryStorageUsageDict = {
-            "total": cluster_flash_index_total,
-            "avail": cluster_flash_index_total - cluster_flash_index_used,
-            "avail_pct": 100 - cluster_flash_index_used_pct,
-            "used": cluster_flash_index_used,
-            "used_pct": cluster_flash_index_used_pct,
-        }
+    if cluster_flash_index_total > 0 or cluster_flash_index_used > 0:
+        if cluster_flash_index_total > 0:
+            cluster_flash_index_used_pct = (
+                cluster_flash_index_used / cluster_flash_index_total
+            ) * 100.0
+            cluster_flash_index: SummaryStorageUsageDict = {
+                "total": cluster_flash_index_total,
+                "avail": cluster_flash_index_total - cluster_flash_index_used,
+                "avail_pct": 100 - cluster_flash_index_used_pct,
+                "used": cluster_flash_index_used,
+                "used_pct": cluster_flash_index_used_pct,
+            }
+        else:
+            cluster_flash_index = {"used": cluster_flash_index_used}
         summary_dict["CLUSTER"]["flash_index"] = cluster_flash_index
 
     if cluster_shmem_index_used > 0:

--- a/lib/view/templates.py
+++ b/lib/view/templates.py
@@ -276,6 +276,11 @@ info_namespace_usage_sheet = Sheet(
                     "Evict%",
                     Projectors.Percent("ns_stats", "evict-sys-memory-pct"),
                 ),
+                Field(
+                    "Stop%",
+                    Projectors.Number("ns_stats", "stop-writes-sys-memory-pct"),
+                    converter=Converters.pct,
+                ),
             ),
         ),
         Subgroup(
@@ -1502,8 +1507,6 @@ summary_cluster_sheet = Sheet(
         create_summary_used_pct("cluster_dict", "flash_index"),
         create_summary_avail("cluster_dict", "flash_index"),
         create_summary_avail_pct("cluster_dict", "flash_index"),
-        #     ),
-        # ),
         # Subgroup(
         #     "Memory",
         #     (

--- a/lib/view/templates.py
+++ b/lib/view/templates.py
@@ -1482,6 +1482,13 @@ summary_cluster_sheet = Sheet(
         #      ),
         # ),
         # Subgroup(
+        #     "System Memory",
+        #     (
+        create_summary_used_pct("cluster_dict", "system_memory"),
+        create_summary_avail_pct("cluster_dict", "system_memory"),
+        #     ),
+        # ),
+        # Subgroup(
         #     "Shmem Index", # Sindex added to shmem in EE by default in 6.1. However,
         #     this will only be displayed in 7.0. Pre 7.0 includes shmem index metrics
         #     as apart of memory metrics.
@@ -1507,34 +1514,76 @@ summary_cluster_sheet = Sheet(
         create_summary_used_pct("cluster_dict", "flash_index"),
         create_summary_avail("cluster_dict", "flash_index"),
         create_summary_avail_pct("cluster_dict", "flash_index"),
-        # Subgroup(
-        #     "Memory",
-        #     (
-        create_summary_total("cluster_dict", "memory"),
-        create_summary_used("cluster_dict", "memory"),
-        create_summary_used_pct("cluster_dict", "memory"),
-        create_summary_avail("cluster_dict", "memory"),
-        create_summary_avail_pct("cluster_dict", "memory"),
-        #      ),
-        # ),
-        # Subgroup(
-        #     "Device",
-        #     (
-        create_summary_total("cluster_dict", "device"),
-        create_summary_used("cluster_dict", "device"),
-        create_summary_used_pct("cluster_dict", "device"),
-        create_summary_avail("cluster_dict", "device"),
-        create_summary_avail_pct("cluster_dict", "device"),
         #     ),
         # ),
         # Subgroup(
-        #     "Pmem",
+        #     "Shmem Sindex",
         #     (
-        create_summary_total("cluster_dict", "pmem"),
-        create_summary_used("cluster_dict", "pmem"),
-        create_summary_used_pct("cluster_dict", "pmem"),
-        create_summary_avail("cluster_dict", "pmem"),
-        create_summary_avail_pct("cluster_dict", "pmem"),
+        create_summary_used("cluster_dict", "shmem_sindex"),
+        #     ),
+        # ),
+        # Subgroup(
+        #     "Pmem Sindex",
+        #     (
+        create_summary_total("cluster_dict", "pmem_sindex"),
+        create_summary_used("cluster_dict", "pmem_sindex"),
+        create_summary_used_pct("cluster_dict", "pmem_sindex"),
+        create_summary_avail("cluster_dict", "pmem_sindex"),
+        create_summary_avail_pct("cluster_dict", "pmem_sindex"),
+        #     ),
+        # ),
+        # Subgroup(
+        #     "Flash Sindex",
+        #     (
+        create_summary_total("cluster_dict", "flash_sindex"),
+        create_summary_used("cluster_dict", "flash_sindex"),
+        create_summary_used_pct("cluster_dict", "flash_sindex"),
+        create_summary_avail("cluster_dict", "flash_sindex"),
+        create_summary_avail_pct("cluster_dict", "flash_sindex"),
+        #     ),
+        # ),
+        # Subgroup(
+        #     "Set Index",
+        #     (
+        create_summary_used("cluster_dict", "set_index"),
+        #     ),
+        # ),
+        # Subgroup(
+        #     "Indexes Memory",
+        #     (
+        create_summary_total("cluster_dict", "indexes_memory"),
+        create_summary_used("cluster_dict", "indexes_memory"),
+        create_summary_used_pct("cluster_dict", "indexes_memory"),
+        create_summary_avail("cluster_dict", "indexes_memory"),
+        create_summary_avail_pct("cluster_dict", "indexes_memory"),
+        # Subgroup(
+        #     "Data Memory",
+        #     (
+        create_summary_total("cluster_dict", "data_memory"),
+        create_summary_used("cluster_dict", "data_memory"),
+        create_summary_used_pct("cluster_dict", "data_memory"),
+        create_summary_avail("cluster_dict", "data_memory"),
+        create_summary_avail_pct("cluster_dict", "data_memory"),
+        #      ),
+        # ),
+        # Subgroup(
+        #     "Data Device",
+        #     (
+        create_summary_total("cluster_dict", "data_device"),
+        create_summary_used("cluster_dict", "data_device"),
+        create_summary_used_pct("cluster_dict", "data_device"),
+        create_summary_avail("cluster_dict", "data_device"),
+        create_summary_avail_pct("cluster_dict", "data_device"),
+        #     ),
+        # ),
+        # Subgroup(
+        #     "Data Pmem",
+        #     (
+        create_summary_total("cluster_dict", "data_pmem"),
+        create_summary_used("cluster_dict", "data_pmem"),
+        create_summary_used_pct("cluster_dict", "data_pmem"),
+        create_summary_avail("cluster_dict", "data_pmem"),
+        create_summary_avail_pct("cluster_dict", "data_pmem"),
         #     ),
         # ),
         Field(
@@ -1699,27 +1748,59 @@ summary_namespace_sheet = Sheet(
             ),
         ),
         Subgroup(
-            "Memory",
+            "Shmem Sindex",
+            (create_summary_used("ns_stats", "shmem_sindex", subgroup=True),),
+        ),
+        Subgroup(
+            "Pmem Sindex",
             (
-                create_summary_total("ns_stats", "memory", subgroup=True),
-                create_summary_used_pct("ns_stats", "memory", subgroup=True),
-                create_summary_avail_pct("ns_stats", "memory", subgroup=True),
+                create_summary_total("ns_stats", "pmem_sindex", subgroup=True),
+                create_summary_used_pct("ns_stats", "pmem_sindex", subgroup=True),
+                create_summary_avail_pct("ns_stats", "pmem_sindex", subgroup=True),
             ),
         ),
         Subgroup(
-            "Device",
+            "Flash Sindex",
             (
-                create_summary_total("ns_stats", "device", subgroup=True),
-                create_summary_used_pct("ns_stats", "device", subgroup=True),
-                create_summary_avail_pct("ns_stats", "device", subgroup=True),
+                create_summary_total("ns_stats", "flash_sindex", subgroup=True),
+                create_summary_used_pct("ns_stats", "flash_sindex", subgroup=True),
+                create_summary_avail_pct("ns_stats", "flash_sindex", subgroup=True),
             ),
         ),
         Subgroup(
-            "Pmem",
+            "Set Index",
+            (create_summary_used("ns_stats", "set_index", subgroup=True),),
+        ),
+        Subgroup(
+            "Indexes Memory",
             (
-                create_summary_total("ns_stats", "pmem", subgroup=True),
-                create_summary_used_pct("ns_stats", "pmem", subgroup=True),
-                create_summary_avail_pct("ns_stats", "pmem", subgroup=True),
+                create_summary_total("ns_stats", "indexes_memory", subgroup=True),
+                create_summary_used_pct("ns_stats", "indexes_memory", subgroup=True),
+                create_summary_avail_pct("ns_stats", "indexes_memory", subgroup=True),
+            ),
+        ),
+        Subgroup(
+            "Data Memory",
+            (
+                create_summary_total("ns_stats", "data_memory", subgroup=True),
+                create_summary_used_pct("ns_stats", "data_memory", subgroup=True),
+                create_summary_avail_pct("ns_stats", "data_memory", subgroup=True),
+            ),
+        ),
+        Subgroup(
+            "Data Device",
+            (
+                create_summary_total("ns_stats", "data_device", subgroup=True),
+                create_summary_used_pct("ns_stats", "data_device", subgroup=True),
+                create_summary_avail_pct("ns_stats", "data_device", subgroup=True),
+            ),
+        ),
+        Subgroup(
+            "Data Pmem",
+            (
+                create_summary_total("ns_stats", "data_pmem", subgroup=True),
+                create_summary_used_pct("ns_stats", "data_pmem", subgroup=True),
+                create_summary_avail_pct("ns_stats", "data_pmem", subgroup=True),
             ),
         ),
         Field(

--- a/lib/view/view.py
+++ b/lib/view/view.py
@@ -2349,6 +2349,15 @@ class CliView(object):
             )
         )
 
+        if "system_memory" in cluster_dict:
+            sm = cluster_dict["system_memory"]
+            numbered_lines.append(
+                CliView.SummaryLine(
+                    "System Memory",
+                    f"{sm['avail_pct']:.2f}% free",
+                )
+            )
+
         if "pmem_index" in cluster_dict:
             numbered_lines.append(
                 CliView.SummaryUsageLine(
@@ -2373,6 +2382,46 @@ class CliView(object):
                 )
             )
 
+        if "pmem_sindex" in cluster_dict:
+            numbered_lines.append(
+                CliView.SummaryUsageLine(
+                    "Pmem Sindex",
+                    cluster_dict["pmem_sindex"],
+                )
+            )
+
+        if "flash_sindex" in cluster_dict:
+            numbered_lines.append(
+                CliView.SummaryUsageLine(
+                    "Flash Sindex",
+                    cluster_dict["flash_sindex"],
+                )
+            )
+
+        if "shmem_sindex" in cluster_dict:
+            numbered_lines.append(
+                CliView.SummaryUsageLine(
+                    "Shmem Sindex",
+                    cluster_dict["shmem_sindex"],
+                )
+            )
+
+        if "set_index" in cluster_dict:
+            numbered_lines.append(
+                CliView.SummaryUsageLine(
+                    "Set Index",
+                    cluster_dict["set_index"],
+                )
+            )
+
+        if "indexes_memory" in cluster_dict:
+            numbered_lines.append(
+                CliView.SummaryUsageLine(
+                    "Indexes Memory",
+                    cluster_dict["indexes_memory"],
+                )
+            )
+
         if "memory_data_and_indexes" in cluster_dict:
             numbered_lines.append(
                 CliView.SummaryUsageLine(
@@ -2383,29 +2432,29 @@ class CliView(object):
                 )
             )
 
-        if "memory" in cluster_dict:
+        if "data_memory" in cluster_dict:
             numbered_lines.append(
                 CliView.SummaryUsageLine(
-                    "Memory",
-                    cluster_dict["memory"],
+                    "Data Memory",
+                    cluster_dict["data_memory"],
                     contiguous=True,
                 )
             )
 
-        if "device" in cluster_dict:
+        if "data_device" in cluster_dict:
             numbered_lines.append(
                 CliView.SummaryUsageLine(
-                    "Device",
-                    cluster_dict["device"],
+                    "Data Device",
+                    cluster_dict["data_device"],
                     contiguous=True,
                 )
             )
 
-        if "pmem" in cluster_dict:
+        if "data_pmem" in cluster_dict:
             numbered_lines.append(
                 CliView.SummaryUsageLine(
-                    "Pmem",
-                    cluster_dict["pmem"],
+                    "Data Pmem",
+                    cluster_dict["data_pmem"],
                     contiguous=True,
                 )
             )
@@ -2495,6 +2544,33 @@ class CliView(object):
             except:
                 pass
 
+            if "pmem_sindex" in ns_stats:
+                ns_lines.append(
+                    CliView.SummaryUsageLine("Pmem Sindex", ns_stats["pmem_sindex"])
+                )
+
+            if "flash_sindex" in ns_stats:
+                ns_lines.append(
+                    CliView.SummaryUsageLine("Flash Sindex", ns_stats["flash_sindex"])
+                )
+
+            if "shmem_sindex" in ns_stats:
+                ns_lines.append(
+                    CliView.SummaryUsageLine("Shmem Sindex", ns_stats["shmem_sindex"])
+                )
+
+            if "set_index" in ns_stats:
+                ns_lines.append(
+                    CliView.SummaryUsageLine("Set Index", ns_stats["set_index"])
+                )
+
+            if "indexes_memory" in ns_stats:
+                ns_lines.append(
+                    CliView.SummaryUsageLine(
+                        "Indexes Memory", ns_stats["indexes_memory"]
+                    )
+                )
+
             if "memory_data_and_indexes" in ns_stats:
                 ns_lines.append(
                     CliView.SummaryUsageLine(
@@ -2505,28 +2581,28 @@ class CliView(object):
                     )
                 )
 
-            if "memory" in ns_stats:
+            if "data_memory" in ns_stats:
                 ns_lines.append(
                     CliView.SummaryUsageLine(
-                        "Memory", ns_stats["memory"], contiguous=True
+                        "Data Memory", ns_stats["data_memory"], contiguous=True
                     )
                 )
 
-            if "device" in ns_stats:
+            if "data_device" in ns_stats:
                 try:
                     ns_lines.append(
                         CliView.SummaryUsageLine(
-                            "Device", ns_stats["device"], contiguous=True
+                            "Data Device", ns_stats["data_device"], contiguous=True
                         )
                     )
                 except:
                     pass
 
-            if "pmem" in ns_stats:
+            if "data_pmem" in ns_stats:
                 try:
                     ns_lines.append(
                         CliView.SummaryUsageLine(
-                            "Pmem", ns_stats["pmem"], contiguous=True
+                            "Data Pmem", ns_stats["data_pmem"], contiguous=True
                         )
                     )
                 except:

--- a/test/unit/utils/test_common.py
+++ b/test/unit/utils/test_common.py
@@ -944,7 +944,7 @@ class CreateStopWritesSummaryTests(unittest.IsolatedAsyncioTestCase):
                     }
                 },
             ),
-            # stop_writes is not triggered by index_used_bytes
+            # stop_writes is not triggered by indexes memory (PI only)
             create_tc(
                 ns_stats={
                     "1.1.1.1": {
@@ -959,8 +959,8 @@ class CreateStopWritesSummaryTests(unittest.IsolatedAsyncioTestCase):
                 },
                 expected={
                     "1.1.1.1": {
-                        ("ns1", None, "index_used_bytes"): {
-                            "metric": "index_used_bytes",
+                        ("ns1", None, "indexes_memory_used"): {
+                            "metric": "indexes_memory_used",
                             "config": "indexes-memory-budget",
                             "stop_writes": False,
                             "metric_usage": 10,
@@ -970,7 +970,7 @@ class CreateStopWritesSummaryTests(unittest.IsolatedAsyncioTestCase):
                     }
                 },
             ),
-            # stop_writes is triggered by index_used_bytes
+            # stop_writes is triggered by indexes memory (PI only)
             create_tc(
                 ns_stats={
                     "1.1.1.1": {
@@ -989,11 +989,109 @@ class CreateStopWritesSummaryTests(unittest.IsolatedAsyncioTestCase):
                 },
                 expected={
                     "1.1.1.1": {
-                        ("ns1", None, "index_used_bytes"): {
-                            "metric": "index_used_bytes",
+                        ("ns1", None, "indexes_memory_used"): {
+                            "metric": "indexes_memory_used",
                             "config": "indexes-memory-budget",
                             "stop_writes": True,
                             "metric_usage": 90,
+                            "metric_threshold": 90,
+                            "namespace": "ns1",
+                        },
+                    }
+                },
+            ),
+            # stop_writes is triggered by combined PI + SI + set-index
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "ns1": {
+                            "stop_writes": "true",
+                            "index_used_bytes": "40",
+                            "sindex_used_bytes": "30",
+                            "set_index_used_bytes": "25",
+                        }
+                    },
+                },
+                ns_config={
+                    "1.1.1.1": {
+                        "ns1": {
+                            "indexes-memory-budget": "90",
+                        }
+                    },
+                },
+                expected={
+                    "1.1.1.1": {
+                        ("ns1", None, "indexes_memory_used"): {
+                            "metric": "indexes_memory_used",
+                            "config": "indexes-memory-budget",
+                            "stop_writes": True,
+                            "metric_usage": 95,
+                            "metric_threshold": 90,
+                            "namespace": "ns1",
+                        },
+                    }
+                },
+            ),
+            # stop_writes excludes persisted PI from indexes-memory-budget check
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "ns1": {
+                            "stop_writes": "true",
+                            "index-type": "flash",
+                            "index_used_bytes": "500",
+                            "sindex_used_bytes": "30",
+                            "set_index_used_bytes": "25",
+                        }
+                    },
+                },
+                ns_config={
+                    "1.1.1.1": {
+                        "ns1": {
+                            "indexes-memory-budget": "90",
+                        }
+                    },
+                },
+                expected={
+                    "1.1.1.1": {
+                        ("ns1", None, "indexes_memory_used"): {
+                            "metric": "indexes_memory_used",
+                            "config": "indexes-memory-budget",
+                            "stop_writes": False,
+                            "metric_usage": 55,
+                            "metric_threshold": 90,
+                            "namespace": "ns1",
+                        },
+                    }
+                },
+            ),
+            # stop_writes excludes persisted SI from indexes-memory-budget check
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "ns1": {
+                            "stop_writes": "true",
+                            "sindex-type": "pmem",
+                            "index_used_bytes": "40",
+                            "sindex_used_bytes": "500",
+                            "set_index_used_bytes": "25",
+                        }
+                    },
+                },
+                ns_config={
+                    "1.1.1.1": {
+                        "ns1": {
+                            "indexes-memory-budget": "90",
+                        }
+                    },
+                },
+                expected={
+                    "1.1.1.1": {
+                        ("ns1", None, "indexes_memory_used"): {
+                            "metric": "indexes_memory_used",
+                            "config": "indexes-memory-budget",
+                            "stop_writes": False,
+                            "metric_usage": 65,
                             "metric_threshold": 90,
                             "namespace": "ns1",
                         },

--- a/test/unit/utils/test_common.py
+++ b/test/unit/utils/test_common.py
@@ -2032,6 +2032,504 @@ class CreateSummaryTests(unittest.TestCase):
                     },
                 },
             ),
+            # Test sindex (shmem) folded into existing shmem_index + set_index
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "index_used_bytes": 512,
+                            "sindex_used_bytes": 256,
+                            "set_index_used_bytes": 128,
+                            "data_used_bytes": 1024,
+                            "data_total_bytes": 2048,
+                            "data_avail_pct": 50,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "memory",
+                            "index-type": "shmem",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-shmem"],
+                        "ns_count": 1,
+                        "license_data": {"latest": 1024},
+                        "shmem_index": {
+                            "used": 896,
+                        },
+                        "memory": {
+                            "total": 2048,
+                            "used": 1024,
+                            "used_pct": 50.0,
+                            "avail": 1024.0,
+                            "avail_pct": 50.0,
+                        },
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "shmem",
+                            "shmem_index": {
+                                "used": 896,
+                            },
+                            "memory": {
+                                "total": 2048,
+                                "used": 1024,
+                                "used_pct": 50.0,
+                                "avail": 1024.0,
+                                "avail_pct": 50.0,
+                            },
+                            "repl_factor": [1],
+                            "license_data": {"latest": 1024},
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
+            # Test sindex (pmem) folded into existing pmem_index
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "index_used_bytes": 512,
+                            "sindex_used_bytes": 256,
+                            "data_used_bytes": 1024,
+                            "data_total_bytes": 2048,
+                            "data_avail_pct": 50,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "device",
+                            "index-type": "pmem",
+                            "index-type.mounts-budget": "2048",
+                            "sindex-type": "pmem",
+                            "sindex-type.mounts-budget": "1024",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-pmem"],
+                        "ns_count": 1,
+                        "license_data": {"latest": 1024},
+                        "pmem_index": {
+                            "total": 3072,
+                            "used": 768,
+                            "used_pct": 25.0,
+                            "avail": 2304,
+                            "avail_pct": 75.0,
+                        },
+                        "device": {
+                            "total": 2048,
+                            "used": 1024,
+                            "used_pct": 50.0,
+                            "avail": 1024.0,
+                            "avail_pct": 50.0,
+                        },
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "pmem",
+                            "pmem_index": {
+                                "total": 3072,
+                                "used": 768,
+                                "used_pct": 25.0,
+                                "avail": 2304,
+                                "avail_pct": 75.0,
+                            },
+                            "device": {
+                                "total": 2048,
+                                "used": 1024,
+                                "used_pct": 50.0,
+                                "avail": 1024.0,
+                                "avail_pct": 50.0,
+                            },
+                            "repl_factor": [1],
+                            "license_data": {"latest": 1024},
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
+            # Test sindex (flash) folded into existing flash_index
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "index_used_bytes": 512,
+                            "sindex_used_bytes": 256,
+                            "data_used_bytes": 1024,
+                            "data_total_bytes": 4096,
+                            "data_avail_pct": 75,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "device",
+                            "index-type": "flash",
+                            "index-type.mounts-budget": "2048",
+                            "sindex-type": "flash",
+                            "sindex-type.mounts-budget": "1024",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-flash"],
+                        "ns_count": 1,
+                        "license_data": {"latest": 1024},
+                        "flash_index": {
+                            "total": 3072,
+                            "used": 768,
+                            "used_pct": 25.0,
+                            "avail": 2304,
+                            "avail_pct": 75.0,
+                        },
+                        "device": {
+                            "total": 4096,
+                            "used": 1024,
+                            "used_pct": 25.0,
+                            "avail": 3072.0,
+                            "avail_pct": 75.0,
+                        },
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "flash",
+                            "flash_index": {
+                                "total": 3072,
+                                "used": 768,
+                                "used_pct": 25.0,
+                                "avail": 2304,
+                                "avail_pct": 75.0,
+                            },
+                            "device": {
+                                "total": 4096,
+                                "used": 1024,
+                                "used_pct": 25.0,
+                                "avail": 3072.0,
+                                "avail_pct": 75.0,
+                            },
+                            "repl_factor": [1],
+                            "license_data": {"latest": 1024},
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
+            # Test sindex (pmem) creates new pmem_index when PI is shmem
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "index_used_bytes": 512,
+                            "sindex_used_bytes": 256,
+                            "data_used_bytes": 1024,
+                            "data_total_bytes": 2048,
+                            "data_avail_pct": 50,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "memory",
+                            "index-type": "shmem",
+                            "sindex-type": "pmem",
+                            "sindex-type.mounts-budget": "1024",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-shmem"],
+                        "ns_count": 1,
+                        "license_data": {"latest": 1024},
+                        "shmem_index": {
+                            "used": 512,
+                        },
+                        "pmem_index": {
+                            "total": 1024,
+                            "used": 256,
+                            "used_pct": 25.0,
+                            "avail": 768,
+                            "avail_pct": 75.0,
+                        },
+                        "memory": {
+                            "total": 2048,
+                            "used": 1024,
+                            "used_pct": 50.0,
+                            "avail": 1024.0,
+                            "avail_pct": 50.0,
+                        },
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "shmem",
+                            "shmem_index": {
+                                "used": 512,
+                            },
+                            "pmem_index": {
+                                "total": 1024,
+                                "used": 256,
+                                "used_pct": 25.0,
+                                "avail": 768,
+                                "avail_pct": 75.0,
+                            },
+                            "memory": {
+                                "total": 2048,
+                                "used": 1024,
+                                "used_pct": 50.0,
+                                "avail": 1024.0,
+                                "avail_pct": 50.0,
+                            },
+                            "repl_factor": [1],
+                            "license_data": {"latest": 1024},
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
+            # Test sindex (flash) creates new flash_index when PI is shmem
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "index_used_bytes": 512,
+                            "sindex_used_bytes": 256,
+                            "data_used_bytes": 1024,
+                            "data_total_bytes": 2048,
+                            "data_avail_pct": 50,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "memory",
+                            "index-type": "shmem",
+                            "sindex-type": "flash",
+                            "sindex-type.mounts-budget": "1024",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-shmem"],
+                        "ns_count": 1,
+                        "license_data": {"latest": 1024},
+                        "shmem_index": {
+                            "used": 512,
+                        },
+                        "flash_index": {
+                            "total": 1024,
+                            "used": 256,
+                            "used_pct": 25.0,
+                            "avail": 768,
+                            "avail_pct": 75.0,
+                        },
+                        "memory": {
+                            "total": 2048,
+                            "used": 1024,
+                            "used_pct": 50.0,
+                            "avail": 1024.0,
+                            "avail_pct": 50.0,
+                        },
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "shmem",
+                            "shmem_index": {
+                                "used": 512,
+                            },
+                            "flash_index": {
+                                "total": 1024,
+                                "used": 256,
+                                "used_pct": 25.0,
+                                "avail": 768,
+                                "avail_pct": 75.0,
+                            },
+                            "memory": {
+                                "total": 2048,
+                                "used": 1024,
+                                "used_pct": 50.0,
+                                "avail": 1024.0,
+                                "avail_pct": 50.0,
+                            },
+                            "repl_factor": [1],
+                            "license_data": {"latest": 1024},
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
+            # Test sindex (shmem default) creates new shmem_index when PI is flash
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "index_used_bytes": 512,
+                            "sindex_used_bytes": 256,
+                            "data_used_bytes": 1024,
+                            "data_total_bytes": 4096,
+                            "data_avail_pct": 75,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "device",
+                            "index-type": "flash",
+                            "index-type.mounts-budget": "2048",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-flash"],
+                        "ns_count": 1,
+                        "license_data": {"latest": 1024},
+                        "flash_index": {
+                            "total": 2048,
+                            "used": 512,
+                            "used_pct": 25.0,
+                            "avail": 1536,
+                            "avail_pct": 75.0,
+                        },
+                        "shmem_index": {
+                            "used": 256,
+                        },
+                        "device": {
+                            "total": 4096,
+                            "used": 1024,
+                            "used_pct": 25.0,
+                            "avail": 3072.0,
+                            "avail_pct": 75.0,
+                        },
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "flash",
+                            "flash_index": {
+                                "total": 2048,
+                                "used": 512,
+                                "used_pct": 25.0,
+                                "avail": 1536,
+                                "avail_pct": 75.0,
+                            },
+                            "shmem_index": {
+                                "used": 256,
+                            },
+                            "device": {
+                                "total": 4096,
+                                "used": 1024,
+                                "used_pct": 25.0,
+                                "avail": 3072.0,
+                                "avail_pct": 75.0,
+                            },
+                            "repl_factor": [1],
+                            "license_data": {"latest": 1024},
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
+            # Test set_index creates new shmem_index when PI is on flash
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "index_used_bytes": 512,
+                            "set_index_used_bytes": 128,
+                            "data_used_bytes": 1024,
+                            "data_total_bytes": 4096,
+                            "data_avail_pct": 75,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "device",
+                            "index-type": "flash",
+                            "index-type.mounts-budget": "2048",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-flash"],
+                        "ns_count": 1,
+                        "license_data": {"latest": 1024},
+                        "flash_index": {
+                            "total": 2048,
+                            "used": 512,
+                            "used_pct": 25.0,
+                            "avail": 1536,
+                            "avail_pct": 75.0,
+                        },
+                        "shmem_index": {
+                            "used": 128,
+                        },
+                        "device": {
+                            "total": 4096,
+                            "used": 1024,
+                            "used_pct": 25.0,
+                            "avail": 3072.0,
+                            "avail_pct": 75.0,
+                        },
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "flash",
+                            "flash_index": {
+                                "total": 2048,
+                                "used": 512,
+                                "used_pct": 25.0,
+                                "avail": 1536,
+                                "avail_pct": 75.0,
+                            },
+                            "shmem_index": {
+                                "used": 128,
+                            },
+                            "device": {
+                                "total": 4096,
+                                "used": 1024,
+                                "used_pct": 25.0,
+                                "avail": 3072.0,
+                                "avail_pct": 75.0,
+                            },
+                            "repl_factor": [1],
+                            "license_data": {"latest": 1024},
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
             # Test Compression Ratio usage
             create_tc(
                 ns_stats={

--- a/test/unit/utils/test_common.py
+++ b/test/unit/utils/test_common.py
@@ -2260,6 +2260,119 @@ class CreateSummaryTests(unittest.TestCase):
                     },
                 },
             ),
+            # pmem PI used-only fallback: server reports index_used_bytes but no
+            # mounts-budget configured. Both ns-level and cluster-level entries
+            # should render in used-only form (mirrors the SI fallback at the
+            # cluster level so bytes aren't silently dropped from the summary).
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "index_used_bytes": 512,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "device",
+                            "index-type": "pmem",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-pmem"],
+                        "ns_count": 1,
+                        "license_data": {"latest": 0},
+                        "pmem_index": {"used": 512},
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "pmem",
+                            "pmem_index": {"used": 512},
+                            "repl_factor": [1],
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
+            # flash PI used-only fallback: same as above but for flash index.
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "index_used_bytes": 512,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "device",
+                            "index-type": "flash",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-flash"],
+                        "ns_count": 1,
+                        "license_data": {"latest": 0},
+                        "flash_index": {"used": 512},
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "flash",
+                            "flash_index": {"used": 512},
+                            "repl_factor": [1],
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
+            # flash sindex used-only fallback: server reports sindex_used_bytes
+            # but no sindex-type.mounts-budget configured. Cluster-level
+            # flash_sindex must still render as used-only (covers the else
+            # branch at common.py:1543).
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "sindex_used_bytes": 256,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "device",
+                            "sindex-type": "flash",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": [],
+                        "ns_count": 1,
+                        "license_data": {"latest": 0},
+                        "flash_sindex": {"used": 256},
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "flash_sindex": {"used": 256},
+                            "repl_factor": [1],
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
             # shmem PI + pmem SI → shmem_index and pmem_sindex
             create_tc(
                 ns_stats={
@@ -3443,6 +3556,11 @@ class CreateSummaryTests(unittest.TestCase):
                         "os_version": [],
                         "server_version": [],
                         "compression_enabled": False,
+                        # No `index-type` configured for "test" ns, so the PI
+                        # branch defaults unknown to shmem (sums 200+200 across
+                        # the two nodes). Mirrors the policy used for sindex
+                        # and the `Indexes Memory` aggregate.
+                        "shmem_index": {"used": 400},
                     },
                     "NAMESPACES": {
                         "test": {
@@ -3457,6 +3575,8 @@ class CreateSummaryTests(unittest.TestCase):
                             "rack_aware": False,
                             "repl_factor": [2],
                             "compression_enabled": False,
+                            "index_type": "",
+                            "shmem_index": {"used": 400},
                         },
                         "bar": {
                             "compression_ratio": 0.5,

--- a/test/unit/utils/test_common.py
+++ b/test/unit/utils/test_common.py
@@ -1567,7 +1567,7 @@ class CreateSummaryTests(unittest.TestCase):
                             "avail": 1024,
                             "avail_pct": 50.0,
                         },
-                        "pmem": {
+                        "data_pmem": {
                             "total": 4096,
                             "used": 2048,
                             "used_pct": 50.0,
@@ -1593,7 +1593,7 @@ class CreateSummaryTests(unittest.TestCase):
                                 "avail": 512,
                                 "avail_pct": 50.0,
                             },
-                            "pmem": {
+                            "data_pmem": {
                                 "total": 2048,
                                 "used": 1024,
                                 "used_pct": 50.0,
@@ -1620,7 +1620,7 @@ class CreateSummaryTests(unittest.TestCase):
                                 "avail": 512,
                                 "avail_pct": 50.0,
                             },
-                            "pmem": {
+                            "data_pmem": {
                                 "total": 2048,
                                 "used": 1024,
                                 "used_pct": 50.0,
@@ -1685,7 +1685,7 @@ class CreateSummaryTests(unittest.TestCase):
                             "avail": 1024,
                             "avail_pct": 50.0,
                         },
-                        "device": {
+                        "data_device": {
                             "total": 4096,
                             "used": 2048,
                             "used_pct": 50.0,
@@ -1703,7 +1703,7 @@ class CreateSummaryTests(unittest.TestCase):
                                 "avail": 512,
                                 "avail_pct": 50.0,
                             },
-                            "device": {
+                            "data_device": {
                                 "total": 2048,
                                 "used": 1024,
                                 "used_pct": 50.0,
@@ -1723,7 +1723,7 @@ class CreateSummaryTests(unittest.TestCase):
                                 "avail": 512,
                                 "avail_pct": 50.0,
                             },
-                            "device": {
+                            "data_device": {
                                 "total": 2048,
                                 "used": 1024,
                                 "used_pct": 50.0,
@@ -1781,7 +1781,7 @@ class CreateSummaryTests(unittest.TestCase):
                         "shmem_index": {
                             "used": 1024,
                         },
-                        "memory": {
+                        "data_memory": {
                             "total": 4096,
                             "used": 2048,
                             "used_pct": 50.0,
@@ -1796,7 +1796,7 @@ class CreateSummaryTests(unittest.TestCase):
                             "shmem_index": {
                                 "used": 512,
                             },
-                            "memory": {
+                            "data_memory": {
                                 "total": 2048,
                                 "used": 1024,
                                 "used_pct": 50.0,
@@ -1812,7 +1812,7 @@ class CreateSummaryTests(unittest.TestCase):
                             "shmem_index": {
                                 "used": 512,
                             },
-                            "memory": {
+                            "data_memory": {
                                 "total": 2048,
                                 "used": 1024,
                                 "used_pct": 50.0,
@@ -1876,7 +1876,7 @@ class CreateSummaryTests(unittest.TestCase):
                             "avail": 1024,
                             "avail_pct": 50.0,
                         },
-                        "device": {
+                        "data_device": {
                             "total": 4096,
                             "used": 2048,
                             "used_pct": 50.0,
@@ -1895,7 +1895,7 @@ class CreateSummaryTests(unittest.TestCase):
                                 "avail": 512,
                                 "avail_pct": 50.0,
                             },
-                            "device": {
+                            "data_device": {
                                 "total": 2048,
                                 "used": 1024,
                                 "used_pct": 50.0,
@@ -1915,7 +1915,7 @@ class CreateSummaryTests(unittest.TestCase):
                                 "avail": 512,
                                 "avail_pct": 50.0,
                             },
-                            "device": {
+                            "data_device": {
                                 "total": 2048,
                                 "used": 1024,
                                 "used_pct": 50.0,
@@ -1979,7 +1979,7 @@ class CreateSummaryTests(unittest.TestCase):
                             "avail": 1024,
                             "avail_pct": 50.0,
                         },
-                        "pmem": {
+                        "data_pmem": {
                             "total": 4096,
                             "used": 2048,
                             "used_pct": 50.0,
@@ -1998,7 +1998,7 @@ class CreateSummaryTests(unittest.TestCase):
                                 "avail": 512,
                                 "avail_pct": 50.0,
                             },
-                            "pmem": {
+                            "data_pmem": {
                                 "total": 2048,
                                 "used": 1024,
                                 "used_pct": 50.0,
@@ -2018,7 +2018,7 @@ class CreateSummaryTests(unittest.TestCase):
                                 "avail": 512,
                                 "avail_pct": 50.0,
                             },
-                            "pmem": {
+                            "data_pmem": {
                                 "total": 2048,
                                 "used": 1024,
                                 "used_pct": 50.0,
@@ -2032,7 +2032,7 @@ class CreateSummaryTests(unittest.TestCase):
                     },
                 },
             ),
-            # Test sindex (shmem) folded into existing shmem_index + set_index
+            # shmem PI + shmem SI (no sindex-type) + set_index → three separate lines
             create_tc(
                 ns_stats={
                     "1.1.1.1": {
@@ -2060,10 +2060,10 @@ class CreateSummaryTests(unittest.TestCase):
                         "active_features": ["Index-on-shmem"],
                         "ns_count": 1,
                         "license_data": {"latest": 1024},
-                        "shmem_index": {
-                            "used": 896,
-                        },
-                        "memory": {
+                        "shmem_index": {"used": 512},
+                        "shmem_sindex": {"used": 256},
+                        "set_index": {"used": 128},
+                        "data_memory": {
                             "total": 2048,
                             "used": 1024,
                             "used_pct": 50.0,
@@ -2075,10 +2075,10 @@ class CreateSummaryTests(unittest.TestCase):
                     "NAMESPACES": {
                         "test": {
                             "index_type": "shmem",
-                            "shmem_index": {
-                                "used": 896,
-                            },
-                            "memory": {
+                            "shmem_index": {"used": 512},
+                            "shmem_sindex": {"used": 256},
+                            "set_index": {"used": 128},
+                            "data_memory": {
                                 "total": 2048,
                                 "used": 1024,
                                 "used_pct": 50.0,
@@ -2092,7 +2092,7 @@ class CreateSummaryTests(unittest.TestCase):
                     },
                 },
             ),
-            # Test sindex (pmem) folded into existing pmem_index
+            # pmem PI + pmem SI → independent pmem_index and pmem_sindex (not summed)
             create_tc(
                 ns_stats={
                     "1.1.1.1": {
@@ -2123,13 +2123,20 @@ class CreateSummaryTests(unittest.TestCase):
                         "ns_count": 1,
                         "license_data": {"latest": 1024},
                         "pmem_index": {
-                            "total": 3072,
-                            "used": 768,
+                            "total": 2048,
+                            "used": 512,
                             "used_pct": 25.0,
-                            "avail": 2304,
+                            "avail": 1536,
                             "avail_pct": 75.0,
                         },
-                        "device": {
+                        "pmem_sindex": {
+                            "total": 1024,
+                            "used": 256,
+                            "used_pct": 25.0,
+                            "avail": 768,
+                            "avail_pct": 75.0,
+                        },
+                        "data_device": {
                             "total": 2048,
                             "used": 1024,
                             "used_pct": 50.0,
@@ -2142,13 +2149,20 @@ class CreateSummaryTests(unittest.TestCase):
                         "test": {
                             "index_type": "pmem",
                             "pmem_index": {
-                                "total": 3072,
-                                "used": 768,
+                                "total": 2048,
+                                "used": 512,
                                 "used_pct": 25.0,
-                                "avail": 2304,
+                                "avail": 1536,
                                 "avail_pct": 75.0,
                             },
-                            "device": {
+                            "pmem_sindex": {
+                                "total": 1024,
+                                "used": 256,
+                                "used_pct": 25.0,
+                                "avail": 768,
+                                "avail_pct": 75.0,
+                            },
+                            "data_device": {
                                 "total": 2048,
                                 "used": 1024,
                                 "used_pct": 50.0,
@@ -2162,7 +2176,7 @@ class CreateSummaryTests(unittest.TestCase):
                     },
                 },
             ),
-            # Test sindex (flash) folded into existing flash_index
+            # flash PI + flash SI → independent flash_index and flash_sindex
             create_tc(
                 ns_stats={
                     "1.1.1.1": {
@@ -2193,13 +2207,20 @@ class CreateSummaryTests(unittest.TestCase):
                         "ns_count": 1,
                         "license_data": {"latest": 1024},
                         "flash_index": {
-                            "total": 3072,
-                            "used": 768,
+                            "total": 2048,
+                            "used": 512,
                             "used_pct": 25.0,
-                            "avail": 2304,
+                            "avail": 1536,
                             "avail_pct": 75.0,
                         },
-                        "device": {
+                        "flash_sindex": {
+                            "total": 1024,
+                            "used": 256,
+                            "used_pct": 25.0,
+                            "avail": 768,
+                            "avail_pct": 75.0,
+                        },
+                        "data_device": {
                             "total": 4096,
                             "used": 1024,
                             "used_pct": 25.0,
@@ -2212,13 +2233,20 @@ class CreateSummaryTests(unittest.TestCase):
                         "test": {
                             "index_type": "flash",
                             "flash_index": {
-                                "total": 3072,
-                                "used": 768,
+                                "total": 2048,
+                                "used": 512,
                                 "used_pct": 25.0,
-                                "avail": 2304,
+                                "avail": 1536,
                                 "avail_pct": 75.0,
                             },
-                            "device": {
+                            "flash_sindex": {
+                                "total": 1024,
+                                "used": 256,
+                                "used_pct": 25.0,
+                                "avail": 768,
+                                "avail_pct": 75.0,
+                            },
+                            "data_device": {
                                 "total": 4096,
                                 "used": 1024,
                                 "used_pct": 25.0,
@@ -2232,7 +2260,7 @@ class CreateSummaryTests(unittest.TestCase):
                     },
                 },
             ),
-            # Test sindex (pmem) creates new pmem_index when PI is shmem
+            # shmem PI + pmem SI → shmem_index and pmem_sindex
             create_tc(
                 ns_stats={
                     "1.1.1.1": {
@@ -2261,17 +2289,15 @@ class CreateSummaryTests(unittest.TestCase):
                         "active_features": ["Index-on-shmem"],
                         "ns_count": 1,
                         "license_data": {"latest": 1024},
-                        "shmem_index": {
-                            "used": 512,
-                        },
-                        "pmem_index": {
+                        "shmem_index": {"used": 512},
+                        "pmem_sindex": {
                             "total": 1024,
                             "used": 256,
                             "used_pct": 25.0,
                             "avail": 768,
                             "avail_pct": 75.0,
                         },
-                        "memory": {
+                        "data_memory": {
                             "total": 2048,
                             "used": 1024,
                             "used_pct": 50.0,
@@ -2283,17 +2309,15 @@ class CreateSummaryTests(unittest.TestCase):
                     "NAMESPACES": {
                         "test": {
                             "index_type": "shmem",
-                            "shmem_index": {
-                                "used": 512,
-                            },
-                            "pmem_index": {
+                            "shmem_index": {"used": 512},
+                            "pmem_sindex": {
                                 "total": 1024,
                                 "used": 256,
                                 "used_pct": 25.0,
                                 "avail": 768,
                                 "avail_pct": 75.0,
                             },
-                            "memory": {
+                            "data_memory": {
                                 "total": 2048,
                                 "used": 1024,
                                 "used_pct": 50.0,
@@ -2307,7 +2331,7 @@ class CreateSummaryTests(unittest.TestCase):
                     },
                 },
             ),
-            # Test sindex (flash) creates new flash_index when PI is shmem
+            # shmem PI + flash SI → shmem_index and flash_sindex
             create_tc(
                 ns_stats={
                     "1.1.1.1": {
@@ -2336,17 +2360,15 @@ class CreateSummaryTests(unittest.TestCase):
                         "active_features": ["Index-on-shmem"],
                         "ns_count": 1,
                         "license_data": {"latest": 1024},
-                        "shmem_index": {
-                            "used": 512,
-                        },
-                        "flash_index": {
+                        "shmem_index": {"used": 512},
+                        "flash_sindex": {
                             "total": 1024,
                             "used": 256,
                             "used_pct": 25.0,
                             "avail": 768,
                             "avail_pct": 75.0,
                         },
-                        "memory": {
+                        "data_memory": {
                             "total": 2048,
                             "used": 1024,
                             "used_pct": 50.0,
@@ -2358,17 +2380,15 @@ class CreateSummaryTests(unittest.TestCase):
                     "NAMESPACES": {
                         "test": {
                             "index_type": "shmem",
-                            "shmem_index": {
-                                "used": 512,
-                            },
-                            "flash_index": {
+                            "shmem_index": {"used": 512},
+                            "flash_sindex": {
                                 "total": 1024,
                                 "used": 256,
                                 "used_pct": 25.0,
                                 "avail": 768,
                                 "avail_pct": 75.0,
                             },
-                            "memory": {
+                            "data_memory": {
                                 "total": 2048,
                                 "used": 1024,
                                 "used_pct": 50.0,
@@ -2382,7 +2402,7 @@ class CreateSummaryTests(unittest.TestCase):
                     },
                 },
             ),
-            # Test sindex (shmem default) creates new shmem_index when PI is flash
+            # flash PI + shmem-default SI (no sindex-type set) → flash_index and shmem_sindex
             create_tc(
                 ns_stats={
                     "1.1.1.1": {
@@ -2417,10 +2437,8 @@ class CreateSummaryTests(unittest.TestCase):
                             "avail": 1536,
                             "avail_pct": 75.0,
                         },
-                        "shmem_index": {
-                            "used": 256,
-                        },
-                        "device": {
+                        "shmem_sindex": {"used": 256},
+                        "data_device": {
                             "total": 4096,
                             "used": 1024,
                             "used_pct": 25.0,
@@ -2439,10 +2457,8 @@ class CreateSummaryTests(unittest.TestCase):
                                 "avail": 1536,
                                 "avail_pct": 75.0,
                             },
-                            "shmem_index": {
-                                "used": 256,
-                            },
-                            "device": {
+                            "shmem_sindex": {"used": 256},
+                            "data_device": {
                                 "total": 4096,
                                 "used": 1024,
                                 "used_pct": 25.0,
@@ -2456,7 +2472,7 @@ class CreateSummaryTests(unittest.TestCase):
                     },
                 },
             ),
-            # Test set_index creates new shmem_index when PI is on flash
+            # flash PI + set_index → flash_index and set_index (not folded into shmem_index)
             create_tc(
                 ns_stats={
                     "1.1.1.1": {
@@ -2491,10 +2507,8 @@ class CreateSummaryTests(unittest.TestCase):
                             "avail": 1536,
                             "avail_pct": 75.0,
                         },
-                        "shmem_index": {
-                            "used": 128,
-                        },
-                        "device": {
+                        "set_index": {"used": 128},
+                        "data_device": {
                             "total": 4096,
                             "used": 1024,
                             "used_pct": 25.0,
@@ -2513,10 +2527,8 @@ class CreateSummaryTests(unittest.TestCase):
                                 "avail": 1536,
                                 "avail_pct": 75.0,
                             },
-                            "shmem_index": {
-                                "used": 128,
-                            },
-                            "device": {
+                            "set_index": {"used": 128},
+                            "data_device": {
                                 "total": 4096,
                                 "used": 1024,
                                 "used_pct": 25.0,
@@ -2525,6 +2537,772 @@ class CreateSummaryTests(unittest.TestCase):
                             },
                             "repl_factor": [1],
                             "license_data": {"latest": 1024},
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
+            # persisted SI without mounts-budget → used-only entry, no total
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "index_used_bytes": 512,
+                            "sindex_used_bytes": 256,
+                            "data_used_bytes": 1024,
+                            "data_total_bytes": 2048,
+                            "data_avail_pct": 50,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "memory",
+                            "index-type": "shmem",
+                            "sindex-type": "pmem",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-shmem"],
+                        "ns_count": 1,
+                        "license_data": {"latest": 1024},
+                        "shmem_index": {"used": 512},
+                        "pmem_sindex": {"used": 256},
+                        "data_memory": {
+                            "total": 2048,
+                            "used": 1024,
+                            "used_pct": 50.0,
+                            "avail": 1024.0,
+                            "avail_pct": 50.0,
+                        },
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "shmem",
+                            "shmem_index": {"used": 512},
+                            "pmem_sindex": {"used": 256},
+                            "data_memory": {
+                                "total": 2048,
+                                "used": 1024,
+                                "used_pct": 50.0,
+                                "avail": 1024.0,
+                                "avail_pct": 50.0,
+                            },
+                            "repl_factor": [1],
+                            "license_data": {"latest": 1024},
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
+            # system_memory cluster line from service_stats system_free_mem_pct
+            # (averaged across nodes; no namespace-level system_memory).
+            create_tc(
+                service_stats={
+                    "1.1.1.1": {"system_free_mem_pct": 80},
+                    "2.2.2.2": {"system_free_mem_pct": 60},
+                },
+                ns_stats={
+                    "1.1.1.1": {"test": {"index_used_bytes": 100}},
+                    "2.2.2.2": {"test": {"index_used_bytes": 100}},
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "memory",
+                            "index-type": "shmem",
+                            "replication-factor": 1,
+                        },
+                    },
+                    "2.2.2.2": {
+                        "test": {
+                            "storage-engine": "memory",
+                            "index-type": "shmem",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-shmem"],
+                        "ns_count": 1,
+                        "cluster_size": [0],
+                        "shmem_index": {"used": 200},
+                        "system_memory": {
+                            "used_pct": 30.0,
+                            "avail_pct": 70.0,
+                        },
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "shmem",
+                            "shmem_index": {"used": 200},
+                            "repl_factor": [1],
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
+            # multi-namespace cluster aggregation: pmem sindex sums across namespaces
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "index_used_bytes": 100,
+                            "sindex_used_bytes": 256,
+                        },
+                        "bar": {
+                            "index_used_bytes": 100,
+                            "sindex_used_bytes": 256,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "memory",
+                            "index-type": "shmem",
+                            "sindex-type": "pmem",
+                            "sindex-type.mounts-budget": "1024",
+                            "replication-factor": 1,
+                        },
+                        "bar": {
+                            "storage-engine": "memory",
+                            "index-type": "shmem",
+                            "sindex-type": "pmem",
+                            "sindex-type.mounts-budget": "1024",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-shmem"],
+                        "ns_count": 2,
+                        "shmem_index": {"used": 200},
+                        "pmem_sindex": {
+                            "total": 2048,
+                            "used": 512,
+                            "used_pct": 25.0,
+                            "avail": 1536,
+                            "avail_pct": 75.0,
+                        },
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "shmem",
+                            "shmem_index": {"used": 100},
+                            "pmem_sindex": {
+                                "total": 1024,
+                                "used": 256,
+                                "used_pct": 25.0,
+                                "avail": 768,
+                                "avail_pct": 75.0,
+                            },
+                            "repl_factor": [1],
+                            "compression_enabled": False,
+                        },
+                        "bar": {
+                            "index_type": "shmem",
+                            "shmem_index": {"used": 100},
+                            "pmem_sindex": {
+                                "total": 1024,
+                                "used": 256,
+                                "used_pct": 25.0,
+                                "avail": 768,
+                                "avail_pct": 75.0,
+                            },
+                            "repl_factor": [1],
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
+            # No sindex / no set_index → no sindex/set_index keys in summary
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "index_used_bytes": 512,
+                            "data_used_bytes": 1024,
+                            "data_total_bytes": 2048,
+                            "data_avail_pct": 50,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "memory",
+                            "index-type": "shmem",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-shmem"],
+                        "ns_count": 1,
+                        "license_data": {"latest": 1024},
+                        "shmem_index": {"used": 512},
+                        "data_memory": {
+                            "total": 2048,
+                            "used": 1024,
+                            "used_pct": 50.0,
+                            "avail": 1024.0,
+                            "avail_pct": 50.0,
+                        },
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "shmem",
+                            "shmem_index": {"used": 512},
+                            "data_memory": {
+                                "total": 2048,
+                                "used": 1024,
+                                "used_pct": 50.0,
+                                "avail": 1024.0,
+                                "avail_pct": 50.0,
+                            },
+                            "repl_factor": [1],
+                            "license_data": {"latest": 1024},
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
+            # indexes_memory: shmem PI + shmem SI + set_index, all draw on the
+            # shared budget → total/used/used_pct/avail/avail_pct populated.
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "index_used_bytes": 512,
+                            "sindex_used_bytes": 256,
+                            "set_index_used_bytes": 128,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "memory",
+                            "index-type": "shmem",
+                            "indexes-memory-budget": "4096",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-shmem"],
+                        "ns_count": 1,
+                        "shmem_index": {"used": 512},
+                        "shmem_sindex": {"used": 256},
+                        "set_index": {"used": 128},
+                        "indexes_memory": {
+                            "total": 4096,
+                            "used": 896,
+                            "used_pct": 21.875,
+                            "avail": 3200,
+                            "avail_pct": 78.125,
+                        },
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "shmem",
+                            "shmem_index": {"used": 512},
+                            "shmem_sindex": {"used": 256},
+                            "set_index": {"used": 128},
+                            "indexes_memory": {
+                                "total": 4096,
+                                "used": 896,
+                                "used_pct": 21.875,
+                                "avail": 3200,
+                                "avail_pct": 78.125,
+                            },
+                            "repl_factor": [1],
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
+            # indexes_memory: persisted PI is excluded from the budget tally
+            # (mirrors server eval_stop_writes) — only SI + set_index count.
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "index_used_bytes": 10000,  # excluded (flash PI)
+                            "sindex_used_bytes": 256,
+                            "set_index_used_bytes": 0,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "device",
+                            "index-type": "flash",
+                            "index-type.mounts-budget": "100000",
+                            "indexes-memory-budget": "2048",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-flash"],
+                        "ns_count": 1,
+                        "flash_index": {
+                            "total": 100000,
+                            "used": 10000,
+                            "used_pct": 10.0,
+                            "avail": 90000,
+                            "avail_pct": 90.0,
+                        },
+                        "shmem_sindex": {"used": 256},
+                        "indexes_memory": {
+                            "total": 2048,
+                            "used": 256,
+                            "used_pct": 12.5,
+                            "avail": 1792,
+                            "avail_pct": 87.5,
+                        },
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "flash",
+                            "flash_index": {
+                                "total": 100000,
+                                "used": 10000,
+                                "used_pct": 10.0,
+                                "avail": 90000,
+                                "avail_pct": 90.0,
+                            },
+                            "shmem_sindex": {"used": 256},
+                            "indexes_memory": {
+                                "total": 2048,
+                                "used": 256,
+                                "used_pct": 12.5,
+                                "avail": 1792,
+                                "avail_pct": 87.5,
+                            },
+                            "repl_factor": [1],
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
+            # indexes_memory: both PI and SI persisted → only set_index counts.
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "index_used_bytes": 10000,  # excluded (pmem PI)
+                            "sindex_used_bytes": 8000,  # excluded (pmem SI)
+                            "set_index_used_bytes": 128,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "device",
+                            "index-type": "pmem",
+                            "index-type.mounts-budget": "100000",
+                            "sindex-type": "pmem",
+                            "sindex-type.mounts-budget": "100000",
+                            "indexes-memory-budget": "1024",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-pmem"],
+                        "ns_count": 1,
+                        "pmem_index": {
+                            "total": 100000,
+                            "used": 10000,
+                            "used_pct": 10.0,
+                            "avail": 90000,
+                            "avail_pct": 90.0,
+                        },
+                        "pmem_sindex": {
+                            "total": 100000,
+                            "used": 8000,
+                            "used_pct": 8.0,
+                            "avail": 92000,
+                            "avail_pct": 92.0,
+                        },
+                        "set_index": {"used": 128},
+                        "indexes_memory": {
+                            "total": 1024,
+                            "used": 128,
+                            "used_pct": 12.5,
+                            "avail": 896,
+                            "avail_pct": 87.5,
+                        },
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "pmem",
+                            "pmem_index": {
+                                "total": 100000,
+                                "used": 10000,
+                                "used_pct": 10.0,
+                                "avail": 90000,
+                                "avail_pct": 90.0,
+                            },
+                            "pmem_sindex": {
+                                "total": 100000,
+                                "used": 8000,
+                                "used_pct": 8.0,
+                                "avail": 92000,
+                                "avail_pct": 92.0,
+                            },
+                            "set_index": {"used": 128},
+                            "indexes_memory": {
+                                "total": 1024,
+                                "used": 128,
+                                "used_pct": 12.5,
+                                "avail": 896,
+                                "avail_pct": 87.5,
+                            },
+                            "repl_factor": [1],
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
+            # indexes_memory: budget=0 (default) → no indexes_memory key emitted.
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "index_used_bytes": 512,
+                            "sindex_used_bytes": 256,
+                            "set_index_used_bytes": 128,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "memory",
+                            "index-type": "shmem",
+                            "indexes-memory-budget": "0",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-shmem"],
+                        "ns_count": 1,
+                        "shmem_index": {"used": 512},
+                        "shmem_sindex": {"used": 256},
+                        "set_index": {"used": 128},
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "shmem",
+                            "shmem_index": {"used": 512},
+                            "shmem_sindex": {"used": 256},
+                            "set_index": {"used": 128},
+                            "repl_factor": [1],
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
+            # indexes_memory: cluster-level totals sum across namespaces.
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "index_used_bytes": 100,
+                            "sindex_used_bytes": 50,
+                        },
+                        "bar": {
+                            "index_used_bytes": 200,
+                            "sindex_used_bytes": 100,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "memory",
+                            "index-type": "shmem",
+                            "indexes-memory-budget": "1000",
+                            "replication-factor": 1,
+                        },
+                        "bar": {
+                            "storage-engine": "memory",
+                            "index-type": "shmem",
+                            "indexes-memory-budget": "2000",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "active_features": ["Index-on-shmem"],
+                        "ns_count": 2,
+                        "shmem_index": {"used": 300},
+                        "shmem_sindex": {"used": 150},
+                        # cluster: total 3000 (1000+2000), used 450 (150+300)
+                        "indexes_memory": {
+                            "total": 3000,
+                            "used": 450,
+                            "used_pct": 15.0,
+                            "avail": 2550,
+                            "avail_pct": 85.0,
+                        },
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "shmem",
+                            "shmem_index": {"used": 100},
+                            "shmem_sindex": {"used": 50},
+                            "indexes_memory": {
+                                "total": 1000,
+                                "used": 150,
+                                "used_pct": 15.0,
+                                "avail": 850,
+                                "avail_pct": 85.0,
+                            },
+                            "repl_factor": [1],
+                            "compression_enabled": False,
+                        },
+                        "bar": {
+                            "index_type": "shmem",
+                            "shmem_index": {"used": 200},
+                            "shmem_sindex": {"used": 100},
+                            "indexes_memory": {
+                                "total": 2000,
+                                "used": 300,
+                                "used_pct": 15.0,
+                                "avail": 1700,
+                                "avail_pct": 85.0,
+                            },
+                            "repl_factor": [1],
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
+            # Backward-compat: pre-7.0 SI on flash uses sindex_flash_used_bytes
+            # and sindex-type.mounts-size-limit, populating flash_sindex.
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "sindex_flash_used_bytes": 256,
+                            "device_used_bytes": 1024,
+                            "device_total_bytes": 4096,
+                            "device_available_pct": 75,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "device",
+                            "sindex-type": "flash",
+                            "sindex-type.mounts-size-limit": "1024",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "ns_count": 1,
+                        "license_data": {"latest": 1024},
+                        "flash_sindex": {
+                            "total": 1024,
+                            "used": 256,
+                            "used_pct": 25.0,
+                            "avail": 768,
+                            "avail_pct": 75.0,
+                        },
+                        "data_device": {
+                            "total": 4096,
+                            "used": 1024,
+                            "used_pct": 25.0,
+                            "avail": 3072.0,
+                            "avail_pct": 75.0,
+                        },
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "license_data": {"latest": 1024},
+                            "flash_sindex": {
+                                "total": 1024,
+                                "used": 256,
+                                "used_pct": 25.0,
+                                "avail": 768,
+                                "avail_pct": 75.0,
+                            },
+                            "data_device": {
+                                "total": 4096,
+                                "used": 1024,
+                                "used_pct": 25.0,
+                                "avail": 3072.0,
+                                "avail_pct": 75.0,
+                            },
+                            "repl_factor": [1],
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
+            # Backward-compat: pre-7.0 in-memory PI uses memory_used_index_bytes,
+            # falling through to shmem_index.
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "memory_used_index_bytes": 512,
+                            "memory-size": 2048,
+                            "memory_used_bytes": 1024,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "memory",
+                            "index-type": "shmem",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "ns_count": 1,
+                        "active_features": ["Index-on-shmem"],
+                        "license_data": {"latest": 512},
+                        "shmem_index": {"used": 512},
+                        "memory_data_and_indexes": {
+                            "total": 2048,
+                            "used": 1024,
+                            "used_pct": 50.0,
+                            "avail": 1024,
+                            "avail_pct": 50.0,
+                        },
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "index_type": "shmem",
+                            "license_data": {"latest": 512},
+                            "shmem_index": {"used": 512},
+                            "memory_data_and_indexes": {
+                                "total": 2048,
+                                "used": 1024,
+                                "used_pct": 50.0,
+                                "avail": 1024,
+                                "avail_pct": 50.0,
+                            },
+                            "repl_factor": [1],
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
+            # Backward-compat: pre-7.0 in-memory SI uses memory_used_sindex_bytes,
+            # falling through to shmem_sindex.
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "memory_used_sindex_bytes": 256,
+                            "memory-size": 2048,
+                            "memory_used_bytes": 1024,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "storage-engine": "memory",
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "ns_count": 1,
+                        "active_features": ["SIndex"],
+                        "shmem_sindex": {"used": 256},
+                        "memory_data_and_indexes": {
+                            "total": 2048,
+                            "used": 1024,
+                            "used_pct": 50.0,
+                            "avail": 1024,
+                            "avail_pct": 50.0,
+                        },
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "shmem_sindex": {"used": 256},
+                            "memory_data_and_indexes": {
+                                "total": 2048,
+                                "used": 1024,
+                                "used_pct": 50.0,
+                                "avail": 1024,
+                                "avail_pct": 50.0,
+                            },
+                            "repl_factor": [1],
+                            "compression_enabled": False,
+                        },
+                    },
+                },
+            ),
+            # Backward-compat: pre-7.0 set_index uses memory_used_set_index_bytes.
+            create_tc(
+                ns_stats={
+                    "1.1.1.1": {
+                        "test": {
+                            "memory_used_set_index_bytes": 128,
+                        },
+                    },
+                },
+                ns_configs={
+                    "1.1.1.1": {
+                        "test": {
+                            "replication-factor": 1,
+                        },
+                    },
+                },
+                expected={
+                    "CLUSTER": {
+                        "ns_count": 1,
+                        "set_index": {"used": 128},
+                        "compression_enabled": False,
+                    },
+                    "NAMESPACES": {
+                        "test": {
+                            "set_index": {"used": 128},
+                            "repl_factor": [1],
                             "compression_enabled": False,
                         },
                     },

--- a/test/unit/view/test_view.py
+++ b/test/unit/view/test_view.py
@@ -774,21 +774,21 @@ class CliViewTest(unittest.TestCase):
                 "used_pct": 4,
                 "avail_pct": 5,
             },
-            "memory": {
+            "data_memory": {
                 "total": 1,
                 "used": 2,
                 "avail": 3,
                 "used_pct": 4,
                 "avail_pct": 5,
             },
-            "device": {
+            "data_device": {
                 "total": 1,
                 "used": 2,
                 "avail": 3,
                 "used_pct": 4,
                 "avail_pct": 5,
             },
-            "pmem": {
+            "data_pmem": {
                 "total": 1,
                 "used": 2,
                 "avail": 3,
@@ -821,9 +821,9 @@ class CliViewTest(unittest.TestCase):
    7.   Flash Index              :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
    8.   Shmem Index              :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
    9.   Memory                   :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B) includes data, pindex, and sindex
-   10.  Memory                   :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   11.  Device                   :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   12.  Pmem                     :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   10.  Data Memory              :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   11.  Data Device              :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   12.  Data Pmem                :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
    13.  License Usage            :  Latest (2023-10-04T20:35:42+00:00): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
    14.  Active Namespaces        :  2 of 2
    15.  Active Features          :  Compression, Depression
@@ -877,21 +877,21 @@ class CliViewTest(unittest.TestCase):
                     "used_pct": 4,
                     "avail_pct": 5,
                 },
-                "memory": {
+                "data_memory": {
                     "total": 5,
                     "used": 2,
                     "avail": 3,
                     "used_pct": 4,
                     "avail_pct": 5,
                 },
-                "device": {
+                "data_device": {
                     "total": 6,
                     "used": 2,
                     "avail": 3,
                     "used_pct": 4,
                     "avail_pct": 5,
                 },
-                "pmem": {
+                "data_pmem": {
                     "total": 7,
                     "used": 2,
                     "avail": 3,
@@ -948,21 +948,21 @@ class CliViewTest(unittest.TestCase):
                     "used_pct": 4,
                     "avail_pct": 5,
                 },
-                "memory": {
+                "data_memory": {
                     "total": 5,
                     "used": 2,
                     "avail": 3,
                     "used_pct": 4,
                     "avail_pct": 5,
                 },
-                "device": {
+                "data_device": {
                     "total": 6,
                     "used": 2,
                     "avail": 3,
                     "used_pct": 4,
                     "avail_pct": 5,
                 },
-                "pmem": {
+                "data_pmem": {
                     "total": 7,
                     "used": 2,
                     "avail": 3,
@@ -995,9 +995,9 @@ class CliViewTest(unittest.TestCase):
    3.   Flash Index              :  Total 2.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
    4.   Shmem Index              :  Total 3.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
    5.   Memory                   :  Total 4.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B) includes data, pindex, and sindex
-   6.   Memory                   :  Total 5.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   7.   Device                   :  Total 6.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   8.   Pmem                     :  Total 7.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   6.   Data Memory              :  Total 5.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   7.   Data Device              :  Total 6.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   8.   Data Pmem                :  Total 7.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
    9.   License Usage            :  Latest (2023-10-04T20:35:42+00:00): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
    10.  Replication Factor       :  1
    11.  Post-Write-Queue Hit-Rate:  1.000  
@@ -1012,9 +1012,9 @@ class CliViewTest(unittest.TestCase):
    3.   Flash Index              :  Total 2.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
    4.   Shmem Index              :  Total 3.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
    5.   Memory                   :  Total 4.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B) includes data, pindex, and sindex
-   6.   Memory                   :  Total 5.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   7.   Device                   :  Total 6.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   8.   Pmem                     :  Total 7.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   6.   Data Memory              :  Total 5.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   7.   Data Device              :  Total 6.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   8.   Data Pmem                :  Total 7.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
    9.   License Usage            :  Latest (2023-10-04T20:35:42+00:00): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
    10.  Replication Factor       :  1
    11.  Post-Write-Queue Hit-Rate:  1.000  

--- a/test/unit/view/test_view.py
+++ b/test/unit/view/test_view.py
@@ -746,6 +746,11 @@ class CliViewTest(unittest.TestCase):
             "device_count": 2,
             "device_count_per_node": 2,
             "device_count_same_across_nodes": True,
+            "system_memory": {
+                "used": 0,
+                "used_pct": 19.5,
+                "avail_pct": 80.5,
+            },
             "pmem_index": {
                 "total": 1,
                 "used": 2,
@@ -761,6 +766,29 @@ class CliViewTest(unittest.TestCase):
                 "avail_pct": 5,
             },
             "shmem_index": {
+                "total": 1,
+                "used": 2,
+                "avail": 3,
+                "used_pct": 4,
+                "avail_pct": 5,
+            },
+            "pmem_sindex": {
+                "total": 1,
+                "used": 2,
+                "avail": 3,
+                "used_pct": 4,
+                "avail_pct": 5,
+            },
+            "flash_sindex": {
+                "total": 1,
+                "used": 2,
+                "avail": 3,
+                "used_pct": 4,
+                "avail_pct": 5,
+            },
+            "shmem_sindex": {"used": 2},
+            "set_index": {"used": 2},
+            "indexes_memory": {
                 "total": 1,
                 "used": 2,
                 "avail": 3,
@@ -817,16 +845,22 @@ class CliViewTest(unittest.TestCase):
    3.   OS Version               :  Linux 4.15.0-106-generic
    4.   Cluster Size             :  1
    5.   Devices                  :  Total 2, per-node 2
-   6.   Pmem Index               :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
-   7.   Flash Index              :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
-   8.   Shmem Index              :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
-   9.   Memory                   :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B) includes data, pindex, and sindex
-   10.  Data Memory              :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   11.  Data Device              :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   12.  Data Pmem                :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   13.  License Usage            :  Latest (2023-10-04T20:35:42+00:00): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
-   14.  Active Namespaces        :  2 of 2
-   15.  Active Features          :  Compression, Depression
+   6.   System Memory            :  80.50% free
+   7.   Pmem Index               :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   8.   Flash Index              :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   9.   Shmem Index              :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   10.  Pmem Sindex              :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   11.  Flash Sindex             :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   12.  Shmem Sindex             :  2.000 B used
+   13.  Set Index                :  2.000 B used
+   14.  Indexes Memory           :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   15.  Memory                   :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B) includes data, pindex, and sindex
+   16.  Data Memory              :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   17.  Data Device              :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   18.  Data Pmem                :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   19.  License Usage            :  Latest (2023-10-04T20:35:42+00:00): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
+   20.  Active Namespaces        :  2 of 2
+   21.  Active Features          :  Compression, Depression
 
 """
 
@@ -865,6 +899,29 @@ class CliViewTest(unittest.TestCase):
                 },
                 "shmem_index": {
                     "total": 3,
+                    "used": 2,
+                    "avail": 3,
+                    "used_pct": 4,
+                    "avail_pct": 5,
+                },
+                "pmem_sindex": {
+                    "total": 1,
+                    "used": 2,
+                    "avail": 3,
+                    "used_pct": 4,
+                    "avail_pct": 5,
+                },
+                "flash_sindex": {
+                    "total": 2,
+                    "used": 2,
+                    "avail": 3,
+                    "used_pct": 4,
+                    "avail_pct": 5,
+                },
+                "shmem_sindex": {"used": 2},
+                "set_index": {"used": 2},
+                "indexes_memory": {
+                    "total": 8,
                     "used": 2,
                     "avail": 3,
                     "used_pct": 4,
@@ -941,6 +998,29 @@ class CliViewTest(unittest.TestCase):
                     "used_pct": 4,
                     "avail_pct": 5,
                 },
+                "pmem_sindex": {
+                    "total": 1,
+                    "used": 2,
+                    "avail": 3,
+                    "used_pct": 4,
+                    "avail_pct": 5,
+                },
+                "flash_sindex": {
+                    "total": 2,
+                    "used": 2,
+                    "avail": 3,
+                    "used_pct": 4,
+                    "avail_pct": 5,
+                },
+                "shmem_sindex": {"used": 2},
+                "set_index": {"used": 2},
+                "indexes_memory": {
+                    "total": 8,
+                    "used": 2,
+                    "avail": 3,
+                    "used_pct": 4,
+                    "avail_pct": 5,
+                },
                 "memory_data_and_indexes": {
                     "total": 4,
                     "used": 2,
@@ -994,16 +1074,21 @@ class CliViewTest(unittest.TestCase):
    2.   Pmem Index               :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
    3.   Flash Index              :  Total 2.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
    4.   Shmem Index              :  Total 3.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
-   5.   Memory                   :  Total 4.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B) includes data, pindex, and sindex
-   6.   Data Memory              :  Total 5.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   7.   Data Device              :  Total 6.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   8.   Data Pmem                :  Total 7.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   9.   License Usage            :  Latest (2023-10-04T20:35:42+00:00): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
-   10.  Replication Factor       :  1
-   11.  Post-Write-Queue Hit-Rate:  1.000  
-   12.  Rack-aware               :  True
-   13.  Master Objects           :  2.000  
-   14.  Compression-ratio        :  0.5
+   5.   Pmem Sindex              :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   6.   Flash Sindex             :  Total 2.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   7.   Shmem Sindex             :  2.000 B used
+   8.   Set Index                :  2.000 B used
+   9.   Indexes Memory           :  Total 8.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   10.  Memory                   :  Total 4.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B) includes data, pindex, and sindex
+   11.  Data Memory              :  Total 5.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   12.  Data Device              :  Total 6.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   13.  Data Pmem                :  Total 7.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   14.  License Usage            :  Latest (2023-10-04T20:35:42+00:00): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
+   15.  Replication Factor       :  1
+   16.  Post-Write-Queue Hit-Rate:  1.000  
+   17.  Rack-aware               :  True
+   18.  Master Objects           :  2.000  
+   19.  Compression-ratio        :  0.5
 
    {terminal.fg_red()}bar{terminal.fg_clear()}
    ===
@@ -1011,16 +1096,21 @@ class CliViewTest(unittest.TestCase):
    2.   Pmem Index               :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
    3.   Flash Index              :  Total 2.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
    4.   Shmem Index              :  Total 3.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
-   5.   Memory                   :  Total 4.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B) includes data, pindex, and sindex
-   6.   Data Memory              :  Total 5.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   7.   Data Device              :  Total 6.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   8.   Data Pmem                :  Total 7.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
-   9.   License Usage            :  Latest (2023-10-04T20:35:42+00:00): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
-   10.  Replication Factor       :  1
-   11.  Post-Write-Queue Hit-Rate:  1.000  
-   12.  Rack-aware               :  False
-   13.  Master Objects           :  2.000  
-   14.  Compression-ratio        :  0.5
+   5.   Pmem Sindex              :  Total 1.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   6.   Flash Sindex             :  Total 2.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   7.   Shmem Sindex             :  2.000 B used
+   8.   Set Index                :  2.000 B used
+   9.   Indexes Memory           :  Total 8.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B)
+   10.  Memory                   :  Total 4.000 B, 4.00% used (2.000 B), 5.00% available (3.000 B) includes data, pindex, and sindex
+   11.  Data Memory              :  Total 5.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   12.  Data Device              :  Total 6.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   13.  Data Pmem                :  Total 7.000 B, 4.00% used (2.000 B), 5.00% available contiguous space (3.000 B)
+   14.  License Usage            :  Latest (2023-10-04T20:35:42+00:00): 2.000 B  Min: 3.000 B  Max: 4.000 B  Avg: 5.000 B 
+   15.  Replication Factor       :  1
+   16.  Post-Write-Queue Hit-Rate:  1.000  
+   17.  Rack-aware               :  False
+   18.  Master Objects           :  2.000  
+   19.  Compression-ratio        :  0.5
 """
 
         actual = CliView._summary_namespace_list_view(ns_data)
@@ -1471,6 +1561,69 @@ class CliViewTest(unittest.TestCase):
         # Should not have a Used% column for sindex
         self.assertNotIn("Used%", output)
         self.assertNotIn("SIndex Used%", output)
+
+    def test_info_namespace_usage_renders_system_memory_stop_pct(self):
+        """The System Memory subgroup must surface stop-writes-sys-memory-pct as a Stop% column."""
+
+        ns_stats = {
+            "1.1.1.1": {
+                "test": {
+                    "stop-writes-sys-memory-pct": "90",
+                    "evict-sys-memory-pct": "85",
+                    "storage-engine": "memory",
+                    "index-type": "shmem",
+                    "sindex-type": "shmem",
+                }
+            }
+        }
+        service_stats = {"1.1.1.1": {"system_free_mem_pct": "40"}}
+        node_names = {"1.1.1.1": "node1"}
+        node_ids = {"1.1.1.1": "NODE1"}
+        principal = "test-principal"
+
+        self.cluster_mock = MagicMock()
+        self.cluster_mock.get_node_names.return_value = node_names
+        self.cluster_mock.get_node_ids.return_value = node_ids
+        self.cluster_mock.get_expected_principal.return_value = principal
+
+        patch.stopall()
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            CliView.info_namespace_usage(
+                ns_stats, service_stats, self.cluster_mock, timestamp="test-stamp"
+            )
+        output = f.getvalue()
+
+        self.assertIn("System Memory", output)
+        self.assertIn("Stop%", output)
+        self.assertIn("90.0 %", output)  # threshold formatted as pct
+
+    def test_info_namespace_usage_sheet_has_stop_pct_field(self):
+        """Verify lib/view/templates.py wires Stop% -> stop-writes-sys-memory-pct in the System Memory subgroup."""
+        from lib.view.sheet.decleration import Subgroup
+
+        system_memory_subgroup = next(
+            (
+                f
+                for f in templates.info_namespace_usage_sheet.fields
+                if isinstance(f, Subgroup) and f.title == "System Memory"
+            ),
+            None,
+        )
+        self.assertIsNotNone(
+            system_memory_subgroup,
+            "info_namespace_usage_sheet missing 'System Memory' subgroup",
+        )
+
+        field_titles = [f.title for f in system_memory_subgroup.fields]
+        self.assertIn("Stop%", field_titles)
+
+        stop_pct_field = next(
+            f for f in system_memory_subgroup.fields if f.title == "Stop%"
+        )
+        # Projector should target the new stop-writes-sys-memory-pct config key.
+        self.assertIn("stop-writes-sys-memory-pct", stop_pct_field.projector.keys)
 
     def test_info_transactions_monitors_with_with_modifier(self):
         ns_stats = {"1.1.1.1": {"test": {"mrt_monitors": 100}}}


### PR DESCRIPTION
**Description:**

Refactors the `summary` command's memory accounting so each component (primary index, secondary index, set index, data) is reported on its own line, and aligns the index-memory stop-writes calculation with the server's `eval_stop_writes()` exactly. Adds a `System Memory` cluster line, a combined `Indexes Memory` budget line, and renames data lines to make the data/index distinction explicit.

**Summary Output Changes:**

- **Bifurcated index reporting** — Secondary index, set index, and primary index now each get their own summary lines (`Pmem/Flash/Shmem Sindex`, `Set Index`, `Pmem/Flash/Shmem Index`). Previously sindex and set-index were folded into the primary-index line.

- **Renamed data lines** to make "data, not indexes" explicit:
  - `Memory` → `Data Memory`
  - `Device` → `Data Device`
  - `Pmem` → `Data Pmem`
  - Underlying dict keys renamed to match (`memory` → `data_memory`, etc.).

- **New `System Memory` cluster line** showing used%/avail% derived from `system_free_mem_pct` — a quick "is this machine running out of RAM?" indicator.

- **New `Indexes Memory` line** (cluster + namespace) that mirrors the server's `eval_stop_writes()` `ixs_sz`: combines non-persisted PI + non-persisted SI + set_index against `indexes-memory-budget`. Emitted only when the budget is configured (>0).

**Stop-Writes Changes:**

- The synthesized `indexes_memory_used` metric now mirrors the server's combined `ixs_sz` exactly (PI/SI excluded when persisted) and is checked against `indexes-memory-budget`.
- Added `Stop%` column for `stop-writes-sys-memory-pct` in the System Memory subgroup of `info namespace`.

**Health Check Changes:**

- Index memory check now uses the server's pre-computed `indexes_memory_used_pct` directly rather than approximating client-side.
- Added a sindex mounts-budget check (`sindex_used_bytes` vs `sindex-type.mounts-budget`).

**Backward Compatibility:**

- Pre-7.0 metric names handled as fallbacks: `memory_used_index_bytes`, `memory_used_sindex_bytes`, `memory_used_set_index_bytes`, `sindex_pmem_used_bytes` / `sindex_flash_used_bytes`, plus pre-7.0 `mounts-size-limit` budgets. Older servers continue to render correctly with the new bifurcation.
- The `Indexes Memory` line is gated on `indexes-memory-budget` (7.1+ config); older servers simply don't show it.
