### PR TITLE
TOOLS-3556 - Add Ubuntu 26.04 to CI build matrix

### DIFF
--- a/.github/bin/install_deps.sh
+++ b/.github/bin/install_deps.sh
@@ -28,7 +28,8 @@ DEBIAN_13_DEPS="libreadline8 libreadline-dev ruby-rubygems make rpm git snapd cu
 UBUNTU_2004_DEPS="libreadline8 libreadline-dev ruby make rpm git snapd curl binutils rsync libssl1.1 libssl-dev lzma lzma-dev libffi-dev build-essential gcc g++ less"
 UBUNTU_2204_DEPS="libreadline8 libreadline-dev ruby-rubygems make rpm git snapd curl binutils rsync libssl3 libssl-dev lzma lzma-dev libffi-dev build-essential gcc g++ less"
 UBUNTU_2404_DEPS="libreadline8 libreadline-dev ruby-rubygems make rpm git snapd curl binutils rsync libssl3 libssl-dev lzma lzma-dev libffi-dev build-essential gcc g++ less"
-UBUNTU_2604_DEPS="$UBUNTU_2404_DEPS"
+# Ubuntu 26.04+ (questing): lzma-dev was dropped; liblzma-dev provides the same headers.
+UBUNTU_2604_DEPS="${UBUNTU_2404_DEPS/lzma-dev/liblzma-dev}"
 EL8_DEPS="ruby rubygems redhat-rpm-config rpm-build make git rsync gcc gcc-c++ make automake zlib zlib-devel libffi-devel openssl-devel bzip2-devel xz-devel xz xz-libs sqlite sqlite-devel sqlite-libs less"
 EL9_DEPS="ruby rpmdevtools make git rsync gcc g++ make automake zlib zlib-devel libffi-devel openssl-devel bzip2-devel xz-devel xz xz-libs sqlite sqlite-devel sqlite-libs less"
 EL10_DEPS="ruby rpmdevtools make git rsync gcc g++ make automake zlib zlib-devel libffi-devel openssl-devel bzip2-devel xz-devel xz xz-libs sqlite sqlite-devel sqlite-libs less"

--- a/.github/bin/install_deps.sh
+++ b/.github/bin/install_deps.sh
@@ -28,10 +28,11 @@ DEBIAN_13_DEPS="libreadline8 libreadline-dev ruby-rubygems make rpm git snapd cu
 UBUNTU_2004_DEPS="libreadline8 libreadline-dev ruby make rpm git snapd curl binutils rsync libssl1.1 libssl-dev lzma lzma-dev libffi-dev build-essential gcc g++ less"
 UBUNTU_2204_DEPS="libreadline8 libreadline-dev ruby-rubygems make rpm git snapd curl binutils rsync libssl3 libssl-dev lzma lzma-dev libffi-dev build-essential gcc g++ less"
 UBUNTU_2404_DEPS="libreadline8 libreadline-dev ruby-rubygems make rpm git snapd curl binutils rsync libssl3 libssl-dev lzma lzma-dev libffi-dev build-essential gcc g++ less"
-# Ubuntu 26.04+ (questing): lzma-dev was dropped; liblzma-dev provides the same headers.
-# Questing images are leaner than 24.04's; add pyenv-style -dev packages so CPython's
-# stdlib modules (e.g. zlib) and ensurepip bootstrap succeed (otherwise make install fails).
+# Ubuntu 26.04 (resolute): lzma-dev was dropped — use liblzma-dev. Do not pin libreadline8
+# (t64 / readline major varies); libreadline-dev pulls the correct runtime (see aerospike/aql#70).
+# Extra pyenv-style -dev packages keep CPython stdlib modules complete; ensurepip workaround below.
 UBUNTU_2604_DEPS="${UBUNTU_2404_DEPS/lzma-dev/liblzma-dev} zlib1g-dev libbz2-dev libsqlite3-dev libncursesw5-dev xz-utils tk-dev uuid-dev"
