### PR TITLE
fix: TOOLS-3482 Update best practices documentation link

### DIFF
--- a/lib/view/view.py
+++ b/lib/view/view.py
@@ -1335,7 +1335,7 @@ class CliView(object):
         )
         CliView.print_result(
             "Following Aerospike's best-practices are required for optimal stability and performance.\n"
-            + "Descriptions of each can be found @ https://docs.aerospike.com/docs/operations/install/linux/bestpractices/index.html"
+            + "Descriptions of each can be found @ https://aerospike.com/docs/database/learn/best-practices"
         )
 
     @staticmethod


### PR DESCRIPTION
## Summary
- Updates the best practices documentation URL in `CliView` from the old `docs.aerospike.com/docs/operations/install/linux/bestpractices/index.html` to the current `aerospike.com/docs/database/learn/best-practices`

## Test plan
- [ ] Verify the link is correct by running `asadm` and checking the best practices output