### PR TITLE
feat: TOOLS-3541 Add ASClusterError and ASNoNodesError for improved error handling in cluster operations

### DIFF
--- a/lib/live_cluster/client/__init__.py
+++ b/lib/live_cluster/client/__init__.py
@@ -20,6 +20,8 @@ from .types import (
     ASInfoConfigError,
     ASProtocolError,
     ASResponse,
+    ASClusterError,
+    ASNoNodesError,
     ASINFO_RESPONSE_OK,
     Addr_Port_TLSName,
 )

--- a/lib/live_cluster/client/cluster.py
+++ b/lib/live_cluster/client/cluster.py
@@ -21,7 +21,11 @@ import inspect
 from OpenSSL import SSL
 from typing import Any, Callable, Coroutine, Union
 from time import time
-from lib.live_cluster.client import ASInfoNotAuthenticatedError, ASProtocolError
+from lib.live_cluster.client import (
+    ASInfoNotAuthenticatedError,
+    ASNoNodesError,
+    ASProtocolError,
+)
 from lib.live_cluster.client.types import Addr_Port_TLSName
 from lib.utils.async_object import AsyncObject
 
@@ -677,7 +681,7 @@ class Cluster(AsyncObject):
         use_nodes = self.get_nodes(nodes)
 
         if len(use_nodes) == 0:
-            raise IOError("Unable to find any Aerospike nodes")
+            raise ASNoNodesError()
 
         async def key_to_method(node) -> tuple[str, Any]:
             node_result = getattr(node, method_name)(*args, **kwargs)
@@ -703,7 +707,7 @@ class Cluster(AsyncObject):
         use_nodes = self.get_nodes(nodes)
 
         if len(use_nodes) == 0:
-            raise IOError("Unable to find any Aerospike nodes")
+            raise ASNoNodesError()
 
         def key_to_method(node):
             node_result = getattr(node, method_name)(*args, **kwargs)

--- a/lib/live_cluster/client/types.py
+++ b/lib/live_cluster/client/types.py
@@ -336,3 +336,23 @@ class ASInfoNotAuthenticatedError(ASInfoResponseError):
 class ASInfoClusterStableError(ASInfoResponseError):
     def __init__(self, server_resp: str):
         super().__init__("Cluster is unstable", server_resp)
+
+
+class ASClusterError(Exception):
+    """Base for cluster-level reachability and state errors surfaced to the user."""
+
+    pass
+
+
+class ASNoNodesError(ASClusterError):
+    """Raised when no live Aerospike node is available to serve a request."""
+
+    DEFAULT_MESSAGE = (
+        "Cannot reach any Aerospike nodes.\n"
+        "  Try: verify the cluster connection options used at startup "
+        "(-h/-p, -U/-P, --auth, --tls-*) and that the service port is "
+        "reachable from this host."
+    )
+
+    def __init__(self, message: str | None = None):
+        super().__init__(message or self.DEFAULT_MESSAGE)

--- a/lib/live_cluster/collectinfo_controller.py
+++ b/lib/live_cluster/collectinfo_controller.py
@@ -21,6 +21,7 @@ import shutil
 import time
 import traceback
 from typing import Any, Callable
+from lib.live_cluster.client import ASNoNodesError
 from lib.live_cluster.client.node import Node
 from lib.live_cluster.logfile_downloader import LogFileDownloader
 from lib.live_cluster import ssh
@@ -930,6 +931,13 @@ class CollectinfoController(LiveClusterCommandController):
             self.failed_cmds = []
 
             try:
+                # Preflight: with no alive nodes there is nothing to collect.
+                # Surface the same typed error the cluster client would raise
+                # deeper in the call stack, so the message and handling stay
+                # consistent.
+                if not self.cluster.get_nodes():
+                    raise ASNoNodesError()
+
                 await self._dump_collectinfo_json(
                     individual_file_prefix,
                     enable_ssh,
@@ -941,6 +949,11 @@ class CollectinfoController(LiveClusterCommandController):
                     snp_count,
                     wait_time,
                 )