+UBUNTU_2604_DEPS="${UBUNTU_2604_DEPS/libreadline8 /}"
 EL8_DEPS="ruby rubygems redhat-rpm-config rpm-build make git rsync gcc gcc-c++ make automake zlib zlib-devel libffi-devel openssl-devel bzip2-devel xz-devel xz xz-libs sqlite sqlite-devel sqlite-libs less"
 EL9_DEPS="ruby rpmdevtools make git rsync gcc g++ make automake zlib zlib-devel libffi-devel openssl-devel bzip2-devel xz-devel xz xz-libs sqlite sqlite-devel sqlite-libs less"
 EL10_DEPS="ruby rpmdevtools make git rsync gcc g++ make automake zlib zlib-devel libffi-devel openssl-devel bzip2-devel xz-devel xz xz-libs sqlite sqlite-devel sqlite-libs less"
@@ -127,7 +128,7 @@ _install_python_via_asdf_and_fpm() {
   /opt/golang/go/bin/go install "github.com/asdf-vm/asdf/cmd/asdf@${ASDF_VERSION}"
   install "$HOME/go/bin/asdf" /usr/local/bin/asdf
   asdf plugin add python https://github.com/asdf-community/asdf-python.git
-  # Ubuntu questing: ensurepip during "make install" can fail (pip bootstrap to --root /).
+  # Ubuntu 26.04 (resolute): ensurepip during "make install" can fail (pip bootstrap to --root /).
   # Build without bundled pip and install pip explicitly afterward.
   if [[ "$distro" == "ubuntu26.04" ]]; then
     export PYTHON_CONFIGURE_OPTS="--with-ensurepip=no"

--- a/.github/bin/install_deps.sh
+++ b/.github/bin/install_deps.sh
@@ -11,6 +11,7 @@
 #                    el8, el9, el10, amzn2023
 #
 # Set DEBUG=1 to enable bash trace mode.
+# ubuntu26.04: set GET_PIP_SHA256 to override the expected sha256 for bootstrap get-pip.py when PyPA updates it.
 #
 
 set -euo pipefail
@@ -124,6 +125,12 @@ _install_go() {
 _install_python_via_asdf_and_fpm() {
   local pip_flags="$1"  # "" or "--break-system-packages"
   local distro="${2:-}"
+  local saved_pyconf_set=0
+  local saved_pyconf=""
+  if [[ -n "${PYTHON_CONFIGURE_OPTS+x}" ]]; then
+    saved_pyconf_set=1
+    saved_pyconf="${PYTHON_CONFIGURE_OPTS}"
+  fi
 
   /opt/golang/go/bin/go install "github.com/asdf-vm/asdf/cmd/asdf@${ASDF_VERSION}"
   install "$HOME/go/bin/asdf" /usr/local/bin/asdf
@@ -135,8 +142,15 @@ _install_python_via_asdf_and_fpm() {
   fi
   asdf install python "$PYTHON_VERSION"
   if [[ "$distro" == "ubuntu26.04" ]]; then
-    unset PYTHON_CONFIGURE_OPTS
-    curl -L "${CURL_RETRY_OPTS[@]}" https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
+    if [[ "$saved_pyconf_set" -eq 1 ]]; then
+      export PYTHON_CONFIGURE_OPTS="${saved_pyconf}"
+    else
+      unset PYTHON_CONFIGURE_OPTS
+    fi
+    # Fail on HTTP errors (-f); checksum pins bootstrap.pypa.io content (bump when updating intentionally).
+    local get_pip_expected_sha="${GET_PIP_SHA256:-66904bccb878e363db6236ea900e6935e507dcb887e9f178f6212edfe7f46a76}"
+    curl -fSL "${CURL_RETRY_OPTS[@]}" https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
+    echo "${get_pip_expected_sha}  /tmp/get-pip.py" | sha256sum -c - >/dev/null
     "$HOME/.asdf/installs/python/$PYTHON_VERSION/bin/python" /tmp/get-pip.py --no-warn-script-location
     rm -f /tmp/get-pip.py
   fi

--- a/.github/bin/install_deps.sh
+++ b/.github/bin/install_deps.sh
@@ -7,7 +7,7 @@
 #   install_deps <distro>     # e.g. install_deps ubuntu24.04
 #
 # Supported distros: debian11, debian12, debian13,
-#                    ubuntu20.04, ubuntu22.04, ubuntu24.04,
+#                    ubuntu20.04, ubuntu22.04, ubuntu24.04, ubuntu26.04,
 #                    el8, el9, el10, amzn2023
 #
 # Set DEBUG=1 to enable bash trace mode.
@@ -28,6 +28,7 @@ DEBIAN_13_DEPS="libreadline8 libreadline-dev ruby-rubygems make rpm git snapd cu
 UBUNTU_2004_DEPS="libreadline8 libreadline-dev ruby make rpm git snapd curl binutils rsync libssl1.1 libssl-dev lzma lzma-dev libffi-dev build-essential gcc g++ less"
 UBUNTU_2204_DEPS="libreadline8 libreadline-dev ruby-rubygems make rpm git snapd curl binutils rsync libssl3 libssl-dev lzma lzma-dev libffi-dev build-essential gcc g++ less"
 UBUNTU_2404_DEPS="libreadline8 libreadline-dev ruby-rubygems make rpm git snapd curl binutils rsync libssl3 libssl-dev lzma lzma-dev libffi-dev build-essential gcc g++ less"
+UBUNTU_2604_DEPS="$UBUNTU_2404_DEPS"
 EL8_DEPS="ruby rubygems redhat-rpm-config rpm-build make git rsync gcc gcc-c++ make automake zlib zlib-devel libffi-devel openssl-devel bzip2-devel xz-devel xz xz-libs sqlite sqlite-devel sqlite-libs less"
 EL9_DEPS="ruby rpmdevtools make git rsync gcc g++ make automake zlib zlib-devel libffi-devel openssl-devel bzip2-devel xz-devel xz xz-libs sqlite sqlite-devel sqlite-libs less"
 EL10_DEPS="ruby rpmdevtools make git rsync gcc g++ make automake zlib zlib-devel libffi-devel openssl-devel bzip2-devel xz-devel xz xz-libs sqlite sqlite-devel sqlite-libs less"
@@ -41,6 +42,7 @@ _pkg_list_for() {
     ubuntu20.04) echo "$UBUNTU_2004_DEPS" ;;
     ubuntu22.04) echo "$UBUNTU_2204_DEPS" ;;
     ubuntu24.04) echo "$UBUNTU_2404_DEPS" ;;
+    ubuntu26.04) echo "$UBUNTU_2604_DEPS" ;;
     el8)         echo "$EL8_DEPS" ;;
     el9)         echo "$EL9_DEPS" ;;
     el10)        echo "$EL10_DEPS" ;;
