### PR TITLE
fix: TOOLS-3772 show pmap renders Cluster Key as ~~ for keys shaped like an overflowing float literal

### DIFF
--- a/lib/health/util.py
+++ b/lib/health/util.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import copy
+import math
 
 from lib.utils import util
 
@@ -233,7 +234,13 @@ def h_eval(data):
                 pass
 
             try:
-                return float(data)
+                as_float = float(data)
+
+                # Hex strings like "9E0123456789" (e.g. cluster_key) parse
+                # as scientific notation and overflow to inf, making
+                # different values compare equal; keep the original string.
+                if not math.isinf(as_float) and not math.isnan(as_float):
+                    return as_float
             except Exception:
                 pass
 

--- a/lib/view/sheet/decleration.py
+++ b/lib/view/sheet/decleration.py
@@ -14,6 +14,7 @@
 from collections import Counter
 from functools import reduce
 import logging
+import math
 from operator import itemgetter
 from typing import Any, Callable, Generic, Optional, TypeVar, Union
 
@@ -524,9 +525,16 @@ class Projectors(object):
             value = super().do_project(sheet, sources)
 
             try:
-                return float(value)
+                result = float(value)
             except ValueError:
                 return value
+
+            # Hex strings like "9E0123456789" parse as scientific notation
+            # and overflow to inf; keep the original value in that case.
+            if math.isinf(result) or math.isnan(result):
+                return value
+
+            return result
 
     class Number(SimpleProjector):
         def __init__(self, source: str, *keys, **kwargs):
@@ -539,8 +547,17 @@ class Projectors(object):
                 return int(value)
             except ValueError:
                 try:
-                    return int(float(value))
-                except ValueError:
+                    as_float = float(value)
+
+                    # Hex strings like "9E0123456789" parse as scientific
+                    # notation and overflow to inf, and int(inf) raises
+                    # OverflowError; keep the original value instead of
+                    # failing the entry and rendering it as error_entry.
+                    if math.isinf(as_float) or math.isnan(as_float):
+                        return value
+
+                    return int(as_float)
+                except (ValueError, OverflowError):
                     pass
 
                 return value

--- a/lib/view/sheet/decleration.py
+++ b/lib/view/sheet/decleration.py
@@ -526,7 +526,7 @@ class Projectors(object):
 
             try:
                 result = float(value)
-            except ValueError:
+            except (ValueError, TypeError, OverflowError):
                 return value
 
             # Hex strings like "9E0123456789" parse as scientific notation
@@ -545,7 +545,7 @@ class Projectors(object):
 
             try:
                 return int(value)
-            except ValueError:
+            except (ValueError, TypeError):
                 try:
                     as_float = float(value)
 
@@ -557,7 +557,7 @@ class Projectors(object):
                         return value
 
                     return int(as_float)
-                except (ValueError, OverflowError):
+                except (ValueError, TypeError, OverflowError):
                     pass
 
                 return value

--- a/lib/view/sheet/decleration.py
+++ b/lib/view/sheet/decleration.py
@@ -544,8 +544,9 @@ class Projectors(object):
             value = super().do_project(sheet, sources)
 
             try:
+                # int(value) raises OverflowError when value is float inf.
                 return int(value)
-            except (ValueError, TypeError):
+            except (ValueError, TypeError, OverflowError):
                 try:
                     as_float = float(value)
 

--- a/lib/view/sheet/render/base_rsheet.py
+++ b/lib/view/sheet/render/base_rsheet.py
@@ -332,12 +332,13 @@ class BaseRSheet(object):
 
         for entry in entries:
             try:
+                # int(entry) raises OverflowError when entry is float inf.
                 int(entry)
 
                 if not "." in str(entry):
                     has_int = True
                     continue
-            except (ValueError, TypeError):
+            except (ValueError, TypeError, OverflowError):
                 pass
 
             try:

--- a/lib/view/sheet/render/base_rsheet.py
+++ b/lib/view/sheet/render/base_rsheet.py
@@ -758,7 +758,14 @@ class BaseRField(object):
             aggregate_value = ErrorEntry
         else:
             group_entries = [e for e in group if not e.is_no_entry]
-            aggregate_value = self.decleration.aggregator.compute(group_entries)
+
+            try:
+                aggregate_value = self.decleration.aggregator.compute(group_entries)
+            except Exception:
+                # Aggregating a numeric column that contains a non-numeric
+                # fallback value (e.g. a hex string in a Number field) must
+                # not crash the render.
+                aggregate_value = ErrorEntry
 
             if aggregate_value is None:
                 aggregate_value = NoEntry
