### PR TITLE
feat: TOOLS-2537 add command aliases for improved usability in controllers

### DIFF
--- a/lib/base_controller.py
+++ b/lib/base_controller.py
@@ -300,6 +300,7 @@ class BaseController(object):
     def complete(self, line):
         self._init()
         command = line.pop(0) if line else ""
+        command = self.aliases.get(command, command)
         commands = self.commands.get_key(command)
 
         logger.debug("Auto-complete: command {}".format(command))
@@ -373,10 +374,24 @@ class BaseController(object):
         except Exception:
             self._context = []
 
+    def _init_aliases(self):
+        """
+        Define aliases if not defined. Maps an alias to its canonical command
+        name so alternate spellings (e.g. 'stats' -> 'statistics') resolve to the
+        same command without competing in prefix matching. This way, not all
+        sub-commands need to define it or call super().
+        """
+        try:
+            if self.aliases:
+                pass
+        except Exception:
+            self.aliases: dict[str, str] = {}
+
     def _init(self):
         self._init_modifiers()
         self._init_controller_map()
         self._init_context()
+        self._init_aliases()
         self._init_commands()
 
     def _find_method(self, line):
@@ -391,6 +406,9 @@ class BaseController(object):
 
             if method is not None:
                 return method
+
+        # Resolve aliases to their canonical command name before lookup.
+        command = self.aliases.get(command, command)
 
         try:
             logger.debug("Looking for {} in command_map".format(command))

--- a/lib/collectinfo_analyzer/show_controller.py
+++ b/lib/collectinfo_analyzer/show_controller.py
@@ -76,6 +76,7 @@ class ShowController(CollectinfoCommandController):
             "statistics": ShowStatisticsController,
             "masking": ShowMaskingController,
         }
+        self.aliases = {"stats": "statistics"}
         self.modifiers = set()
 
 

--- a/lib/live_cluster/show_controller.py
+++ b/lib/live_cluster/show_controller.py
@@ -91,6 +91,7 @@ class ShowController(LiveClusterCommandController):
             "user-agents": ShowUserAgentsController,
             "masking": ShowMaskingController,
         }
+        self.aliases = {"stats": "statistics"}
 
         self.modifiers = set()
 

--- a/test/unit/collectinfo_analyzer/test_show_controller.py
+++ b/test/unit/collectinfo_analyzer/test_show_controller.py
@@ -32,10 +32,14 @@ from lib.base_controller import ShellException
 
 class ShowControllerAliasTest(unittest.TestCase):
     def setUp(self):
-        # Sub-controllers read the log_handler off the class attribute during _init().
-        CollectinfoCommandController.log_handler = create_autospec(
-            CollectinfoLogHandler
-        )
+        # Sub-controllers read the log_handler off the class attribute during
+        # _init(). Patch it so the mock is restored and doesn't leak into others.
+        patch.object(
+            CollectinfoCommandController,
+            "log_handler",
+            create_autospec(CollectinfoLogHandler),
+            create=True,
+        ).start()
         self.controller = ShowController()
         self.controller._init()
         self.addCleanup(patch.stopall)

--- a/test/unit/collectinfo_analyzer/test_show_controller.py
+++ b/test/unit/collectinfo_analyzer/test_show_controller.py
@@ -14,12 +14,50 @@
 
 import unittest
 from mock import create_autospec, patch, MagicMock
+from parameterized import parameterized
 
+from lib.collectinfo_analyzer.collectinfo_command_controller import (
+    CollectinfoCommandController,
+)
 from lib.collectinfo_analyzer.collectinfo_handler.log_handler import (
     CollectinfoLogHandler,
 )
-from lib.collectinfo_analyzer.show_controller import ShowMaskingController
+from lib.collectinfo_analyzer.show_controller import (
+    ShowController,
+    ShowMaskingController,
+    ShowStatisticsController,
+)
 from lib.base_controller import ShellException