@@ -64,7 +66,7 @@ _readline_url_for() {
 # PEP 668: newer distros need --break-system-packages for pip.
 _pip_flags_for() {
   case "$1" in
-    debian*|ubuntu24.04|el9|el10|amzn2023) echo "--break-system-packages" ;;
+    debian*|ubuntu24.04|ubuntu26.04|el9|el10|amzn2023) echo "--break-system-packages" ;;
     *) echo "" ;;
   esac
 }

--- a/.github/bin/install_deps.sh
+++ b/.github/bin/install_deps.sh
@@ -29,7 +29,9 @@ UBUNTU_2004_DEPS="libreadline8 libreadline-dev ruby make rpm git snapd curl binu
 UBUNTU_2204_DEPS="libreadline8 libreadline-dev ruby-rubygems make rpm git snapd curl binutils rsync libssl3 libssl-dev lzma lzma-dev libffi-dev build-essential gcc g++ less"
 UBUNTU_2404_DEPS="libreadline8 libreadline-dev ruby-rubygems make rpm git snapd curl binutils rsync libssl3 libssl-dev lzma lzma-dev libffi-dev build-essential gcc g++ less"
 # Ubuntu 26.04+ (questing): lzma-dev was dropped; liblzma-dev provides the same headers.
-UBUNTU_2604_DEPS="${UBUNTU_2404_DEPS/lzma-dev/liblzma-dev}"
+# Questing images are leaner than 24.04's; add pyenv-style -dev packages so CPython's
+# stdlib modules (e.g. zlib) and ensurepip bootstrap succeed (otherwise make install fails).
+UBUNTU_2604_DEPS="${UBUNTU_2404_DEPS/lzma-dev/liblzma-dev} zlib1g-dev libbz2-dev libsqlite3-dev libncursesw5-dev xz-utils tk-dev uuid-dev"
 EL8_DEPS="ruby rubygems redhat-rpm-config rpm-build make git rsync gcc gcc-c++ make automake zlib zlib-devel libffi-devel openssl-devel bzip2-devel xz-devel xz xz-libs sqlite sqlite-devel sqlite-libs less"
 EL9_DEPS="ruby rpmdevtools make git rsync gcc g++ make automake zlib zlib-devel libffi-devel openssl-devel bzip2-devel xz-devel xz xz-libs sqlite sqlite-devel sqlite-libs less"
 EL10_DEPS="ruby rpmdevtools make git rsync gcc g++ make automake zlib zlib-devel libffi-devel openssl-devel bzip2-devel xz-devel xz xz-libs sqlite sqlite-devel sqlite-libs less"