@@ -783,7 +790,13 @@ class BaseRField(object):
                     else:
                         group_converted.append(self.rsheet.decleration.no_entry)
                 else:
-                    group_converted.append(str(self.decleration.converter(edata)))
+                    try:
+                        group_converted.append(str(self.decleration.converter(edata)))
+                    except Exception:
+                        # Converters assume numeric input; a non-numeric
+                        # fallback value (e.g. a hex string in a Number
+                        # field) must not crash the render.
+                        group_converted.append(str(edata.value))
 
     def _prepare_convert_aggregates(self):
         if self.decleration.aggregator is None:
@@ -804,9 +817,12 @@ class BaseRField(object):
             elif aggregate is ErrorEntry:
                 self.aggregates_converted.append(self.rsheet.decleration.error_entry)
             else:
-                self.aggregates_converted.append(
-                    str(converter(EntryValue(value=aggregate)))
-                )
+                try:
+                    self.aggregates_converted.append(
+                        str(converter(EntryValue(value=aggregate)))
+                    )
+                except Exception:
+                    self.aggregates_converted.append(str(aggregate))
 
     def entry_value(self, entry):
         if entry is ErrorEntry or entry is NoEntry:

--- a/lib/view/templates.py
+++ b/lib/view/templates.py
@@ -1908,7 +1908,9 @@ show_pmap_sheet = Sheet(
         Field("Namespace", Projectors.String("pmap", None, for_each_key=True)),
         node_field,
         hidden_node_id_field,
-        Field("Cluster Key", Projectors.Number("pmap", "cluster_key")),
+        # The cluster key is a hex string; keys like "9E0123456789" parse as
+        # overflowing scientific notation if projected as a Number.
+        Field("Cluster Key", Projectors.String("pmap", "cluster_key")),
         Subgroup(
             "Partitions",
             (

--- a/lib/view/view.py
+++ b/lib/view/view.py
@@ -15,6 +15,7 @@
 from collections.abc import Iterator
 import datetime
 import locale
+import math
 from os import path
 import sys
 import time
@@ -1818,8 +1819,13 @@ class CliView(object):
             return CliView._format_value(int(val))
         elif isinstance(val, str):
             try:
-                val = float(val)
-                return CliView._format_value(val)
+                as_float = float(val)
+
+                # Hex strings like "9E0123456789" (e.g. cluster_key) parse
+                # as scientific notation and overflow to inf; keep the
+                # original string.
+                if not math.isinf(as_float) and not math.isnan(as_float):
+                    return CliView._format_value(as_float)
             except Exception:
                 pass
 

--- a/test/unit/health/test_util.py
+++ b/test/unit/health/test_util.py
@@ -179,6 +179,12 @@ class UtilTest(unittest.TestCase):
                         ("CONFIG1", "KEY"): "abcd",
                         ("CONFIG2", "KEY"): "100%",
                         ("CONFIG3", "KEY"): "n/e",
+                        # Hex values like cluster_key that parse as
+                        # overflowing scientific notation (TOOLS-3772).
+                        ("CONFIG4", "KEY"): "9E0123456789",
+                        ("CONFIG5", "KEY"): "B40E9AE14C62",
+                        ("CONFIG6", "KEY"): "1E2",
+                        ("CONFIG7", "KEY"): "nan",
                     },
                 }
             }
@@ -196,6 +202,10 @@ class UtilTest(unittest.TestCase):
                     ("NS2", "NAMESPACE"): {
                         ("CONFIG1", "KEY"): "abcd",
                         ("CONFIG2", "KEY"): 100,
+                        ("CONFIG4", "KEY"): "9E0123456789",
+                        ("CONFIG5", "KEY"): "B40E9AE14C62",
+                        ("CONFIG6", "KEY"): 100.0,
+                        ("CONFIG7", "KEY"): "nan",
                     },
                 }
             }

--- a/test/unit/view/test_sheet.py
+++ b/test/unit/view/test_sheet.py
@@ -146,6 +146,8 @@ class SheetTest(unittest.TestCase):
             ("B40E9AE14C62", "B40E9AE14C62", "B40E9AE14C62"),
             ("9E0123456789", "9E0123456789", "9E0123456789"),
             ("1e999", "1e999", "1e999"),
