### PR TITLE
Show Used% for shmem primary/secondary index + highlight the self node

### DIFF
--- a/lib/collectinfo_analyzer/collectinfo_handler/collectinfo_log.py
+++ b/lib/collectinfo_analyzer/collectinfo_handler/collectinfo_log.py
@@ -400,6 +400,9 @@ class _CollectinfoSnapshot:
     def get_summary(self, stanza=""):
         return self.get_data(type="summary", stanza=stanza)
 
+    def get_self_node(self) -> str:
+        return ""
+
     def get_expected_principal(self) -> str:
         try:
             principal = "0"

--- a/lib/live_cluster/client/cluster.py
+++ b/lib/live_cluster/client/cluster.py
@@ -815,8 +815,10 @@ class Cluster(AsyncObject):
         self.node_lookup = LookupDict()
 
     def get_self_node(self):
+        # Returns the first node flagged localhost; if multiple co-located
+        # nodes are flagged, dict-iteration order decides which wins.
         for node in self.nodes.values():
-            if node.localhost:
+            if node.is_localhost():
                 return node.node_id
         return ""
 

--- a/lib/live_cluster/client/cluster.py
+++ b/lib/live_cluster/client/cluster.py
@@ -814,5 +814,11 @@ class Cluster(AsyncObject):
         self.nodes = {}
         self.node_lookup = LookupDict()
 
+    def get_self_node(self):
+        for node in self.nodes.values():
+            if node.localhost:
+                return node.node_id
+        return ""
+
     def get_seed_nodes(self):
         return list(self._seed_nodes)

--- a/lib/live_cluster/live_cluster_root_controller.py
+++ b/lib/live_cluster/live_cluster_root_controller.py
@@ -45,7 +45,16 @@ from .manage_controller import (
 )
 
 
-@CommandHelp("A tool for interacting with your Aerospike cluster")
+@CommandHelp(
+    "A tool for interacting with your Aerospike cluster.",
+    "Color legend for the Node column of 'info' and 'show' output:",
+    "a node name shown in green is the cluster's expected principal",
+    "(the node with the highest node ID among the nodes asadm is",
+    "connected to, which may differ from the actual cluster principal",
+    "when not connected to every node); a node name shown in cyan is",
+    "the local self node that asadm connected from.",
+    short_msg="A tool for interacting with your Aerospike cluster",
+)
 class LiveClusterRootController(BaseController, AsyncObject):
     cluster: Cluster
 

--- a/lib/live_cluster/live_cluster_root_controller.py
+++ b/lib/live_cluster/live_cluster_root_controller.py
@@ -48,11 +48,11 @@ from .manage_controller import (
 @CommandHelp(
     "A tool for interacting with your Aerospike cluster.",
     "Color legend for the Node column of 'info' and 'show' output:",
-    "a node name shown in green is the cluster's expected principal",
-    "(the node with the highest node ID among the nodes asadm is",
-    "connected to, which may differ from the actual cluster principal",
-    "when not connected to every node); a node name shown in cyan is",
-    "the local self node that asadm connected from.",
+    "a node shown in green (node name and Node ID prefixed with *) is the",
+    "cluster's expected principal (the node with the highest node ID among",
+    "the nodes asadm is connected to, which may differ from the actual",
+    "cluster principal when not connected to every node); a node shown in",
+    "cyan (prefixed with @) is the local self node that asadm connected from.",
     short_msg="A tool for interacting with your Aerospike cluster",
 )
 class LiveClusterRootController(BaseController, AsyncObject):

--- a/lib/view/sheet/decleration.py
+++ b/lib/view/sheet/decleration.py
@@ -252,6 +252,20 @@ class Formatters(object):
             Formatters._should_apply(predicate_fn, terminal.bold, terminal.unbold),
         )
 
+    @staticmethod
+    def bold_cyan_alert(
+        predicate_fn: FormatterPredicateFnType,
+    ) -> FormatterType:
+        """Applies bold + cyan (light blue) formatting if predicate evaluates to True."""
+        return (
+            "bold-cyan-alert",
+            Formatters._should_apply(
+                predicate_fn,
+                lambda: terminal.bold() + terminal.fg_cyan(),
+                lambda: terminal.fg_not_cyan() + terminal.unbold(),
+            ),
+        )
+
 
 AggregatorFunc = Callable[..., Any]
 