+
+
+class ShowControllerAliasTest(unittest.TestCase):
+    def setUp(self):
+        # Sub-controllers read the log_handler off the class attribute during _init().
+        CollectinfoCommandController.log_handler = create_autospec(
+            CollectinfoLogHandler
+        )
+        self.controller = ShowController()
+        self.controller._init()
+        self.addCleanup(patch.stopall)
+
+    def test_stats_is_alias_for_statistics(self):
+        self.assertEqual(self.controller.aliases, {"stats": "statistics"})
+
+    def test_stats_alias_does_not_register_a_command(self):
+        # The alias must not become a command key, otherwise the shared "stat"
+        # prefix would resolve ambiguously.
+        self.assertNotIn("stats", self.controller.commands.keys())
+        self.assertIn("statistics", self.controller.commands.keys())
+
+    def test_stats_alias_resolves_to_statistics_controller(self):
+        method = self.controller._find_method(["stats"])
+        self.assertIsInstance(method, ShowStatisticsController)
+
+    @parameterized.expand([["stat"], ["statistics"]])
+    def test_statistics_prefix_still_resolves(self, command):
+        # Adding the alias must not break the existing prefix shorthand.
+        method = self.controller._find_method([command])
+        self.assertIsInstance(method, ShowStatisticsController)
 
 
 class ShowMaskingControllerTest(unittest.TestCase):

--- a/test/unit/live_cluster/test_show_controller.py
+++ b/test/unit/live_cluster/test_show_controller.py
@@ -18,6 +18,7 @@ import unittest
 import warnings
 from unittest.mock import AsyncMock, MagicMock, call, create_autospec, patch
 
+from parameterized import parameterized
 from pytest import PytestUnraisableExceptionWarning
 
 from lib.base_controller import ShellException
@@ -32,9 +33,13 @@ from lib.live_cluster.get_controller import (
     GetStatisticsController,
     GetUserAgentsController,
 )