+            # Ints too large for float() raise OverflowError; keep raw value.
+            (10**400, 10**400, str(10**400)),
         ]
     )
     def test_sheet_project_float(self, input, expected_raw, expected_converted):
@@ -174,6 +176,7 @@ class SheetTest(unittest.TestCase):
             ("-1e999", "-1e999", "-1e999"),
             ("nan", "nan", "nan"),
             ("inf", "inf", "inf"),
+            (10**400, 10**400, str(10**400)),
         ]
     )
     def test_sheet_project_number(self, input, expected_raw, expected_converted):
@@ -184,6 +187,25 @@ class SheetTest(unittest.TestCase):
 
         self.assertEqual(value["raw"], expected_raw)
         self.assertEqual(value["converted"], expected_converted)
+
+    @parameterized.expand(
+        [
+            ("number", Projectors.Number),
+            ("float", Projectors.Float),
+        ]
+    )
+    def test_sheet_project_none_is_no_entry(self, _, projector):
+        """A present-but-None value renders as no_entry, not error_entry;
+        int(None)/float(None) previously raised TypeError which surfaced as
+        the error entry '~~'."""
+        test_sheet = Sheet(
+            (Field("F", projector("d", "f"), hidden=False),), from_source="d"
+        )
+        sources = dict(d=dict(n0=dict(f=None)))
+        render = do_render(test_sheet, "test", sources)
+        value = render["groups"][0]["records"][0]["F"]
+
+        self.assertEqual(value["converted"], test_sheet.no_entry)
 
     @parameterized.expand(
         [
@@ -385,6 +407,45 @@ class SheetTest(unittest.TestCase):
 
         self.assertEqual(value["raw"], "error")
         self.assertEqual(value["converted"], test_sheet.error_entry)
+
+    def test_sheet_aggregation_mixed_types_is_error_entry(self):
+        """A numeric column containing a non-numeric fallback value (e.g. a
+        hex string in a Number field) must render the aggregate as
+        error_entry instead of crashing the render (TOOLS-3772)."""
+        test_sheet = Sheet(
+            (Field("F", Projectors.Number("d", "f"), aggregator=Aggregators.sum()),),
+            from_source=("d",),
+        )
+        sources = dict(d=dict(n0=dict(f="1"), n1=dict(f="9E0123456789")))
+        render = do_render(test_sheet, "test", sources)
+        group = render["groups"][0]
+
+        records = {r["F"]["raw"] for r in group["records"]}
+        self.assertEqual(records, {1, "9E0123456789"})
+
+        value = group["aggregates"]["F"]
+
+        self.assertEqual(value["raw"], "error")
+        self.assertEqual(value["converted"], test_sheet.error_entry)
+
+    def test_sheet_converter_failure_falls_back_to_raw(self):
+        """A converter that assumes numeric input must not crash the render
+        when the field falls back to a non-numeric value (TOOLS-3772)."""
+        test_sheet = Sheet(
+            (
+                Field(
+                    "F",
+                    Projectors.Number("d", "f"),
+                    converter=Converters.time_seconds,
+                ),
+            ),
+            from_source=("d",),
+        )
+        sources = dict(d=dict(n0=dict(f="9E0123456789"), n1=dict(f="90061")))
+        render = do_render(test_sheet, "test", sources)
+        converted = {r["F"]["converted"] for r in render["groups"][0]["records"]}
+
+        self.assertEqual(converted, {"9E0123456789", "25:01:01"})
 
     def test_sheet_tuple_field(self):
         test_sheet = Sheet(

--- a/test/unit/view/test_sheet.py
+++ b/test/unit/view/test_sheet.py
@@ -139,6 +139,13 @@ class SheetTest(unittest.TestCase):
             (1.25, 1.25, "1.25"),
             ("42", 42.0, "42.0"),
             (42, 42.0, "42.0"),
+            ("1e3", 1000.0, "1000.0"),
+            # Hex strings fall back to the raw value, including "9E..."
+            # shapes that parse as overflowing scientific notation
+            # (TOOLS-3772).
+            ("B40E9AE14C62", "B40E9AE14C62", "B40E9AE14C62"),
+            ("9E0123456789", "9E0123456789", "9E0123456789"),
+            ("1e999", "1e999", "1e999"),
         ]
     )
     def test_sheet_project_float(self, input, expected_raw, expected_converted):
@@ -151,7 +158,23 @@ class SheetTest(unittest.TestCase):
         self.assertEqual(value["converted"], expected_converted)
 
     @parameterized.expand(
-        [("42", 42, "42"), (42, 42, "42"), ("1.25", 1, "1"), (1.25, 1, "1")]
+        [
+            ("42", 42, "42"),
+            (42, 42, "42"),
+            ("1.25", 1, "1"),
+            (1.25, 1, "1"),
+            ("1e3", 1000, "1000"),
+            # Hex strings fall back to the raw value, including "9E..."
+            # shapes that parse as overflowing scientific notation and
+            # previously raised OverflowError, rendering the error entry
+            # "~~" (TOOLS-3772).
+            ("B40E9AE14C62", "B40E9AE14C62", "B40E9AE14C62"),
+            ("9E0123456789", "9E0123456789", "9E0123456789"),
+            ("1e999", "1e999", "1e999"),
+            ("-1e999", "-1e999", "-1e999"),
+            ("nan", "nan", "nan"),
+            ("inf", "inf", "inf"),
+        ]
     )
     def test_sheet_project_number(self, input, expected_raw, expected_converted):
         test_sheet = Sheet((Field("F", Projectors.Number("d", "f")),), from_source="d")

--- a/test/unit/view/test_sheet.py
+++ b/test/unit/view/test_sheet.py
@@ -177,6 +177,10 @@ class SheetTest(unittest.TestCase):
             ("nan", "nan", "nan"),
             ("inf", "inf", "inf"),
             (10**400, 10**400, str(10**400)),
+            # An actual float inf (e.g. Infinity in collectinfo JSON) raises
+            # OverflowError from int(inf); keep the raw value.
+            (float("inf"), float("inf"), "inf"),
+            (float("-inf"), float("-inf"), "-inf"),
         ]
     )
     def test_sheet_project_number(self, input, expected_raw, expected_converted):