--- a/lib/view/templates.py
+++ b/lib/view/templates.py
@@ -131,7 +131,7 @@ node_field = Field(
     Projectors.String("node_names", None),
     formatters=(
         Formatters.bold_cyan_alert(
-            lambda edata: edata.record["Node ID"] == edata.common.get("self_node")
+            lambda edata: edata.record["Node ID"] == edata.common["self_node"]
         ),
         Formatters.green_alert(
             lambda edata: edata.record["Node ID"] == edata.common["principal"]

--- a/lib/view/templates.py
+++ b/lib/view/templates.py
@@ -126,15 +126,33 @@ def weighted_avg(values: Iterable[float], weights: Iterable[float]):
 # Common fields.
 #
 
+
+def _node_marker(node_id, common):
+    """Plain-text counterpart of the green/cyan node highlighting, so the
+    signal survives copy/paste and --no-color: "*" = expected principal,
+    "@" = self node. Principal wins when a node is both."""
+    common = common or {}
+    if node_id:
+        if node_id == common.get("principal"):
+            return "*"
+        if node_id == common.get("self_node"):
+            return "@"
+    return ""
+
+
 node_field = Field(
     "Node",
     Projectors.String("node_names", None),
+    converter=(
+        lambda edata: _node_marker(edata.record.get("Node ID"), edata.common)
+        + edata.value
+    ),
     formatters=(
-        Formatters.bold_cyan_alert(
-            lambda edata: edata.record["Node ID"] == edata.common["self_node"]
-        ),
         Formatters.green_alert(
             lambda edata: edata.record["Node ID"] == edata.common["principal"]
+        ),
+        Formatters.bold_cyan_alert(
+            lambda edata: edata.record["Node ID"] == edata.common["self_node"]
         ),
     ),
 )
@@ -155,15 +173,14 @@ info_network_sheet = Sheet(
             "Node ID",
             Projectors.String("node_ids", None),
             converter=(
-                lambda edata: (
-                    "*" + edata.value
-                    if edata.value == edata.common["principal"]
-                    else edata.value
-                )
+                lambda edata: _node_marker(edata.value, edata.common) + edata.value
             ),
             formatters=(
                 Formatters.green_alert(
                     lambda edata: edata.record["Node ID"] == edata.common["principal"]
+                ),
+                Formatters.bold_cyan_alert(
+                    lambda edata: edata.record["Node ID"] == edata.common["self_node"]
                 ),
             ),
             align=FieldAlignment.right,
@@ -339,7 +356,6 @@ info_namespace_usage_sheet = Sheet(
                             Projectors.Number(
                                 "ns_stats",
                                 "index_used_bytes",
-                                "memory_used_index_bytes",
                             ),
                             Projectors.Number(
                                 "ns_stats",
@@ -425,7 +441,6 @@ info_namespace_usage_sheet = Sheet(
                             Projectors.Number(
                                 "ns_stats",
                                 "sindex_used_bytes",
-                                "memory_used_sindex_bytes",
                             ),
                             Projectors.Number(
                                 "ns_stats",
@@ -2517,15 +2532,14 @@ show_roster = Sheet(
             "Node ID",
             Projectors.String("node_ids", None),
             converter=(
-                lambda edata: (
-                    "*" + edata.value
-                    if edata.value == edata.common["principal"]
-                    else edata.value
-                )
+                lambda edata: _node_marker(edata.value, edata.common) + edata.value
             ),
             formatters=(
                 Formatters.green_alert(
                     lambda edata: edata.record["Node ID"] == edata.common["principal"]
+                ),
+                Formatters.bold_cyan_alert(
+                    lambda edata: edata.record["Node ID"] == edata.common["self_node"]
                 ),
             ),
             align=FieldAlignment.left,

--- a/lib/view/templates.py
+++ b/lib/view/templates.py
@@ -130,6 +130,9 @@ node_field = Field(
     "Node",
     Projectors.String("node_names", None),
     formatters=(
+        Formatters.bold_cyan_alert(
+            lambda edata: edata.record["Node ID"] == edata.common.get("self_node")
+        ),
         Formatters.green_alert(
             lambda edata: edata.record["Node ID"] == edata.common["principal"]
         ),
@@ -332,6 +335,17 @@ info_namespace_usage_sheet = Sheet(
                                 "index-type.mounts-size-limit",
                             ),
                         ),
+                        Projectors.Div(  # shmem with indexes-memory-budget (7.1+)
+                            Projectors.Number(
+                                "ns_stats",
+                                "index_used_bytes",
+                                "memory_used_index_bytes",
+                            ),
+                            Projectors.Number(
+                                "ns_stats",
+                                "indexes-memory-budget",
+                            ),
+                        ),
                     ),
                     converter=Converters.ratio_to_pct,
                     aggregator=ComplexAggregator(
@@ -405,6 +419,17 @@ info_namespace_usage_sheet = Sheet(
                             Projectors.Number(
                                 "ns_stats",
                                 "sindex-type.mounts-size-limit",
+                            ),
+                        ),
+                        Projectors.Div(  # shmem with indexes-memory-budget (7.1+)
+                            Projectors.Number(
+                                "ns_stats",
+                                "sindex_used_bytes",
+                                "memory_used_sindex_bytes",
+                            ),
+                            Projectors.Number(
+                                "ns_stats",
+                                "indexes-memory-budget",
                             ),
                         ),
                     ),

--- a/lib/view/view.py
+++ b/lib/view/view.py
@@ -102,6 +102,16 @@ class CliView(object):
         return " (" + str(timestamp) + ")"
 
     @staticmethod
+    def _common(cluster, **extra):
+        """Build the 'common' dict passed to sheet rendering. Extra keyword
+        arguments are merged in for sheets that need additional fields."""
+        return dict(
+            principal=cluster.get_expected_principal(),
+            self_node=cluster.get_self_node(),
+            **extra,
+        )
+
+    @staticmethod
     @reserved_modifiers
     def info_network(
         stats,
@@ -146,9 +156,8 @@ class CliView(object):
         common_key = util.find_most_frequent(cluster_keys)
         common_principal = util.find_most_frequent(cluster_principals)
 
-        common = dict(
-            principal=cluster.get_expected_principal(),
-            self_node=cluster.get_self_node(),
+        common = CliView._common(
+            cluster,
             common_size=common_size,
             common_key=common_key,
             common_principal=common_principal,
@@ -173,7 +182,7 @@ class CliView(object):
             ns_stats=ns_stats,
             service_stats=service_stats,
         )
-        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
+        common = CliView._common(cluster)
 
         CliView.print_result(
             sheet.render(
@@ -207,7 +216,7 @@ class CliView(object):
             node_names=node_names,
             ns_stats=stats,
         )
-        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
+        common = CliView._common(cluster)
 
         CliView.print_result(
             sheet.render(
@@ -235,7 +244,7 @@ class CliView(object):
             node_names=node_names,
             ns_stats=ns_stats,
         )
-        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
+        common = CliView._common(cluster)
 
         CliView.print_result(
             sheet.render(
@@ -264,7 +273,7 @@ class CliView(object):
             node_names=node_names,
             ns_stats=ns_stats,
         )
-        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
+        common = CliView._common(cluster)
 
         CliView.print_result(
             sheet.render(
@@ -287,7 +296,7 @@ class CliView(object):
             node_names=node_names,
             set_stats=stats,
         )
-        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
+        common = CliView._common(cluster)
 
         CliView.print_result(
             sheet.render(templates.info_set_sheet, title, sources, common=common)
@@ -306,7 +315,7 @@ class CliView(object):
             node_names=node_names,
             dc_stats=stats,
         )
-        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
+        common = CliView._common(cluster)
 
         CliView.print_result(
             sheet.render(templates.info_dc_sheet, title, sources, common=common)
@@ -332,7 +341,7 @@ class CliView(object):
             builds=builds,
             xdr_stats=stats,
         )
-        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
+        common = CliView._common(cluster)
 
         CliView.print_result(
             sheet.render(templates.info_old_xdr_sheet, title, sources, common=common)
@@ -343,7 +352,7 @@ class CliView(object):
         title_suffix = CliView._get_timestamp_suffix(timestamp)
         node_names = cluster.get_node_names()
         node_ids = cluster.get_node_ids()
-        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
+        common = CliView._common(cluster)
         stats = util.flip_keys(stats)
         dcs = list(stats.keys())
         dcs.sort()
@@ -391,7 +400,7 @@ class CliView(object):
             node_names=node_names,
             sindex_stats=sindex_stats,
         )
-        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
+        common = CliView._common(cluster)
 
         CliView.print_result(
             sheet.render(templates.info_sindex_sheet, title, sources, common=common)
@@ -583,7 +592,7 @@ class CliView(object):
         sources = dict(node_names=node_names, data=service_configs, node_ids=node_ids)
         disable_aggregations = not show_total
         style = SheetStyle.columns if flip_output else None
-        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
+        common = CliView._common(cluster)
 
         CliView.print_result(
             sheet.render(
@@ -623,7 +632,7 @@ class CliView(object):
         title_suffix = CliView._get_timestamp_suffix(timestamp)
         node_names = cluster.get_node_names(with_)
         node_ids = cluster.get_node_ids(with_)
-        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
+        common = CliView._common(cluster)
         style = SheetStyle.columns if flip_output else None
 
         # dict format starts at {node: {dc: {ns:{}}}}
@@ -675,7 +684,7 @@ class CliView(object):
         title_suffix = CliView._get_timestamp_suffix(timestamp)
         node_names = cluster.get_node_names(with_)
         node_ids = cluster.get_node_ids(with_)
-        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
+        common = CliView._common(cluster)
         style = SheetStyle.columns if flip_output else None
 
         # dict format starts at {node: {dc: {ns:{}}}}
@@ -1098,7 +1107,7 @@ class CliView(object):
             node_ids=node_ids,
             pmap=pmap_data,
         )
-        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
+        common = CliView._common(cluster)
 
         CliView.print_result(
             sheet.render(templates.show_pmap_sheet, title, sources, common=common)
@@ -1150,7 +1159,7 @@ class CliView(object):
 
         node_names = cluster.get_node_names(with_)
         node_ids = cluster.get_node_ids(with_)
-        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
+        common = CliView._common(cluster)
         title_timestamp = CliView._get_timestamp_suffix(timestamp)
         title = "Users Statistics{}".format(title_timestamp)
 
@@ -1302,7 +1311,7 @@ class CliView(object):
             node_ids=node_ids,
             data=roster_data,
         )
-        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
+        common = CliView._common(cluster)
         style = SheetStyle.columns
 
         if flip:
@@ -1328,7 +1337,7 @@ class CliView(object):
         title = "Best Practices{}".format(title_timestamp)
         node_names = cluster.get_node_names(with_)
         node_ids = cluster.get_node_ids(with_)
-        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
+        common = CliView._common(cluster)
         sources = dict(data=failed_practices, node_names=node_names, node_ids=node_ids)
 
         CliView.print_result(
@@ -1375,7 +1384,7 @@ class CliView(object):
         node_names = cluster.get_node_names(with_)
         node_ids = cluster.get_node_ids(with_)
         sources = dict(data=filtered_data, node_names=node_names, node_ids=node_ids)
-        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
+        common = CliView._common(cluster)
         style = SheetStyle.columns if flip_output else None
 
         CliView.print_result(
@@ -1440,7 +1449,7 @@ class CliView(object):
         node_names = cluster.get_node_names(hosts)
         node_ids = cluster.get_node_ids(hosts)
         sources = dict(data=jobs_data, node_names=node_names, node_ids=node_ids)
-        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
+        common = CliView._common(cluster)
 
         CliView.print_result(
             sheet.render(templates.kill_jobs, title, sources, common=common)
@@ -1624,7 +1633,7 @@ class CliView(object):
     def print_info_responses(title, responses, cluster, **mods):
         node_names = cluster.get_node_names(mods.get("with", []))
         sources = dict(data=responses, node_names=node_names)
-        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
+        common = CliView._common(cluster)
 
         CliView.print_result(
             sheet.render(templates.node_info_responses, title, sources, common=common)
@@ -2761,7 +2770,7 @@ class CliView(object):
             node_names=node_names,
             node_ids=node_ids,
         )
-        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
+        common = CliView._common(cluster)
 
         CliView.print_result(
             sheet.render(templates.info_release_sheet, title, sources, common=common)

--- a/lib/view/view.py
+++ b/lib/view/view.py
@@ -148,6 +148,7 @@ class CliView(object):
 
         common = dict(
             principal=cluster.get_expected_principal(),
+            self_node=cluster.get_self_node(),
             common_size=common_size,
             common_key=common_key,
             common_principal=common_principal,
@@ -172,7 +173,7 @@ class CliView(object):
             ns_stats=ns_stats,
             service_stats=service_stats,
         )
-        common = dict(principal=cluster.get_expected_principal())
+        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
 
         CliView.print_result(
             sheet.render(
@@ -206,7 +207,7 @@ class CliView(object):
             node_names=node_names,
             ns_stats=stats,
         )
-        common = dict(principal=cluster.get_expected_principal())
+        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
 
         CliView.print_result(
             sheet.render(
@@ -234,7 +235,7 @@ class CliView(object):
             node_names=node_names,
             ns_stats=ns_stats,
         )
-        common = dict(principal=cluster.get_expected_principal())
+        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
 
         CliView.print_result(
             sheet.render(
@@ -263,7 +264,7 @@ class CliView(object):
             node_names=node_names,
             ns_stats=ns_stats,
         )
-        common = dict(principal=cluster.get_expected_principal())
+        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
 
         CliView.print_result(
             sheet.render(
@@ -286,7 +287,7 @@ class CliView(object):
             node_names=node_names,
             set_stats=stats,
         )
-        common = dict(principal=cluster.get_expected_principal())
+        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
 
         CliView.print_result(
             sheet.render(templates.info_set_sheet, title, sources, common=common)
@@ -305,7 +306,7 @@ class CliView(object):
             node_names=node_names,
             dc_stats=stats,
         )
-        common = dict(principal=cluster.get_expected_principal())
+        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
 
         CliView.print_result(
             sheet.render(templates.info_dc_sheet, title, sources, common=common)
@@ -331,7 +332,7 @@ class CliView(object):
             builds=builds,
             xdr_stats=stats,
         )
-        common = dict(principal=cluster.get_expected_principal())
+        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
 
         CliView.print_result(
             sheet.render(templates.info_old_xdr_sheet, title, sources, common=common)
@@ -342,7 +343,7 @@ class CliView(object):
         title_suffix = CliView._get_timestamp_suffix(timestamp)
         node_names = cluster.get_node_names()
         node_ids = cluster.get_node_ids()
-        common = dict(principal=cluster.get_expected_principal())
+        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
         stats = util.flip_keys(stats)
         dcs = list(stats.keys())
         dcs.sort()
@@ -390,7 +391,7 @@ class CliView(object):
             node_names=node_names,
             sindex_stats=sindex_stats,
         )
-        common = dict(principal=cluster.get_expected_principal())
+        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
 
         CliView.print_result(
             sheet.render(templates.info_sindex_sheet, title, sources, common=common)
@@ -582,7 +583,7 @@ class CliView(object):
         sources = dict(node_names=node_names, data=service_configs, node_ids=node_ids)
         disable_aggregations = not show_total
         style = SheetStyle.columns if flip_output else None
-        common = dict(principal=cluster.get_expected_principal())
+        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
 
         CliView.print_result(
             sheet.render(
@@ -622,7 +623,7 @@ class CliView(object):
         title_suffix = CliView._get_timestamp_suffix(timestamp)
         node_names = cluster.get_node_names(with_)
         node_ids = cluster.get_node_ids(with_)
-        common = dict(principal=cluster.get_expected_principal())
+        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
         style = SheetStyle.columns if flip_output else None
 
         # dict format starts at {node: {dc: {ns:{}}}}
@@ -674,7 +675,7 @@ class CliView(object):
         title_suffix = CliView._get_timestamp_suffix(timestamp)
         node_names = cluster.get_node_names(with_)
         node_ids = cluster.get_node_ids(with_)
-        common = dict(principal=cluster.get_expected_principal())
+        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
         style = SheetStyle.columns if flip_output else None
 
         # dict format starts at {node: {dc: {ns:{}}}}
@@ -1097,7 +1098,7 @@ class CliView(object):
             node_ids=node_ids,
             pmap=pmap_data,
         )
-        common = dict(principal=cluster.get_expected_principal())
+        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
 
         CliView.print_result(
             sheet.render(templates.show_pmap_sheet, title, sources, common=common)
@@ -1149,7 +1150,7 @@ class CliView(object):
 
         node_names = cluster.get_node_names(with_)
         node_ids = cluster.get_node_ids(with_)
-        common = dict(principal=cluster.get_expected_principal())
+        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
         title_timestamp = CliView._get_timestamp_suffix(timestamp)
         title = "Users Statistics{}".format(title_timestamp)
 
@@ -1301,7 +1302,7 @@ class CliView(object):
             node_ids=node_ids,
             data=roster_data,
         )
-        common = dict(principal=cluster.get_expected_principal())
+        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
         style = SheetStyle.columns
 
         if flip:
@@ -1327,7 +1328,7 @@ class CliView(object):
         title = "Best Practices{}".format(title_timestamp)
         node_names = cluster.get_node_names(with_)
         node_ids = cluster.get_node_ids(with_)
-        common = dict(principal=cluster.get_expected_principal())
+        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
         sources = dict(data=failed_practices, node_names=node_names, node_ids=node_ids)
 
         CliView.print_result(
@@ -1374,7 +1375,7 @@ class CliView(object):
         node_names = cluster.get_node_names(with_)
         node_ids = cluster.get_node_ids(with_)
         sources = dict(data=filtered_data, node_names=node_names, node_ids=node_ids)
-        common = dict(principal=cluster.get_expected_principal())
+        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
         style = SheetStyle.columns if flip_output else None
 
         CliView.print_result(
@@ -1439,7 +1440,7 @@ class CliView(object):
         node_names = cluster.get_node_names(hosts)
         node_ids = cluster.get_node_ids(hosts)
         sources = dict(data=jobs_data, node_names=node_names, node_ids=node_ids)
-        common = dict(principal=cluster.get_expected_principal())
+        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
 
         CliView.print_result(
             sheet.render(templates.kill_jobs, title, sources, common=common)
@@ -1623,7 +1624,7 @@ class CliView(object):
     def print_info_responses(title, responses, cluster, **mods):
         node_names = cluster.get_node_names(mods.get("with", []))
         sources = dict(data=responses, node_names=node_names)
-        common = dict(principal=cluster.get_expected_principal())
+        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
 
         CliView.print_result(
             sheet.render(templates.node_info_responses, title, sources, common=common)
@@ -2760,7 +2761,7 @@ class CliView(object):
             node_names=node_names,
             node_ids=node_ids,
         )
-        common = dict(principal=cluster.get_expected_principal())
+        common = dict(principal=cluster.get_expected_principal(), self_node=cluster.get_self_node())
 
         CliView.print_result(
             sheet.render(templates.info_release_sheet, title, sources, common=common)

--- a/test/unit/live_cluster/client/test_cluster.py
+++ b/test/unit/live_cluster/client/test_cluster.py
@@ -418,6 +418,28 @@ class ClusterTest(unittest.IsolatedAsyncioTestCase):
             "get_expected_principal did not return the expected result",
         )
 
+    async def test_get_self_node(self):
+        cl = await self.get_cluster_mock(3)
+        for node in cl.nodes.values():
+            node.localhost = False
+        self_node = cl.nodes["127.0.0.1:3000"]
+        self_node.localhost = True
+        self.assertEqual(
+            cl.get_self_node(),
+            self_node.node_id,
+            "get_self_node did not return the localhost node's id",
+        )
+
+    async def test_get_self_node_returns_empty_when_no_localhost(self):
+        cl = await self.get_cluster_mock(3)
+        for node in cl.nodes.values():
+            node.localhost = False
+        self.assertEqual(
+            cl.get_self_node(),
+            "",
+            "get_self_node did not return '' when no node is localhost",
+        )
+
     async def test_get_visibility_error_nodes_returns_empty(self):
         cl = await self.get_cluster_mock(3)
         cl._refresh_node_liveliness()

--- a/test/unit/view/test_templates.py
+++ b/test/unit/view/test_templates.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import unittest
 from parameterized import parameterized
 
-from lib.view import templates
+from lib.view import sheet, templates
+from lib.view.sheet import SheetStyle
 from lib.view.sheet.decleration import EntryData
 
 
@@ -85,3 +87,112 @@ class HelperTests(unittest.TestCase):
             license_data, compression_enabled
         )
         self.assertEqual(result, expected)
+
+
+class NodeHighlightingTest(unittest.TestCase):
+    """Behavioral coverage for the principal (green, "*") and self-node
+    (cyan, "@") highlighting on info_network_sheet's Node / Node ID columns."""
+
+    node_keys = ("1.1.1.1:3000", "2.2.2.2:3000", "3.3.3.3:3000")
+    node_ids = ("NODE1", "NODE2", "NODE3")
+
+    def render_network_sheet(self, principal, self_node):
+        stats = {
+            key: {
+                "cluster_size": 3,
+                "cluster_key": "CK",
+                "cluster_integrity": True,
+                "paxos_principal": "NODE1",
+                "migrate_partitions_remaining": 0,
+                "client_connections": 1,
+                "uptime": 100,
+            }
+            for key in self.node_keys
+        }
+        sources = dict(
+            node_names={key: key for key in self.node_keys},
+            node_ids=dict(zip(self.node_keys, self.node_ids)),
+            hosts={key: key for key in self.node_keys},
+            builds={key: "7.1.0.0" for key in self.node_keys},
+            versions={key: "7.1.0.0" for key in self.node_keys},
+            stats=stats,
+        )
+        common = dict(
+            principal=principal,
+            self_node=self_node,
+            common_size="3",
+            common_key="CK",
+            common_principal="NODE1",
+        )
+        render = json.loads(
+            sheet.render(
+                templates.info_network_sheet,
+                "test",
+                sources,
+                common=common,
+                style=SheetStyle.json,
+            )
+        )
+        records = render["groups"][0]["records"]
+        return {record["Node ID"]["raw"]: record for record in records}
+
+    def test_principal_is_green_and_star_prefixed(self):
+        records = self.render_network_sheet(principal="NODE1", self_node="NODE2")
+
+        self.assertEqual(records["NODE1"]["Node"]["format"], "green-alert")
+        self.assertEqual(records["NODE1"]["Node"]["converted"], "*1.1.1.1:3000")
+        self.assertEqual(records["NODE1"]["Node ID"]["format"], "green-alert")
+        self.assertEqual(records["NODE1"]["Node ID"]["converted"], "*NODE1")
+
+    def test_self_node_is_cyan_and_at_prefixed(self):
+        records = self.render_network_sheet(principal="NODE1", self_node="NODE2")
+
+        self.assertEqual(records["NODE2"]["Node"]["format"], "bold-cyan-alert")
+        self.assertEqual(records["NODE2"]["Node"]["converted"], "@2.2.2.2:3000")
+        self.assertEqual(records["NODE2"]["Node ID"]["format"], "bold-cyan-alert")
+        self.assertEqual(records["NODE2"]["Node ID"]["converted"], "@NODE2")
+
+    def test_plain_node_has_no_format_or_prefix(self):
+        records = self.render_network_sheet(principal="NODE1", self_node="NODE2")
+
+        self.assertNotIn("format", records["NODE3"]["Node"])
+        self.assertEqual(records["NODE3"]["Node"]["converted"], "3.3.3.3:3000")
+        self.assertNotIn("format", records["NODE3"]["Node ID"])
+        self.assertEqual(records["NODE3"]["Node ID"]["converted"], "NODE3")
+
+    def test_principal_wins_when_node_is_both_principal_and_self(self):
+        records = self.render_network_sheet(principal="NODE1", self_node="NODE1")
+
+        self.assertEqual(records["NODE1"]["Node"]["format"], "green-alert")
+        self.assertEqual(records["NODE1"]["Node"]["converted"], "*1.1.1.1:3000")
+        self.assertEqual(records["NODE1"]["Node ID"]["format"], "green-alert")
+        self.assertEqual(records["NODE1"]["Node ID"]["converted"], "*NODE1")
+
+    def test_no_marker_when_self_node_unknown(self):
+        """Empty self_node (collectinfo / no localhost node) must not mark anything."""
+        records = self.render_network_sheet(principal="NODE1", self_node="")
+
+        self.assertEqual(records["NODE2"]["Node"]["converted"], "2.2.2.2:3000")
+        self.assertNotIn("format", records["NODE2"]["Node"])
+
+    def test_sheet_without_node_id_column_renders_unmarked(self):
+        """node_info_responses has no Node ID field; the Node converter must
+        degrade to no marker instead of raising KeyError."""
+        sources = dict(
+            node_names={"1.1.1.1:3000": "node1"},
+            data={"1.1.1.1:3000": "ok."},
+        )
+        common = dict(principal="NODE1", self_node="NODE2")
+
+        render = json.loads(
+            sheet.render(
+                templates.node_info_responses,
+                "test",
+                sources,
+                common=common,
+                style=SheetStyle.json,
+            )
+        )
+        record = render["groups"][0]["records"][0]
+
+        self.assertEqual(record["Node"]["converted"], "node1")

--- a/test/unit/view/test_view.py
+++ b/test/unit/view/test_view.py
@@ -57,7 +57,10 @@ class CliViewTest(unittest.TestCase):
         node_names = {"1.1.1.1": "1.1.1.1 is my name"}
         node_ids = {"1.1.1.1": "ABCD"}
         principal = "test-principal"
-        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
+        common = {
+            "principal": principal,
+            "self_node": self.cluster_mock.get_self_node.return_value,
+        }
         self.cluster_mock.get_node_names.return_value = node_names
         self.cluster_mock.get_node_ids.return_value = node_ids
         self.cluster_mock.get_expected_principal.return_value = principal
@@ -165,7 +168,10 @@ class CliViewTest(unittest.TestCase):
         node_names = {"1.1.1.1": "1.1.1.1 is my name", "2.2.2.2": "2.2.2.2 is my name"}
         node_ids = {"1.1.1.1": "ABCD", "2.2.2.2": "EFGH"}
         principal = "test-principal"
-        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
+        common = {
+            "principal": principal,
+            "self_node": self.cluster_mock.get_self_node.return_value,
+        }
         self.cluster_mock.get_node_names.return_value = node_names
         self.cluster_mock.get_node_ids.return_value = node_ids
         self.cluster_mock.get_expected_principal.return_value = principal
@@ -206,7 +212,10 @@ class CliViewTest(unittest.TestCase):
             "node_names": "node_names",
             "node_ids": "node_ids",
         }
-        common = {"principal": "principal", "self_node": self.cluster_mock.get_self_node.return_value}
+        common = {
+            "principal": "principal",
+            "self_node": self.cluster_mock.get_self_node.return_value,
+        }
 
         CliView.show_best_practices(
             self.cluster_mock,
@@ -245,7 +254,10 @@ class CliViewTest(unittest.TestCase):
             "node_names": "node_names",
             "node_ids": "node_ids",
         }
-        common = {"principal": "principal", "self_node": self.cluster_mock.get_self_node.return_value}
+        common = {
+            "principal": "principal",
+            "self_node": self.cluster_mock.get_self_node.return_value,
+        }
 
         CliView.show_jobs(
             "Jobs",
@@ -289,7 +301,10 @@ class CliViewTest(unittest.TestCase):
                 "node_names": "node_names",
                 "node_ids": "node_ids",
             },
-            common={"principal": "principal", "self_node": self.cluster_mock.get_self_node.return_value},
+            common={
+                "principal": "principal",
+                "self_node": self.cluster_mock.get_self_node.return_value,
+            },
             selectors=None,
             style=SheetStyle.columns,
             disable_title_fill_repeat=True,
@@ -528,7 +543,10 @@ class CliViewTest(unittest.TestCase):
                     title_repeat=False,
                     dynamic_diff=False,
                     disable_aggregations=True,
-                    common={"principal": "principal", "self_node": self.cluster_mock.get_self_node.return_value},
+                    common={
+                        "principal": "principal",
+                        "self_node": self.cluster_mock.get_self_node.return_value,
+                    },
                 ),
                 call(
                     templates.show_xdr_ns_sheet,
@@ -539,7 +557,10 @@ class CliViewTest(unittest.TestCase):
                     title_repeat=False,
                     dynamic_diff=False,
                     disable_aggregations=True,
-                    common={"principal": "principal", "self_node": self.cluster_mock.get_self_node.return_value},
+                    common={
+                        "principal": "principal",
+                        "self_node": self.cluster_mock.get_self_node.return_value,
+                    },
                 ),
             ],
             any_order=False,
@@ -602,7 +623,10 @@ class CliViewTest(unittest.TestCase):
                     style=SheetStyle.columns,
                     title_repeat=False,
                     disable_aggregations=True,
-                    common={"principal": "principal", "self_node": self.cluster_mock.get_self_node.return_value},
+                    common={
+                        "principal": "principal",
+                        "self_node": self.cluster_mock.get_self_node.return_value,
+                    },
                 ),
                 call(
                     templates.show_xdr_ns_sheet,
@@ -612,7 +636,10 @@ class CliViewTest(unittest.TestCase):
                     style=SheetStyle.columns,
                     title_repeat=False,
                     disable_aggregations=True,
-                    common={"principal": "principal", "self_node": self.cluster_mock.get_self_node.return_value},
+                    common={
+                        "principal": "principal",
+                        "self_node": self.cluster_mock.get_self_node.return_value,
+                    },
                 ),
             ],
             any_order=False,
@@ -679,7 +706,10 @@ class CliViewTest(unittest.TestCase):
                     style=SheetStyle.columns,
                     title_repeat=False,
                     disable_aggregations=True,
-                    common={"principal": "principal", "self_node": self.cluster_mock.get_self_node.return_value},
+                    common={
+                        "principal": "principal",
+                        "self_node": self.cluster_mock.get_self_node.return_value,
+                    },
                 ),
                 call(
                     templates.show_xdr_ns_sheet_by_dc,
@@ -689,7 +719,10 @@ class CliViewTest(unittest.TestCase):
                     style=SheetStyle.columns,
                     title_repeat=False,
                     disable_aggregations=True,
-                    common={"principal": "principal", "self_node": self.cluster_mock.get_self_node.return_value},
+                    common={
+                        "principal": "principal",
+                        "self_node": self.cluster_mock.get_self_node.return_value,
+                    },
                 ),
             ],
             any_order=False,
@@ -823,7 +856,10 @@ class CliViewTest(unittest.TestCase):
         node_names = {"1.1.1.1": "1.1.1.1 is my name"}
         node_ids = {"1.1.1.1": "ABCD"}
         principal = "test-principal"
-        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
+        common = {
+            "principal": principal,
+            "self_node": self.cluster_mock.get_self_node.return_value,
+        }
         self.cluster_mock.get_node_names.return_value = node_names
         self.cluster_mock.get_node_ids.return_value = node_ids
         self.cluster_mock.get_expected_principal.return_value = principal
@@ -1260,7 +1296,10 @@ class CliViewTest(unittest.TestCase):
             "ns_stats": ns_stats,
             "service_stats": service_stats,
         }
-        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
+        common = {
+            "principal": principal,
+            "self_node": self.cluster_mock.get_self_node.return_value,
+        }
 
         CliView.info_namespace_usage(
             ns_stats, service_stats, self.cluster_mock, timestamp="test-stamp"
@@ -1303,7 +1342,10 @@ class CliViewTest(unittest.TestCase):
             "ns_stats": ns_stats,
             "service_stats": service_stats,
         }
-        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
+        common = {
+            "principal": principal,
+            "self_node": self.cluster_mock.get_self_node.return_value,
+        }
 
         CliView.info_namespace_usage(
             ns_stats, service_stats, self.cluster_mock, timestamp="test-stamp"
@@ -1346,7 +1388,10 @@ class CliViewTest(unittest.TestCase):
             "ns_stats": ns_stats,
             "service_stats": service_stats,
         }
-        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
+        common = {
+            "principal": principal,
+            "self_node": self.cluster_mock.get_self_node.return_value,
+        }
 
         CliView.info_namespace_usage(
             ns_stats, service_stats, self.cluster_mock, timestamp="test-stamp"
@@ -1396,7 +1441,10 @@ class CliViewTest(unittest.TestCase):
             "ns_stats": ns_stats,
             "service_stats": service_stats,
         }
-        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
+        common = {
+            "principal": principal,
+            "self_node": self.cluster_mock.get_self_node.return_value,
+        }
 
         CliView.info_namespace_usage(
             ns_stats, service_stats, self.cluster_mock, timestamp="test-stamp"
@@ -1438,7 +1486,10 @@ class CliViewTest(unittest.TestCase):
             "ns_stats": ns_stats,
             "service_stats": service_stats,
         }
-        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
+        common = {
+            "principal": principal,
+            "self_node": self.cluster_mock.get_self_node.return_value,
+        }
 
         CliView.info_namespace_usage(
             ns_stats, service_stats, self.cluster_mock, timestamp="test-stamp"
@@ -1484,7 +1535,10 @@ class CliViewTest(unittest.TestCase):
             "ns_stats": ns_stats,
             "service_stats": service_stats,
         }
-        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
+        common = {
+            "principal": principal,
+            "self_node": self.cluster_mock.get_self_node.return_value,
+        }
 
         CliView.info_namespace_usage(
             ns_stats, service_stats, self.cluster_mock, timestamp="test-stamp"
@@ -1515,7 +1569,10 @@ class CliViewTest(unittest.TestCase):
             "ns_stats": ns_stats,
             "service_stats": service_stats,
         }
-        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
+        common = {
+            "principal": principal,
+            "self_node": self.cluster_mock.get_self_node.return_value,
+        }
 
         CliView.info_namespace_usage(
             ns_stats, service_stats, self.cluster_mock, timestamp="test-stamp"
@@ -1810,7 +1867,10 @@ class CliViewTest(unittest.TestCase):
             "node_names": node_names,
             "ns_stats": ns_stats,
         }
-        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
+        common = {
+            "principal": principal,
+            "self_node": self.cluster_mock.get_self_node.return_value,
+        }
 
         CliView.info_transactions_monitors(ns_stats, self.cluster_mock)
 
@@ -1854,7 +1914,13 @@ class CliViewTest(unittest.TestCase):
 
         # Verify the title and common data
         self.assertEqual(args[1], "Transaction Monitor Metrics (test-timestamp)")
-        self.assertEqual(kwargs.get("common"), {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value})
+        self.assertEqual(
+            kwargs.get("common"),
+            {
+                "principal": principal,
+                "self_node": self.cluster_mock.get_self_node.return_value,
+            },
+        )
 
         # Verify the sources structure
         sources = args[2]
@@ -2207,7 +2273,10 @@ class CliViewTest(unittest.TestCase):
             "node_names": node_names,
             "ns_stats": ns_stats,
         }
-        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
+        common = {
+            "principal": principal,
+            "self_node": self.cluster_mock.get_self_node.return_value,
+        }
 
         CliView.info_transactions_provisionals(
             ns_stats, self.cluster_mock, timestamp="test-stamp"

--- a/test/unit/view/test_view.py
+++ b/test/unit/view/test_view.py
@@ -57,7 +57,7 @@ class CliViewTest(unittest.TestCase):
         node_names = {"1.1.1.1": "1.1.1.1 is my name"}
         node_ids = {"1.1.1.1": "ABCD"}
         principal = "test-principal"
-        common = {"principal": principal}
+        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
         self.cluster_mock.get_node_names.return_value = node_names
         self.cluster_mock.get_node_ids.return_value = node_ids
         self.cluster_mock.get_expected_principal.return_value = principal
@@ -165,7 +165,7 @@ class CliViewTest(unittest.TestCase):
         node_names = {"1.1.1.1": "1.1.1.1 is my name", "2.2.2.2": "2.2.2.2 is my name"}
         node_ids = {"1.1.1.1": "ABCD", "2.2.2.2": "EFGH"}
         principal = "test-principal"
-        common = {"principal": principal}
+        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
         self.cluster_mock.get_node_names.return_value = node_names
         self.cluster_mock.get_node_ids.return_value = node_ids
         self.cluster_mock.get_expected_principal.return_value = principal
@@ -206,7 +206,7 @@ class CliViewTest(unittest.TestCase):
             "node_names": "node_names",
             "node_ids": "node_ids",
         }
-        common = {"principal": "principal"}
+        common = {"principal": "principal", "self_node": self.cluster_mock.get_self_node.return_value}
 
         CliView.show_best_practices(
             self.cluster_mock,
@@ -245,7 +245,7 @@ class CliViewTest(unittest.TestCase):
             "node_names": "node_names",
             "node_ids": "node_ids",
         }
-        common = {"principal": "principal"}
+        common = {"principal": "principal", "self_node": self.cluster_mock.get_self_node.return_value}
 
         CliView.show_jobs(
             "Jobs",
@@ -289,7 +289,7 @@ class CliViewTest(unittest.TestCase):
                 "node_names": "node_names",
                 "node_ids": "node_ids",
             },
-            common={"principal": "principal"},
+            common={"principal": "principal", "self_node": self.cluster_mock.get_self_node.return_value},
             selectors=None,
             style=SheetStyle.columns,
             disable_title_fill_repeat=True,
@@ -528,7 +528,7 @@ class CliViewTest(unittest.TestCase):
                     title_repeat=False,
                     dynamic_diff=False,
                     disable_aggregations=True,
-                    common={"principal": "principal"},
+                    common={"principal": "principal", "self_node": self.cluster_mock.get_self_node.return_value},
                 ),
                 call(
                     templates.show_xdr_ns_sheet,
@@ -539,7 +539,7 @@ class CliViewTest(unittest.TestCase):
                     title_repeat=False,
                     dynamic_diff=False,
                     disable_aggregations=True,
-                    common={"principal": "principal"},
+                    common={"principal": "principal", "self_node": self.cluster_mock.get_self_node.return_value},
                 ),
             ],
             any_order=False,
@@ -602,7 +602,7 @@ class CliViewTest(unittest.TestCase):
                     style=SheetStyle.columns,
                     title_repeat=False,
                     disable_aggregations=True,
-                    common={"principal": "principal"},
+                    common={"principal": "principal", "self_node": self.cluster_mock.get_self_node.return_value},
                 ),
                 call(
                     templates.show_xdr_ns_sheet,
@@ -612,7 +612,7 @@ class CliViewTest(unittest.TestCase):
                     style=SheetStyle.columns,
                     title_repeat=False,
                     disable_aggregations=True,
-                    common={"principal": "principal"},
+                    common={"principal": "principal", "self_node": self.cluster_mock.get_self_node.return_value},
                 ),
             ],
             any_order=False,
@@ -679,7 +679,7 @@ class CliViewTest(unittest.TestCase):
                     style=SheetStyle.columns,
                     title_repeat=False,
                     disable_aggregations=True,
-                    common={"principal": "principal"},
+                    common={"principal": "principal", "self_node": self.cluster_mock.get_self_node.return_value},
                 ),
                 call(
                     templates.show_xdr_ns_sheet_by_dc,
@@ -689,7 +689,7 @@ class CliViewTest(unittest.TestCase):
                     style=SheetStyle.columns,
                     title_repeat=False,
                     disable_aggregations=True,
-                    common={"principal": "principal"},
+                    common={"principal": "principal", "self_node": self.cluster_mock.get_self_node.return_value},
                 ),
             ],
             any_order=False,
@@ -823,7 +823,7 @@ class CliViewTest(unittest.TestCase):
         node_names = {"1.1.1.1": "1.1.1.1 is my name"}
         node_ids = {"1.1.1.1": "ABCD"}
         principal = "test-principal"
-        common = {"principal": principal}
+        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
         self.cluster_mock.get_node_names.return_value = node_names
         self.cluster_mock.get_node_ids.return_value = node_ids
         self.cluster_mock.get_expected_principal.return_value = principal
@@ -1260,7 +1260,7 @@ class CliViewTest(unittest.TestCase):
             "ns_stats": ns_stats,
             "service_stats": service_stats,
         }
-        common = {"principal": principal}
+        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
 
         CliView.info_namespace_usage(
             ns_stats, service_stats, self.cluster_mock, timestamp="test-stamp"
@@ -1303,7 +1303,7 @@ class CliViewTest(unittest.TestCase):
             "ns_stats": ns_stats,
             "service_stats": service_stats,
         }
-        common = {"principal": principal}
+        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
 
         CliView.info_namespace_usage(
             ns_stats, service_stats, self.cluster_mock, timestamp="test-stamp"
@@ -1346,7 +1346,7 @@ class CliViewTest(unittest.TestCase):
             "ns_stats": ns_stats,
             "service_stats": service_stats,
         }
-        common = {"principal": principal}
+        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
 
         CliView.info_namespace_usage(
             ns_stats, service_stats, self.cluster_mock, timestamp="test-stamp"
@@ -1396,7 +1396,7 @@ class CliViewTest(unittest.TestCase):
             "ns_stats": ns_stats,
             "service_stats": service_stats,
         }
-        common = {"principal": principal}
+        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
 
         CliView.info_namespace_usage(
             ns_stats, service_stats, self.cluster_mock, timestamp="test-stamp"
@@ -1438,7 +1438,7 @@ class CliViewTest(unittest.TestCase):
             "ns_stats": ns_stats,
             "service_stats": service_stats,
         }
-        common = {"principal": principal}
+        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
 
         CliView.info_namespace_usage(
             ns_stats, service_stats, self.cluster_mock, timestamp="test-stamp"
@@ -1484,7 +1484,7 @@ class CliViewTest(unittest.TestCase):
             "ns_stats": ns_stats,
             "service_stats": service_stats,
         }
-        common = {"principal": principal}
+        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
 
         CliView.info_namespace_usage(
             ns_stats, service_stats, self.cluster_mock, timestamp="test-stamp"
@@ -1515,7 +1515,7 @@ class CliViewTest(unittest.TestCase):
             "ns_stats": ns_stats,
             "service_stats": service_stats,
         }
-        common = {"principal": principal}
+        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
 
         CliView.info_namespace_usage(
             ns_stats, service_stats, self.cluster_mock, timestamp="test-stamp"
@@ -1666,6 +1666,42 @@ class CliViewTest(unittest.TestCase):
         self.assertNotIn("Used%", output)
         self.assertNotIn("SIndex Used%", output)
 
+    def test_info_namespace_usage_shmem_with_memory_budget_shows_used_pct(self):
+        """When indexes-memory-budget is set for shmem, Used% should render as index_used_bytes / indexes-memory-budget."""
+
+        ns_stats = {
+            "2.2.2.2": {
+                "test": {
+                    "indexes-memory-budget": "1000000",
+                    "index_used_bytes": "250000",
+                    "sindex_used_bytes": "100000",
+                    "storage-engine": "memory",
+                    "index-type": "shmem",
+                    "sindex-type": "shmem",
+                }
+            }
+        }
+        service_stats = {"2.2.2.2": {}}
+        node_names = {"2.2.2.2": "node2"}
+        node_ids = {"2.2.2.2": "NODE2"}
+
+        self.cluster_mock = MagicMock()
+        self.cluster_mock.get_node_names.return_value = node_names
+        self.cluster_mock.get_node_ids.return_value = node_ids
+        self.cluster_mock.get_expected_principal.return_value = "test-principal"
+
+        patch.stopall()
+
+        f = io.StringIO()
+        with redirect_stdout(f):
+            CliView.info_namespace_usage(
+                ns_stats, service_stats, self.cluster_mock, timestamp="test-stamp"
+            )
+        output = f.getvalue()
+
+        self.assertIn("Used%", output)
+        self.assertIn("25.0 %", output)
+
     def test_info_namespace_usage_renders_system_memory_stop_pct(self):
         """The System Memory subgroup must surface stop-writes-sys-memory-pct as a Stop% column."""
 
@@ -1774,7 +1810,7 @@ class CliViewTest(unittest.TestCase):
             "node_names": node_names,
             "ns_stats": ns_stats,
         }
-        common = {"principal": principal}
+        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
 
         CliView.info_transactions_monitors(ns_stats, self.cluster_mock)
 
@@ -1818,7 +1854,7 @@ class CliViewTest(unittest.TestCase):
 
         # Verify the title and common data
         self.assertEqual(args[1], "Transaction Monitor Metrics (test-timestamp)")
-        self.assertEqual(kwargs.get("common"), {"principal": principal})
+        self.assertEqual(kwargs.get("common"), {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value})
 
         # Verify the sources structure
         sources = args[2]
@@ -2171,7 +2207,7 @@ class CliViewTest(unittest.TestCase):
             "node_names": node_names,
             "ns_stats": ns_stats,
         }
-        common = {"principal": principal}
+        common = {"principal": principal, "self_node": self.cluster_mock.get_self_node.return_value}
 
         CliView.info_transactions_provisionals(
             ns_stats, self.cluster_mock, timestamp="test-stamp"

--- a/test/unit/view/test_view.py
+++ b/test/unit/view/test_view.py
@@ -1757,7 +1757,8 @@ class CliViewTest(unittest.TestCase):
         output = f.getvalue()
 
         self.assertIn("Used%", output)
-        self.assertIn("25.0 %", output)
+        self.assertIn("25.0 %", output)  # primary: 250000 / 1000000
+        self.assertIn("10.0 %", output)  # secondary: 100000 / 1000000
 
     def test_info_namespace_usage_renders_system_memory_stop_pct(self):
         """The System Memory subgroup must surface stop-writes-sys-memory-pct as a Stop% column."""
@@ -2737,3 +2738,20 @@ class CliViewInfoReleaseTest(unittest.TestCase):
         # Verify cluster methods were called with filter
         cluster_mock.get_node_names.assert_called_once_with(["node1"])
         cluster_mock.get_node_ids.assert_called_once_with(["node1"])
+
+
+class CliViewCollectinfoCompatTest(unittest.TestCase):
+    """Verify CliView._common works with _CollectinfoSnapshot, not just Cluster."""
+
+    def test_common_with_collectinfo_snapshot(self):
+        from lib.collectinfo_analyzer.collectinfo_handler.collectinfo_log import (
+            _CollectinfoSnapshot,
+        )
+
+        snapshot = MagicMock(spec=_CollectinfoSnapshot)
+        snapshot.get_expected_principal.return_value = "ABCD"
+
+        result = CliView._common(snapshot)
+
+        self.assertEqual(result["principal"], "ABCD")
+        self.assertIn("self_node", result)


### PR DESCRIPTION
Two related namespace-usage display improvements, plus a small refactor and the in-app docs for both.

1. Used% for shmem indexes with indexes-memory-budget — fills in a column that was previously blank.
2. Self-node highlight — the local node asadm is running on is now highlighted in cyan in the Node column (name prefixed with `@`), distinct from the existing green principal highlight (prefixed with `*`).

<img width="1408" height="974" alt="image" src="https://github.com/user-attachments/assets/2bce12bf-6312-4cff-bf4a-5fb58ad7f95f" />
<img width="639" height="407" alt="image" src="https://github.com/user-attachments/assets/adb009f2-7c9a-4eee-a325-988a136fd905" />

### Problem

- Used%: Used% for primary/secondary index only resolved for flash/pmem index types (via index_mounts_used_pct or a bytes/limit division). For shmem indexes with indexes-memory-budget configured (7.1+), the column rendered blank even though both the usage bytes and the budget were available.
- Self node: Output highlighted the cluster principal (green) but gave no indication of which node you were physically on — useful context when running asadm directly on a cluster node.

### Changes

- templates.py — Add a third fallback to the Projectors.Any chain for primary and secondary Used%: index_used_bytes / indexes-memory-budget (and the sindex equivalent). Placed last in the chain so flash/pmem nodes are unaffected; when no budget is configured the division returns None and the column stays hidden, exactly as before. Numerators use only the 7.0+ consolidated stat names — the budget denominator is 7.1+, so pre-7.0 memory_used_* fallbacks would be dead code (matches how lib/utils/common.py pairs these stats in the summary).
- cluster.py — Add Cluster.get_self_node(), returning the node_id of the first node flagged localhost (via the is_localhost() accessor), or "".
- collectinfo_log.py — Add _CollectinfoSnapshot.get_self_node() returning "" (a capture has no self node), keeping the snapshot duck-type compatible with Cluster for the shared CliView render paths.
- decleration.py — Add bold_cyan_alert formatter, following the existing *_alert factory pattern.
- templates.py — Apply bold_cyan_alert to the Node column for the self node, listed after green_alert so principal wins the renderer's first-match formatter selection. Add a shared _node_marker helper that prefixes `*` (principal) / `@` (self node) on the Node name column of every sheet and on the Node ID column of info network / show roster, so the signal survives copy/paste, piping, and --no-color. Degrades to no marker on sheets without a Node ID column.
- view.py — Thread self_node into the common dict at every render site. Extract the repeated dict(principal=…, self_node=…) construction (~20 sites) into a single CliView._common(cluster, **extra) helper.
- live_cluster_root_controller.py — Document the color + marker legend (green/`*` = expected principal, cyan/`@` = self node) at the top of the base help menu.
- Apply repo-pinned black (26.3.1) formatting.

### Tests

- NodeHighlightingTest (test_templates.py) renders the real info_network_sheet to JSON and asserts: green + `*` on the principal, cyan + `@` on the self node, no format/marker on other nodes, green precedence when a node is both principal and self, no markers when self_node is empty (collectinfo), and no crash on sheets without a Node ID column.
- test_get_self_node / test_get_self_node_returns_empty_when_no_localhost (test_cluster.py) cover the new Cluster method directly.
- Collectinfo compat test asserts CliView._common works against a spec'd _CollectinfoSnapshot, pinning the duck-type contract.
- The shmem Used% test asserts both the primary (25.0 %) and secondary (10.0 %) index percentages.

### Behavior

- Used% now populates for shmem primary/secondary index when indexes-memory-budget is set; unchanged for flash/pmem and when no budget is configured.
- Self node renders cyan with an `@` name prefix in the Node column of info / show output; principal remains green with `*`. When a node is both, green/`*` wins (principal takes precedence).
- Collectinfo mode (asadm -cf) renders exactly as before: self_node resolves to "" so nothing is highlighted or marked.

#### Notes / known limitations (pre-existing, not introduced here)

- Green = expected principal, computed as the highest node-id among the nodes asadm is connected to (get_expected_principal). When you don't seed the full cluster, this can differ from the real paxos_principal — green may land on the highest-id node of your subset. The new help legend calls this out.
- Self-node detection is IPv4-centric. It relies on a localhost/127.0.0.1 seed or an exact-string match of hostname -I against the node's service addresses. IPv6 is best-effort: ::1 isn't special-cased, and the comparison does no address normalization, so cyan may not appear on IPv6 deployments. Can be hardened in a follow-up.
=