+            except ASNoNodesError as e:
+                # No nodes means no data — always fatal, --ignore-errors cannot
+                # produce a partial collectinfo bundle in this case.
+                logger.error(e)
+                return
             except (ssh.SSHError, FileNotFoundError) as e:
                 logger.error(ShellException(e))
                 logger.error(

--- a/lib/utils/logger.py
+++ b/lib/utils/logger.py
@@ -40,6 +40,7 @@ class BaseLogger(logging.Logger, object):
             and not isinstance(msg, ShellException)
             and not isinstance(msg, ASProtocolError)
             and not isinstance(msg, ASInfoError)
+            and not isinstance(msg, ASClusterError)
         ):
             traceback.print_exc()
 
@@ -164,4 +165,5 @@ from lib.base_controller import (  # noqa: E402 - suppress flake warning
 from lib.live_cluster.client import (  # noqa: E402 - suppress flake warning
     ASProtocolError,
     ASInfoError,
+    ASClusterError,
 )

--- a/makefile
+++ b/makefile
@@ -116,6 +116,13 @@ coverage:
 	make unit-cov
 	make integration-cov
 	coverage combine
+	coverage report
+
+.PHONY: unit-coverage
+unit-coverage:
+	coverage erase
+	make unit-cov
+	coverage report
 
 .PHONY: install
 install: uninstall

--- a/test/unit/live_cluster/client/test_cluster.py
+++ b/test/unit/live_cluster/client/test_cluster.py
@@ -24,6 +24,7 @@ from pytest import PytestUnraisableExceptionWarning
 import lib
 from lib.live_cluster.client.cluster import Cluster
 from lib.live_cluster.client.node import Node
+from lib.live_cluster.client.types import ASClusterError, ASNoNodesError
 from lib.utils import constants
 
 
@@ -540,6 +541,60 @@ class ClusterTest(unittest.IsolatedAsyncioTestCase):
         n._info_cinfo.assert_any_call("build", n.ip)
         n = cl.get_node(keys[0])[1]
         n._info_cinfo.assert_any_call("build", n.ip)
+
+    async def test_call_node_method_async_raises_no_nodes_error_when_empty(self):
+        """When no alive nodes are known, call_node_method_async should raise
+        ASNoNodesError (a ShellException-equivalent typed cluster error) rather
+        than a generic IOError. The default message must include actionable
+        remediation hints."""
+        cl = await self.get_cluster_mock(0)
+        # Avoid refreshing during the call so we exercise the no-nodes branch
+        # deterministically.
+        cl.need_to_refresh_cluster = lambda: False
+
+        with self.assertRaises(ASNoNodesError) as ctx:
+            await cl.call_node_method_async(nodes="all", method_name="info_peers")
+
+        # Inherits from the cluster-error base — preserves the contract callers
+        # can match on.
+        self.assertIsInstance(ctx.exception, ASClusterError)
+        # Remediation guidance must reach the user.
+        message = str(ctx.exception)
+        self.assertIn("Cannot reach any Aerospike nodes", message)
+        self.assertIn("-h", message)
+        self.assertIn("Try", message)
+
+    async def test_call_node_method_sync_raises_no_nodes_error_when_empty(self):
+        """Sync sibling: call_node_method must raise ASNoNodesError when no
+        alive nodes exist."""
+        cl = await self.get_cluster_mock(0)
+
+        with self.assertRaises(ASNoNodesError):
+            cl.call_node_method(nodes="all", method_name="info_peers")
+
+    async def test_call_node_method_async_raises_when_named_nodes_unknown(self):
+        """Even with live nodes in the cluster, asking for a specific node
+        that doesn't match anything yields ASNoNodesError — the contract is
+        about resolved-target-set, not just total cluster size."""
+        cl = await self.get_cluster_mock(2)
+        cl.need_to_refresh_cluster = lambda: False
+
+        with self.assertRaises(ASNoNodesError):
+            await cl.call_node_method_async(
+                nodes=["10.255.255.255:3000"], method_name="info", command="build"
+            )
+
+    def test_no_nodes_error_accepts_custom_message(self):
+        """The exception's constructor accepts an explicit override so
+        callers with more context (e.g. an auth-rejected crawl) can
+        surface a more specific reason while keeping the clean-no-traceback
+        contract. When no message is given, the actionable default applies."""
+        custom = ASNoNodesError("cluster auth rejected for user 'admin'")
+        self.assertIn("auth rejected", str(custom))
+
+        default = ASNoNodesError()
+        self.assertIn("Cannot reach any Aerospike nodes", str(default))
+        self.assertIn("Try", str(default))
 
     async def test_is_XDR_enabled(self):
         cl = await self.get_cluster_mock(

--- a/test/unit/live_cluster/test_collectinfo_controller.py
+++ b/test/unit/live_cluster/test_collectinfo_controller.py
@@ -1,0 +1,254 @@
+# Copyright 2013-2025 Aerospike, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import unittest
+import warnings
+from unittest.mock import AsyncMock, Mock, patch, create_autospec
+
+from pytest import PytestUnraisableExceptionWarning
+
+from lib.live_cluster.client.cluster import Cluster
+from lib.live_cluster.client.types import ASNoNodesError
+from lib.live_cluster.collectinfo_controller import CollectinfoController
+from lib.live_cluster.live_cluster_command_controller import (
+    LiveClusterCommandController,
+)
+from lib.view.terminal import terminal
+
+
+class CollectinfoControllerTest(unittest.IsolatedAsyncioTestCase):
+    """Tests for CollectinfoController._run_collectinfo error-handling paths.
+
+    The preflight check is the only branch exercised here — full collectinfo
+    execution requires SSH/cluster fixtures and is covered by e2e tests.
+    """
+
+    async def asyncSetUp(self) -> None:
+        warnings.filterwarnings("error", category=RuntimeWarning)
+        warnings.filterwarnings("error", category=PytestUnraisableExceptionWarning)
+
+        # `_run_collectinfo` calls `terminal.enable_color(False)`, which mutates
+        # module-level globals in `lib.view.terminal.terminal`. Snapshot the
+        # current `color_enabled` state and restore it on teardown so we do not
+        # pollute downstream tests (notably test_view.py and
+        # test_base_controller.py) that depend on the original terminal state.
+        original_color_enabled = terminal.color_enabled
+
+        def _restore_terminal_color():
+            terminal.enable_color(original_color_enabled)
+
+        self.addCleanup(_restore_terminal_color)
+
+        # Freeze time so collectinfo path generation is deterministic.
+        patch(
+            "lib.live_cluster.collectinfo_controller.time.gmtime", autospec=True
+        ).start().return_value = time.gmtime(1693259247)
+
+        # Stub out the path-creation helper so _run_collectinfo does not touch
+        # disk during the preflight.
+        path_info_mock = Mock()
+        path_info_mock.cf_dir = "/tmp/test_collectinfo"
+        path_info_mock.files_prefix = "20230828_214727_"
+        patch(
+            "lib.live_cluster.collectinfo_controller.common.get_collectinfo_path",
+            autospec=True,
+        ).start().return_value = path_info_mock
+
+        self.controller = CollectinfoController()
+        # setup_loggers / teardown_loggers touch real log handlers; bypass them.
+        self.controller.setup_loggers = Mock()
+        self.controller.teardown_loggers = Mock()
+
+        # Inject a mocked cluster on the LiveClusterCommandController class
+        # attribute (that's where the controller looks it up). Restore the
+        # original value on teardown so we don't pollute downstream tests
+        # that rely on the unset/default class-level `cluster`.
+        self._original_cluster = LiveClusterCommandController.cluster
+        self.cluster_mock = create_autospec(Cluster)
+        LiveClusterCommandController.cluster = self.cluster_mock
+
+        def _restore_cluster():
+            LiveClusterCommandController.cluster = self._original_cluster
+
+        self.addCleanup(_restore_cluster)
+
+        self.logger_mock = patch(
+            "lib.live_cluster.collectinfo_controller.logger"
+        ).start()
+
+        self.addCleanup(patch.stopall)
+
+    async def test_preflight_short_circuits_on_no_nodes(self):
+        """When cluster.get_nodes() returns an empty list, _run_collectinfo
+        must log the ASNoNodesError remediation message and return without
+        starting the snapshot loop."""
+        self.cluster_mock.get_nodes.return_value = []
+        self.controller._dump_collectinfo_json = AsyncMock()
+
+        await self.controller._run_collectinfo(
+            ssh_user=None,
+            ssh_pwd=None,
+            ssh_port=None,
+            ssh_key=None,
+            ssh_key_pwd=None,
+            snp_count=1,
+            wait_time=0,
+            ignore_errors=False,
+        )
+
+        # The expensive snapshot path must NOT run.
+        self.controller._dump_collectinfo_json.assert_not_called()
+
+        # logger.error was called with an ASNoNodesError instance whose
+        # message carries actionable remediation.
+        error_calls = self.logger_mock.error.call_args_list
+        no_nodes_calls = [
+            c for c in error_calls if c.args and isinstance(c.args[0], ASNoNodesError)
+        ]
+        self.assertEqual(
+            len(no_nodes_calls),
+            1,
+            f"expected exactly one ASNoNodesError log, got: {error_calls!r}",
+        )
+        message = str(no_nodes_calls[0].args[0])
+        self.assertIn("Cannot reach any Aerospike nodes", message)
+        self.assertIn("Try", message)
+
+    async def test_no_nodes_mid_run_is_handled_cleanly(self):
+        """Mid-run case: preflight passes (nodes are alive at the start) but
+        the cluster client raises ASNoNodesError later during the actual
+        snapshot — e.g. because the cluster went away between preflight and
+        the deeper info call. The dedicated `except ASNoNodesError` handler
+        must catch it, log the same clean error, and return without falling
+        into the generic `--ignore-errors`-aware Exception branch (which
+        would otherwise produce a misleading 'Aborting collectinfo...' line
+        for what is the same root cause)."""
+        self.cluster_mock.get_nodes.return_value = [Mock(), Mock()]
+        deep_error = ASNoNodesError()
+        self.controller._dump_collectinfo_json = AsyncMock(side_effect=deep_error)
+
+        await self.controller._run_collectinfo(
+            ssh_user=None,
+            ssh_pwd=None,
+            ssh_port=None,
+            ssh_key=None,
+            ssh_key_pwd=None,
+            snp_count=1,
+            wait_time=0,
+            ignore_errors=False,
+        )
+
+        # Exactly one error was logged — the ASNoNodesError itself. No
+        # 'Aborting collectinfo. To bypass use --ignore-errors.' follow-up
+        # line, because that belongs to the generic handler that we are
+        # specifically bypassing for this case.
+        error_calls = self.logger_mock.error.call_args_list
+        self.assertEqual(
+            len(error_calls),
+            1,
+            f"expected a single error log for mid-run ASNoNodesError, got: {error_calls!r}",
+        )
+        self.assertIs(error_calls[0].args[0], deep_error)
+
+    async def test_no_nodes_mid_run_aborts_even_with_ignore_errors(self):
+        """The mid-run handler must return regardless of --ignore-errors,
+        for the same reason as preflight: there is no usable partial
+        bundle when the cluster goes away."""
+        self.cluster_mock.get_nodes.return_value = [Mock(), Mock()]
+        self.controller._dump_collectinfo_json = AsyncMock(side_effect=ASNoNodesError())
+        # Tripwires for the downstream summary/health phases that should
+        # NEVER run when collectinfo bailed out.
+        self.controller._dump_collectinfo_ascollectinfo = AsyncMock()
+        self.controller._dump_collectinfo_summary = AsyncMock()
+        self.controller._dump_collectinfo_health = AsyncMock()
+
+        await self.controller._run_collectinfo(
+            ssh_user=None,
+            ssh_pwd=None,
+            ssh_port=None,
+            ssh_key=None,
+            ssh_key_pwd=None,
+            snp_count=1,
+            wait_time=0,
+            ignore_errors=True,
+        )
+
+        self.controller._dump_collectinfo_ascollectinfo.assert_not_called()
+        self.controller._dump_collectinfo_summary.assert_not_called()
+        self.controller._dump_collectinfo_health.assert_not_called()
+
+    async def test_preflight_short_circuits_regardless_of_ignore_errors(self):
+        """--ignore-errors must NOT cause collectinfo to continue past a
+        no-nodes preflight: there is no partial bundle worth producing."""
+        self.cluster_mock.get_nodes.return_value = []
+        self.controller._dump_collectinfo_json = AsyncMock()
+        # If preflight wrongly fell through to summary/health/etc., these
+        # would be reached; assert they aren't.
+        self.controller._dump_collectinfo_ascollectinfo = AsyncMock()
+        self.controller._dump_collectinfo_summary = AsyncMock()
+        self.controller._dump_collectinfo_health = AsyncMock()
+
+        await self.controller._run_collectinfo(
+            ssh_user=None,
+            ssh_pwd=None,
+            ssh_port=None,
+            ssh_key=None,
+            ssh_key_pwd=None,
+            snp_count=1,
+            wait_time=0,
+            ignore_errors=True,
+        )
+
+        self.controller._dump_collectinfo_json.assert_not_called()
+        self.controller._dump_collectinfo_ascollectinfo.assert_not_called()
+        self.controller._dump_collectinfo_summary.assert_not_called()
+        self.controller._dump_collectinfo_health.assert_not_called()
+
+    async def test_preflight_passes_when_nodes_present(self):
+        """Sanity check the negative: when nodes exist, preflight does not
+        short-circuit and _dump_collectinfo_json is invoked. We let
+        _dump_collectinfo_json raise a generic exception so the existing
+        except-Exception handler returns cleanly without dragging the test
+        through the downstream summary/health code paths."""
+        self.cluster_mock.get_nodes.return_value = [Mock(), Mock()]
+        sentinel = RuntimeError("stop after preflight")
+        self.controller._dump_collectinfo_json = AsyncMock(side_effect=sentinel)
+
+        await self.controller._run_collectinfo(
+            ssh_user=None,
+            ssh_pwd=None,
+            ssh_port=None,
+            ssh_key=None,
+            ssh_key_pwd=None,
+            snp_count=1,
+            wait_time=0,
+            ignore_errors=False,
+        )
+
+        self.controller._dump_collectinfo_json.assert_awaited_once()
+        # And the generic handler logged the underlying error (not ASNoNodesError).
+        error_calls = self.logger_mock.error.call_args_list
+        self.assertTrue(
+            any(c.args and c.args[0] is sentinel for c in error_calls),
+            f"expected the sentinel exception to reach logger.error, got: {error_calls!r}",
+        )
+        self.assertFalse(
+            any(c.args and isinstance(c.args[0], ASNoNodesError) for c in error_calls),
+            "preflight should not have flagged ASNoNodesError when nodes exist",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit/utils/test_logger.py
+++ b/test/unit/utils/test_logger.py
@@ -1,0 +1,98 @@
+# Copyright 2013-2025 Aerospike, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import patch
+
+from lib.base_controller import ShellException
+from lib.live_cluster.client.types import (
+    ASClusterError,
+    ASInfoError,
+    ASNoNodesError,
+    ASProtocolError,
+    ASResponse,
+)
+from lib.utils.logger import logger
+
+
+class LoggerAllowlistTest(unittest.TestCase):
+    """Verify the BaseLogger allowlist that decides whether to dump a Python
+    traceback for an exception logged via `logger.error()`.
+
+    The contract these tests pin down is the user-visible promise of every
+    typed error in this codebase: passing an instance of one of the allowlisted
+    exception classes to `logger.error()` must NOT cause `traceback.print_exc`
+    to fire — the user sees a single clean error line instead of a stack
+    trace. Plain exceptions must continue to dump tracebacks so unexpected
+    failures stay diagnosable.
+
+    These tests exercise the real `BaseLogger._handle_exception` code path
+    (no mocks of the logger itself), so removing or reordering an isinstance
+    check in `lib/utils/logger.py` will break them.
+    """
+
+    def _assert_no_traceback(self, exc: Exception):
+        """Call logger.error(exc) and assert traceback.print_exc is NOT
+        triggered by the BaseLogger allowlist."""
+        with patch("lib.utils.logger.traceback.print_exc") as mock_print_exc:
+            logger.error(exc)
+        mock_print_exc.assert_not_called()
+
+    def _assert_traceback(self, exc: Exception):
+        """Call logger.error(exc) and assert traceback.print_exc IS called —
+        confirms the allowlist is exclusive, not a free pass for every type."""
+        with patch("lib.utils.logger.traceback.print_exc") as mock_print_exc:
+            logger.error(exc)
+        mock_print_exc.assert_called_once()
+
+    def test_no_nodes_error_suppresses_traceback(self):
+        """Primary contract: the new ASNoNodesError must be treated as a
+        clean error by the logger. This guards against someone removing the
+        `ASClusterError` line in BaseLogger._handle_exception."""
+        self._assert_no_traceback(ASNoNodesError())
+
+    def test_cluster_error_base_suppresses_traceback(self):
+        """The whole ASClusterError hierarchy is on the allowlist, not just
+        ASNoNodesError. Future cluster-level error types (auth, TLS, etc.)
+        that subclass ASClusterError will inherit clean handling for free."""
+        self._assert_no_traceback(ASClusterError("some cluster problem"))
+
+    def test_shell_exception_suppresses_traceback(self):
+        """Regression guard for the pre-existing ShellException entry."""
+        self._assert_no_traceback(ShellException("bad command"))
+
+    def test_as_info_error_suppresses_traceback(self):
+        """Regression guard for the pre-existing ASInfoError entry."""
+        self._assert_no_traceback(ASInfoError("info failed"))
+
+    def test_as_protocol_error_suppresses_traceback(self):
+        """Regression guard for the pre-existing ASProtocolError entry."""
+        self._assert_no_traceback(ASProtocolError(ASResponse.OK, "protocol issue"))
+
+    def test_generic_exception_still_dumps_traceback(self):
+        """Negative case: unknown exception types must still produce a
+        traceback so unexpected failures remain diagnosable. Without this,
+        the allowlist test above could pass trivially if the logger never
+        printed tracebacks at all."""
+        self._assert_traceback(RuntimeError("unexpected"))
+
+    def test_io_error_still_dumps_traceback(self):
+        """IOError is what the cluster client used to raise. The cleanup
+        only removed it for the no-nodes path; raw IOError elsewhere must
+        still be treated as an unexpected failure."""
+        self._assert_traceback(IOError("disk full"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Introduces a typed exception hierarchy (`ASClusterError` / `ASNoNodesError`) for cluster-reachability failures, replacing the bare `IOError` previously raised by `Cluster.call_node_method_async` / `Cluster.call_node_method`.
- Adds a preflight check to `collectinfo` so a no-nodes cluster fails fast with a clear, actionable error instead of a misleading "Snapshot in progress…" line followed by a Python traceback.
- Surfaces the same clean error (no traceback) across **live mode** (`info`, `show config`, …) and **collectinfo**, by adding the new error type to the `BaseLogger` allowlist.

## Why

When asadm cannot reach any Aerospike node, users currently see one of two unhelpful outcomes:

1. **Live mode**: a terse `ERROR: Unable to find any Aerospike nodes` with no remediation hints.
2. **`collectinfo`**: a deeper stack trace (because the controller bypasses the `base_controller` IOError → ShellException conversion), followed by `Aborting collectinfo. To bypass use --ignore-errors.` — implying `--ignore-errors` is a solution, which is wrong (it just produces a half-written, useless bundle).

This PR addresses both by typing the error, giving it remediation guidance, and treating the no-nodes state as always fatal in `collectinfo` (regardless of `--ignore-errors`).

## Changes

| File | Change |
|---|---|
| `lib/live_cluster/client/types.py` | New `ASClusterError(Exception)` and `ASNoNodesError(ASClusterError)` with a default what/try message |
| `lib/live_cluster/client/__init__.py` | Re-exports the two new types |
| `lib/utils/logger.py` | `ASClusterError` added to the no-traceback allowlist in `BaseLogger._handle_exception` |
| `lib/live_cluster/client/cluster.py` | `call_node_method_async` / `call_node_method` raise `ASNoNodesError()` instead of `IOError` |
| `lib/live_cluster/collectinfo_controller.py` | Preflight on empty cluster + dedicated `except ASNoNodesError` handler that returns regardless of `--ignore-errors` |
| `Makefile` | `make coverage` now ends with a report; new `make unit-coverage` target for unit-only coverage |

## New tests (16 added; 1331 → 1347 passing, 0 failed)

- `test/unit/live_cluster/client/test_cluster.py` — 4 tests: async + sync raise on empty cluster; named-but-unknown nodes also raise (the error is about resolved targets, not total cluster size); custom-message constructor; type inherits from `ASClusterError`; message carries actionable remediation keywords.
- `test/unit/live_cluster/test_collectinfo_controller.py` (new file) — 5 tests: preflight short-circuits on empty cluster; `--ignore-errors=True` does NOT continue past preflight; positive case where preflight passes and `_dump_collectinfo_json` runs; mid-run case where dump raises `ASNoNodesError` deep in the stack (caught by dedicated handler, no spurious "Aborting…" follow-up); mid-run case also aborts with `--ignore-errors=True`. Includes proper teardown for the `LiveClusterCommandController.cluster` class attribute and `terminal.color_enabled` global state.
- `test/unit/utils/test_logger.py` (new file) — 7 tests: the **real** `BaseLogger._handle_exception` path (no logger mocks); positive cases for `ASNoNodesError`, `ASClusterError`, `ShellException`, `ASInfoError`, `ASProtocolError` all suppress tracebacks; negative cases for `RuntimeError` and `IOError` still dump tracebacks (prevents the allowlist from regressing into a free pass).

## Test plan

- [x] `pytest test/unit` — 1347 passed, 1 skipped, 0 failed
- [x] `make unit-coverage` — every line added by this change is covered (verified per file: `types.py` 341-358 ✓, `cluster.py` 26-28/684/710 ✓, `collectinfo_controller.py` 24/933-956 ✓, `logger.py` 43/168 ✓)
- [ ] Manual: `asadm -h 127.0.0.1 -p 1` (unreachable port) → `info network` shows a clean one-line error with remediation, no traceback
- [ ] Manual: `asadm -h 127.0.0.1 -p 1` → `collectinfo` aborts with the same clean error before producing any output files
- [ ] Manual: same with `--ignore-errors` confirms no partial bundle is produced
- [ ] E2E: `make integration` against a live cluster (sanity, no regression expected on the happy path)