@@ -911,6 +915,19 @@ class SheetTest(unittest.TestCase):
             self.assertEqual(record["h"]["raw"], "1234E2")
             self.assertEqual(record["i"]["raw"], 1)
             self.assertEqual(record["j"]["raw"], 1.0)
+
+    def test_sheet_dynamic_field_infer_projectors_inf(self):
+        """A float inf value (e.g. Infinity in collectinfo JSON) previously
+        crashed projector inference with OverflowError from int(inf)
+        (TOOLS-3772)."""
+        test_sheet = Sheet((DynamicFields("d"),), from_source="d")
+        sources = dict(d=dict(n0=dict(f=float("inf"), g=1)))
+        render = do_render(test_sheet, "test", sources)
+        record = render["groups"][0]["records"][0]
+
+        self.assertEqual(record["f"]["raw"], float("inf"))
+        self.assertEqual(record["f"]["converted"], "inf")
+        self.assertEqual(record["g"]["raw"], 1)
 
     def test_sheet_dynamic_field_selector(self):
         test_sheet = Sheet((DynamicFields("d"),), from_source="d")

--- a/test/unit/view/test_templates.py
+++ b/test/unit/view/test_templates.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import unittest
 from parameterized import parameterized
 
-from lib.view import templates
+from lib.view import sheet, templates
+from lib.view.sheet import SheetStyle
 from lib.view.sheet.decleration import EntryData
 
 
@@ -85,3 +87,70 @@ class HelperTests(unittest.TestCase):
             license_data, compression_enabled
         )
         self.assertEqual(result, expected)