@@ -120,11 +122,23 @@ _install_go() {
 
 _install_python_via_asdf_and_fpm() {
   local pip_flags="$1"  # "" or "--break-system-packages"
+  local distro="${2:-}"
 
   /opt/golang/go/bin/go install "github.com/asdf-vm/asdf/cmd/asdf@${ASDF_VERSION}"
   install "$HOME/go/bin/asdf" /usr/local/bin/asdf
   asdf plugin add python https://github.com/asdf-community/asdf-python.git
+  # Ubuntu questing: ensurepip during "make install" can fail (pip bootstrap to --root /).
+  # Build without bundled pip and install pip explicitly afterward.
+  if [[ "$distro" == "ubuntu26.04" ]]; then
+    export PYTHON_CONFIGURE_OPTS="--with-ensurepip=no"
+  fi
   asdf install python "$PYTHON_VERSION"
+  if [[ "$distro" == "ubuntu26.04" ]]; then
+    unset PYTHON_CONFIGURE_OPTS
+    curl -L "${CURL_RETRY_OPTS[@]}" https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
+    "$HOME/.asdf/installs/python/$PYTHON_VERSION/bin/python" /tmp/get-pip.py --no-warn-script-location
+    rm -f /tmp/get-pip.py
+  fi
   asdf set python "$PYTHON_VERSION"
   echo "python $PYTHON_VERSION" > /.tool-versions
   echo "python $PYTHON_VERSION" > "$HOME/.tool-versions"
@@ -159,6 +173,6 @@ install_deps() {
   fi
 
   _install_go
-  _install_python_via_asdf_and_fpm "$(_pip_flags_for "$distro")"
+  _install_python_via_asdf_and_fpm "$(_pip_flags_for "$distro")" "$distro"
   _post_install_cleanup "$distro"
 }

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -150,6 +150,7 @@ jobs:
           - ubuntu20.04
           - ubuntu22.04
           - ubuntu24.04
+          - ubuntu26.04
     runs-on: ${{ matrix.host }}
     container: >-
       ${{ matrix.distro == 'el8' && 'redhat/ubi8:8.10' ||
@@ -161,7 +162,8 @@ jobs:
         matrix.distro == 'debian13' && 'debian:trixie-20251020' ||
         matrix.distro == 'ubuntu20.04' && 'ubuntu:focal-20210723' ||
         matrix.distro == 'ubuntu22.04' && 'ubuntu:jammy-20231004' ||
-        matrix.distro == 'ubuntu24.04' && 'ubuntu:noble-20251013' }}
+        matrix.distro == 'ubuntu24.04' && 'ubuntu:noble-20251013' ||
+        matrix.distro == 'ubuntu26.04' && 'ubuntu:questing-20251217' }}
     permissions:
       contents: read
     steps:
@@ -322,7 +324,7 @@ jobs:
     needs:
       - get-version
       - organize-built-artifacts
-    uses: aerospike/shared-workflows/.github/workflows/reusable_sign-mac-artifacts.yaml@v3.4.0
+    uses: aerospike/shared-workflows/.github/workflows/reusable_sign-mac-artifacts.yaml@v3.6.0
     permissions:
       contents: read
       id-token: write
@@ -331,7 +333,7 @@ jobs:
       artifact-glob: "**/*.pkg"
       signing-identity: "Developer ID Application: Aerospike, Inc. (22224RFU67)"
       installer-identity: "Developer ID Installer: Aerospike, Inc. (22224RFU67)"
-      gh-workflows-ref: "v3.4.0"
+      gh-workflows-ref: "v3.6.0"
       gh-retention-days: 1
     secrets:
       apple-application-cert: ${{ secrets.APPLE_APPLICATION_CERT }}
@@ -345,11 +347,11 @@ jobs:
     needs:
       - get-version
       - notarize-mac-artifacts
-    uses: aerospike/shared-workflows/.github/workflows/reusable_sign-artifacts.yaml@v3.4.0
+    uses: aerospike/shared-workflows/.github/workflows/reusable_sign-artifacts.yaml@v3.6.0
     with:
       gh-artifact-name: signed-artifacts-${{ needs.get-version.outputs.VERSION }}
       gh-unsigned-artifacts: unsigned-artifacts-${{ needs.get-version.outputs.VERSION }}
-      gh-workflows-ref: "v3.4.0"
+      gh-workflows-ref: "v3.6.0"
     secrets:
       gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
       gpg-public-key: ${{ secrets.GPG_PUBLIC_KEY }}
@@ -373,6 +375,7 @@ jobs:
           - ubuntu20.04
           - ubuntu22.04
           - ubuntu24.04
+          - ubuntu26.04
     runs-on: ${{ matrix.host }}
     container: >-
       ${{ matrix.distro == 'el8' && 'redhat/ubi8:8.10' ||
@@ -384,7 +387,8 @@ jobs:
         matrix.distro == 'debian13' && 'debian:trixie-20251020' ||
         matrix.distro == 'ubuntu20.04' && 'ubuntu:focal-20210723' ||
         matrix.distro == 'ubuntu22.04' && 'ubuntu:jammy-20231004' ||
-        matrix.distro == 'ubuntu24.04' && 'ubuntu:noble-20251013' }}
+        matrix.distro == 'ubuntu24.04' && 'ubuntu:noble-20251013' ||
+        matrix.distro == 'ubuntu26.04' && 'ubuntu:questing-20251217' }}
     permissions:
       contents: read
     steps:
@@ -532,7 +536,7 @@ jobs:
     needs:
       - get-version
       - organize-signed-artifacts
-    uses: aerospike/shared-workflows/.github/workflows/reusable_deploy-artifacts.yaml@v3.4.0
+    uses: aerospike/shared-workflows/.github/workflows/reusable_deploy-artifacts.yaml@v3.6.0
     with:
       jf-project: database
       jf-build-name: "aerospike-asadm"
@@ -544,7 +548,7 @@ jobs:
       dry-run: ${{ inputs.release != true }}
       jf-build-id: ${{ needs.get-version.outputs.VERSION }}
       jf-metadata-build-id: ${{ needs.get-version.outputs.VERSION }}-metadata
-      gh-workflows-ref: "v3.4.0"
+      gh-workflows-ref: "v3.6.0"
 
   docker-build-arch:
     name: Docker build, test & push (${{ matrix.arch }})
@@ -707,7 +711,7 @@ jobs:
       - get-version
       - upload-artifacts-to-jfrog
       - docker-manifest
-    uses: aerospike/shared-workflows/.github/workflows/reusable_create-release-bundle.yaml@v3.4.0
+    uses: aerospike/shared-workflows/.github/workflows/reusable_create-release-bundle.yaml@v3.6.0
     with:
       jf-project: "database"
       jf-build-names: "aerospike-asadm:${{ needs.get-version.outputs.VERSION }}"