+from lib.live_cluster.live_cluster_command_controller import (
+    LiveClusterCommandController,
+)
 from lib.live_cluster.show_controller import (
     ShowBestPracticesController,
     ShowConfigController,
+    ShowController,
     ShowConfigXDRController,
     ShowJobsController,
     ShowMaskingController,
@@ -51,6 +56,34 @@ from lib.live_cluster.show_controller import (
 )
 from lib.view.view import CliView
 from test.unit import util as test_util
+
+
+class ShowControllerAliasTest(unittest.TestCase):
+    def setUp(self):
+        # Sub-controllers read the cluster off the class attribute during _init().
+        LiveClusterCommandController.cluster = create_autospec(Cluster)
+        self.controller = ShowController()
+        self.controller._init()
+        self.addCleanup(patch.stopall)
+
+    def test_stats_is_alias_for_statistics(self):
+        self.assertEqual(self.controller.aliases, {"stats": "statistics"})
+
+    def test_stats_alias_does_not_register_a_command(self):
+        # The alias must not become a command key, otherwise the shared "stat"
+        # prefix would resolve ambiguously.
+        self.assertNotIn("stats", self.controller.commands.keys())
+        self.assertIn("statistics", self.controller.commands.keys())
+
+    def test_stats_alias_resolves_to_statistics_controller(self):
+        method = self.controller._find_method(["stats"])
+        self.assertIsInstance(method, ShowStatisticsController)
+
+    @parameterized.expand([["stat"], ["statistics"]])
+    def test_statistics_prefix_still_resolves(self, command):
+        # Adding the alias must not break the existing prefix shorthand.
+        method = self.controller._find_method([command])
+        self.assertIsInstance(method, ShowStatisticsController)
 
 
 class ShowConfigControllerTest(unittest.IsolatedAsyncioTestCase):

--- a/test/unit/live_cluster/test_show_controller.py
+++ b/test/unit/live_cluster/test_show_controller.py
@@ -61,7 +61,13 @@ from test.unit import util as test_util
 class ShowControllerAliasTest(unittest.TestCase):
     def setUp(self):
         # Sub-controllers read the cluster off the class attribute during _init().
-        LiveClusterCommandController.cluster = create_autospec(Cluster)
+        # Patch it so the mock is restored and doesn't leak into other tests.
+        patch.object(
+            LiveClusterCommandController,
+            "cluster",
+            create_autospec(Cluster),
+            create=True,
+        ).start()
         self.controller = ShowController()
         self.controller._init()
         self.addCleanup(patch.stopall)

--- a/test/unit/test_base_controller.py
+++ b/test/unit/test_base_controller.py
@@ -46,6 +46,8 @@ class FakeRoot(BaseController):
         self.modifiers = set()
 
         self.controller_map = {"fakea1": FakeCommand1, "fakeb2": FakeCommand2}
+        # "renamed" is an alias for the canonical "fakeb2" command.
+        self.aliases = {"renamed": "fakeb2"}
 
 
 @CommandHelp(
@@ -177,6 +179,60 @@ class BaseControllerTest(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(expected_result, "ShellException")
         else:
             self.assertEqual(expected_result, actual_result)
+
+    def test_alias_not_registered_as_command(self):
+        # Aliases must resolve to a command without being added to the command
+        # map, otherwise they would compete in prefix matching.
+        r = FakeRoot()
+        r._init()
+
+        self.assertNotIn("renamed", r.commands.keys())
+        # The canonical commands (and their prefixes) still resolve as before.
+        self.assertEqual(r.complete([]), ["fakea1", "fakeb2"])
+
+    @parameterized.expand(
+        [
+            # The alias resolves to the canonical command's controller ...
+            (["renamed"], "_do_default"),
+            # ... and routing into its sub-commands still works.
+            (["renamed", "foo"], "do_foo"),
+        ]
+    )
+    def test_find_method_resolves_alias(self, line, expected_method):
+        r = FakeRoot()
+        r._init()
+
+        tline = line[:]
+        actual_method = r._find_method(tline)
+
+        try:
+            while True:
+                actual_method._init()
+                actual_method = actual_method._find_method(tline)
+        except AttributeError:
+            pass
+
+        self.assertEqual(actual_method.__name__, expected_method)
+
+    @parameterized.expand(
+        [
+            # "renamed" is an alias for "fakeb2" so both behave identically.
+            (["renamed"], "fake2"),
+            (["renamed", "foo"], "foo"),
+        ]
+    )
+    async def test_execute_alias(self, line, expected_result):
+        r = FakeRoot()
+
+        actual_result = await r(line)
+
+        self.assertEqual(expected_result, actual_result[0])
+
+    def test_complete_alias(self):
+        # Completing an alias yields the canonical command's sub-commands.
+        r = FakeRoot()
+
+        self.assertEqual(r.complete(["renamed"]), ["cmd", "foo", "for", "zoo"])
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Summary

Adds a small, generic **command alias** mechanism so alternate spellings resolve to the same command, and uses it to make `show stats` behave exactly like `show statistics` in both live-cluster and collectinfo modes.

### Why not just add `"stats"` to the controller map?
`show`'s sub-commands are resolved via a `PrefixDict` (prefix matching). Registering `"stats"` as a second command key would make the shared prefix `stat`/`sta` match **two** keys → an "Ambiguous command" error, breaking the existing `show stat` shorthand.

### Approach
- `lib/base_controller.py`: added an `aliases` dict (alias → canonical command), initialized via `_init_aliases()` (defaults to empty, mirroring the other `_init_*` helpers). The command token is translated **before** lookup in both `_find_method` and `complete`. Aliases resolve ahead of prefix matching and are **not** added to the `PrefixDict`, so they introduce no ambiguity.
- `lib/live_cluster/show_controller.py` and `lib/collectinfo_analyzer/show_controller.py`: registered `aliases = {"stats": "statistics"}` on both `ShowController`s.

### Behavior
- `show stats`, `show stats namespace`, tab-completion → identical to `show statistics`.
- `show stat` / `show statistics` → unchanged (no regression).

## Testing
- New unit tests:
  - `test/unit/test_base_controller.py` — core mechanism: alias resolves via `_find_method`/`execute`/`complete`, and the alias is **not** registered as a command key.
  - `test/unit/live_cluster/test_show_controller.py` and `test/unit/collectinfo_analyzer/test_show_controller.py` — `stats → statistics`, the `stat` prefix still resolves unambiguously (regression guard), and `stats` is not a registered command.
- Full unit suite: **1379 passed, 1 skipped**. Coverage confirms every added line in `base_controller.py` is exercised.