+
+
+class ShowPmapSheetTest(unittest.TestCase):
+    """Regression tests for TOOLS-3772: cluster keys shaped like an
+    overflowing float literal (e.g. 9E0123456789) rendered as the error
+    entry '~~' in 'show pmap'."""
+
+    def render_pmap(self, cluster_key, style):
+        node = "127.0.0.1:3000"
+        sources = dict(
+            node_names={node: "node-A"},
+            node_ids={node: "BB9040011AC4202"},
+            pmap={
+                node: {
+                    "test": {
+                        "cluster_key": cluster_key,
+                        "master_partition_count": 683,
+                        "prole_partition_count": 1365,
+                        "unavailable_partitions": 0,
+                        "dead_partitions": 0,
+                    }
+                }
+            },
+        )
+        common = dict(principal="BB9040011AC4202")
+
+        return sheet.render(
+            templates.show_pmap_sheet,
+            "Partition Map Analysis",
+            sources,
+            common=common,
+            style=style,
+        )
+
+    @parameterized.expand(
+        [
+            # <digit>E<digits> parses as overflowing scientific notation.
+            ("9E0123456789",),
+            # <digit>E<digits> that parses as a valid float without overflow.
+            ("1E9",),
+            # Hex key that cannot parse as a float at all.
+            ("B40E9AE14C62",),
+            # All-digit key must not be reformatted as a number.
+            ("123456789012",),
+            # Default when service statistics are unavailable for a node.
+            ("N/E",),
+        ]
+    )
+    def test_cluster_key_renders_verbatim(self, cluster_key):
+        record = json.loads(self.render_pmap(cluster_key, SheetStyle.json))["groups"][
+            0
+        ]["records"][0]
+
+        self.assertEqual(record["Cluster Key"]["raw"], cluster_key)
+        self.assertEqual(record["Cluster Key"]["converted"], cluster_key)
+
+        rendered = self.render_pmap(cluster_key, SheetStyle.columns)
+        self.assertIn(cluster_key, rendered)
+
+    def test_partition_counts_still_aggregate(self):
+        render = json.loads(self.render_pmap("9E0123456789", SheetStyle.json))
+        record = render["groups"][0]["records"][0]
+
+        self.assertEqual(record["Partitions"]["Primary"]["raw"], 683)
+        self.assertEqual(record["Partitions"]["Secondary"]["raw"], 1365)
+        self.assertEqual(record["Partitions"]["Unavailable"]["raw"], 0)
+        self.assertEqual(record["Partitions"]["Dead"]["raw"], 0)


### PR DESCRIPTION
## Problem

[TOOLS-3772](https://aerospike.atlassian.net/browse/TOOLS-3772): `show pmap` renders the `Cluster Key` column as `~~` (the error entry) when the cluster key is shaped like `<digit>E<digits>`, e.g. `9E0123456789`.

The pmap sheet projected the hex cluster key with `Projectors.Number`:

1. `int("9E0123456789")` raises `ValueError` (caught).
2. `float("9E0123456789")` parses as scientific notation and silently overflows to `inf`.
3. `int(inf)` raises `OverflowError`, which the projector's `except ValueError` does not catch, so it surfaces as `ErrorEntryException` and renders as `~~`.

## Fix

Four places, all the same bug class (hex string coerced to a number, overflowing to inf):

1. **Root fix** (`lib/view/templates.py`): project `Cluster Key` in `show_pmap_sheet` as `Projectors.String`, matching how `info network` already treats the same value. This fixes both live mode and collectinfo mode `show pmap`, since both render through the shared sheet.
2. **Projector hardening** (`lib/view/sheet/decleration.py`): `Projectors.Number` and `Projectors.Float` now guard against inf/nan and catch `OverflowError`, falling back to the raw value. Protects every other Number field in every sheet from rendering `~~` on overflowing strings.
3. **Health checks** (`lib/health/util.py`): `h_eval` converted such keys to `float inf`. Beyond display, two different cluster keys that both overflow would both become `inf` and compare equal, silently masking the CRITICAL "Cluster Key difference check". Applies to both live and collectinfo health checks. Genuine scientific notation stats like `1E2` still convert to `100.0`.
4. **Health output formatting** (`lib/view/view.py`): `CliView._format_value` would print such a key as `inf` in health check messages. Same inf/nan guard applied.

## Backward compatibility

- Data collection is untouched; `get_pmap` still handles pre-3.8.4 headerless and pre/post-3.15.0 pmap formats, and the `N/E` fallback (service stats unavailable) renders fine as a string (covered by a test).
- Old collectinfo files store the key as a JSON string, which the String projector handles as-is.
- Prior art: 0a487dc (TOOLS-2570) fixed this same bug class for node IDs in dynamic field inference, so `show statistics` / `show config` were already safe.
- One intentional output change: in `-j` JSON output, `Cluster Key.raw` is now always the verbatim string (previously an int for all-digit keys). This matches the `Key` field of `info network`.

## Testing

- New `ShowPmapSheetTest` renders the real `show_pmap_sheet` and asserts the key renders verbatim for the overflow shape, valid scientific notation shape (`1E9`), plain hex, all-digit, and `N/E`, plus partition count aggregation still works.
- Projector level cases for Number and Float covering `9E0123456789`, `1e999`, `-1e999`, `nan`, `inf`, and that genuine `1e3` still converts.
- `h_eval` cases for overflow-shaped hex, plain hex, `nan`, and valid `1E2`.
- Full unit suite passes: 1443 passed, 1 skipped.

[TOOLS-3772]: https://aerospike.atlassian.net/browse/TOOLS-3772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