@@ -715,7 +719,7 @@ jobs:
       oidc-provider-name: database-gh-aerospike
       oidc-audience: database-gh-aerospike
       version: ${{ needs.get-version.outputs.VERSION }}
-      gh-workflows-ref: v3.4.0
+      gh-workflows-ref: v3.6.0
       dry-run: false
 
   # Tag-last: created only after every publish step succeeds. A failure

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -163,7 +163,7 @@ jobs:
         matrix.distro == 'ubuntu20.04' && 'ubuntu:focal-20210723' ||
         matrix.distro == 'ubuntu22.04' && 'ubuntu:jammy-20231004' ||
         matrix.distro == 'ubuntu24.04' && 'ubuntu:noble-20251013' ||
-        matrix.distro == 'ubuntu26.04' && 'ubuntu:questing-20251217' }}
+        matrix.distro == 'ubuntu26.04' && 'ubuntu:resolute-20260421' }}
     permissions:
       contents: read
     steps:
@@ -388,7 +388,7 @@ jobs:
         matrix.distro == 'ubuntu20.04' && 'ubuntu:focal-20210723' ||
         matrix.distro == 'ubuntu22.04' && 'ubuntu:jammy-20231004' ||
         matrix.distro == 'ubuntu24.04' && 'ubuntu:noble-20251013' ||
-        matrix.distro == 'ubuntu26.04' && 'ubuntu:questing-20251217' }}
+        matrix.distro == 'ubuntu26.04' && 'ubuntu:resolute-20260421' }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,7 +1,7 @@
 # Lightweight installer build check.
 #
 # Purpose: catch dependency / packaging regressions on every push, before
-# they reach the full release pipeline. The release workflow builds for 10
+# they reach the full release pipeline. The release workflow builds for 11
 # distros × 2 arches + signing + notarization — too heavy for every commit.
 #
 # This workflow exercises both fpm code paths (deb on Ubuntu, rpm on EL) on
@@ -38,6 +38,7 @@ jobs:
       matrix:
         include:
           - { distro: ubuntu24.04, container: 'ubuntu:noble-20251013', pkg: deb }
+          - { distro: ubuntu26.04, container: 'ubuntu:questing-20251217', pkg: deb }
           - { distro: el10,        container: 'redhat/ubi10:10.0',    pkg: rpm }
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         include:
           - { distro: ubuntu24.04, container: 'ubuntu:noble-20251013', pkg: deb }
-          - { distro: ubuntu26.04, container: 'ubuntu:questing-20251217', pkg: deb }
+          - { distro: ubuntu26.04, container: 'ubuntu:resolute-20260421', pkg: deb }
           - { distro: el10,        container: 'redhat/ubi10:10.0',    pkg: rpm }
     steps:
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
## Summary
- Extend Build and Release / build-check to build and smoke-test `ubuntu26.04` using `ubuntu:questing-20251217` (matches current questing/26.04 pipeline images).
- Teach `install_deps.sh` about `ubuntu26.04`: swap dropped `lzma-dev` for `liblzma-dev`, add pyenv-style `-dev` packages for CPython, use PEP 668 pip flags, and skip broken `ensurepip` on questing by configuring `--with-ensurepip=no` then bootstrapping pip via `get-pip.py`.
- Bump reusable `aerospike/shared-workflows` references from v3.4.0 to v3.6.0 so mac sign / deploy / bundle jobs stay aligned with other Aerospike repos.

## Test plan
- [ ] Confirm GitHub Actions **Build check (installer)** passes for the `ubuntu26.04` matrix leg.
- [ ] Confirm **Build and Release** dry-run (or branch push) completes `build-artifacts` and **Test install & execute** for `ubuntu26.04` on both `ubuntu-24.04` and `ubuntu-24.04-arm` hosts.
- [ ] Spot-check that published `.deb` names still include `_ubuntu26.04_` and install smoke tests find the artifact.