### PR TITLE
fix: TOOLS-2975 Remove incorrect recluster prompt for cluster-name and centralize recluster-required param handling

### DIFF
--- a/lib/live_cluster/manage_controller.py
+++ b/lib/live_cluster/manage_controller.py
@@ -1704,6 +1704,19 @@ class ManageConfigLeafController(ManageLeafCommandController):
     PARAM = "param"
     TO = "to"
 
+    # Config params that only take effect after "manage recluster" is run.
+    # Subclasses override this with the params for their config context. Params
+    # not listed here take effect immediately and print no recluster reminder.
+    require_recluster: set[str] = set()
+
+    def print_recluster_msg_if_needed(self, param):
+        if param in self.require_recluster:
+            self.view.print_result(
+                'Run "manage recluster" for your changes to {} to take effect.'.format(
+                    param
+                )
+            )
+
     def extract_param_value(self, line):
         param = util.get_arg_and_delete_from_mods(
             line=line,
@@ -2033,10 +2046,13 @@ class ManageConfigLoggingController(ManageConfigLeafController):
     ),
 )
 class ManageConfigServiceController(ManageConfigLeafController):
+    # No service params currently require a recluster. cluster-name takes
+    # effect immediately (TOOLS-2975).
+    require_recluster = set()
+
     def __init__(self):
         self.required_modifiers = set([self.PARAM, self.TO])
         self.modifiers = set(["with"])
-        self.require_recluster = set(["cluster-name"])
 
     async def _do_default(self, line):
         param, value = self.extract_param_value(line)
@@ -2053,12 +2069,7 @@ class ManageConfigServiceController(ManageConfigLeafController):
         title = "Set Service Param {} to {}".format(param, value)
         self.view.print_info_responses(title, resp, self.cluster, **self.mods)
 
-        if param in self.require_recluster:
-            self.view.print_result(
-                'Run "manage recluster" for your changes to {} to take affect.'.format(
-                    param
-                )
-            )
+        self.print_recluster_msg_if_needed(param)
 
 
 @CommandHelp(
@@ -2102,6 +2113,8 @@ class ManageConfigNetworkController(ManageConfigLeafController):
 
         title = "Set Network Param {} to {}".format(param, value)
         self.view.print_info_responses(title, resp, self.cluster, **self.mods)
+
+        self.print_recluster_msg_if_needed(param)
 
 
 @CommandHelp(
@@ -2149,6 +2162,8 @@ class ManageConfigSecurityController(ManageConfigLeafController):
         title = "Set Security Param {} to {}".format(param, value)
         self.view.print_info_responses(title, resp, self.cluster, **self.mods)
 
+        self.print_recluster_msg_if_needed(param)
+
 
 @CommandHelp(
     "Change a namespace context's dynamic runtime configuration",
@@ -2170,6 +2185,8 @@ class ManageConfigSecurityController(ManageConfigLeafController):
     ),
 )
 class ManageConfigNamespaceController(ManageConfigLeafController):
+    require_recluster = set(["prefer-uniform-balance", "rack-id"])
+
     def __init__(self):
         self.required_modifiers = set([self.PARAM, self.TO])
         self.modifiers = set(["with"])
@@ -2177,7 +2194,6 @@ class ManageConfigNamespaceController(ManageConfigLeafController):
         self.controller_map = {
             "set": ManageConfigNamespaceSetController,
         }
-        self.require_recluster = set(["prefer-uniform-balance", "rack-id"])
 
     async def _do_default(self, line):
         param, value = self.extract_param_value(line)
@@ -2201,12 +2217,7 @@ class ManageConfigNamespaceController(ManageConfigLeafController):
         title = "Set Namespace Param {} to {}".format(param, value)
         self.view.print_info_responses(title, resp, self.cluster, **self.mods)
 
-        if param in self.require_recluster:
-            self.view.print_result(
-                'Run "manage recluster" for your changes to {} to take affect.'.format(
-                    param
-                )
-            )
+        self.print_recluster_msg_if_needed(param)
 
 
 @CommandHelp(
@@ -2249,6 +2260,8 @@ class ManageConfigNamespaceSetController(ManageConfigLeafController):
         title = "Set Namespace Set Param {} to {}".format(param, value)
         self.view.print_info_responses(title, resp, self.cluster, **self.mods)
 
+        self.print_recluster_msg_if_needed(param)
+
 
 @CommandHelp(
     "A collection of commands to add/remove xdr nodes, namespace, and change dynamic runtime configuration",
@@ -2288,6 +2301,8 @@ class ManageConfigXDRController(ManageConfigLeafController):
 
         title = "Set XDR Param {} to {}".format(param, value)
         self.view.print_info_responses(title, resp, self.cluster, **self.mods)
+
+        self.print_recluster_msg_if_needed(param)
 
 
 @CommandHelp(
@@ -2400,6 +2415,8 @@ class ManageConfigXDRDCController(ManageConfigLeafController):
 
         title = "Set XDR DC param {} to {}".format(param, value)
         self.view.print_info_responses(title, resp, self.cluster, **self.mods)
+
+        self.print_recluster_msg_if_needed(param)
 
 
 @CommandHelp("Add a node or namespace to xdr datacenter")
@@ -2601,6 +2618,8 @@ class ManageConfigXDRDCNamespaceController(ManageConfigLeafController):
 
         title = "Set XDR Namespace Param {} to {}".format(param, value)
         self.view.print_info_responses(title, resp, self.cluster, **self.mods)
+
+        self.print_recluster_msg_if_needed(param)
 
 
 @CommandHelp(

--- a/test/unit/live_cluster/test_manage_controller.py
+++ b/test/unit/live_cluster/test_manage_controller.py
@@ -50,6 +50,8 @@ from lib.live_cluster.manage_controller import (
     ManageACLQuotasRoleController,
     ManageConfigController,
     ManageConfigLeafController,
+    ManageConfigNamespaceController,
+    ManageConfigServiceController,
     ManageJobsKillAllScansController,
     ManageJobsKillAllQueriesController,
     ManageJobsKillTridController,
@@ -1161,6 +1163,47 @@ class ManageConfigControllerTest(unittest.IsolatedAsyncioTestCase):
             title, resp, self.cluster_mock, **mods
         )
 
+    async def test_service_cluster_name_does_not_print_recluster_msg(self):
+        # TOOLS-2975: cluster-name takes effect immediately, no recluster needed.
+        line = "service param cluster-name to new-name with 1.1.1.1 2.2.2.2"
+        resp = {"1.1.1.1": ASINFO_RESPONSE_OK, "2.2.2.2": ASINFO_RESPONSE_OK}
+        self.cluster_mock.info_set_config_service.return_value = resp
+
+        await self.controller.execute(line.split())
+
+        self.cluster_mock.info_set_config_service.assert_called_once_with(
+            "cluster-name", "new-name", nodes=["1.1.1.1", "2.2.2.2"]
+        )
+        self.view_mock.print_result.assert_not_called()
+
+    async def test_service_param_requiring_recluster_prints_msg(self):
+        # Registering a param in require_recluster is all that is needed for
+        # the recluster reminder to be printed.
+        line = "service param test-param to test-value with 1.1.1.1 2.2.2.2"
+        resp = {"1.1.1.1": ASINFO_RESPONSE_OK}
+        self.cluster_mock.info_set_config_service.return_value = resp
+
+        with patch.object(
+            ManageConfigServiceController, "require_recluster", {"test-param"}
+        ):
+            await self.controller.execute(line.split())
+
+        self.view_mock.print_result.assert_called_once_with(
+            'Run "manage recluster" for your changes to test-param to take effect.'
+        )
+
+    def test_cluster_name_not_registered_as_requiring_recluster(self):
+        # Regression guard for TOOLS-2975.
+        self.assertNotIn(
+            "cluster-name", ManageConfigServiceController.require_recluster
+        )
+
+    def test_namespace_recluster_params_registered(self):
+        self.assertSetEqual(
+            ManageConfigNamespaceController.require_recluster,
+            {"prefer-uniform-balance", "rack-id"},
+        )
+
     async def test_network_subcontext_required(self):
         line = "network param test-param to test-value with 1.1.1.1 2.2.2.2"
         self.prompt_mock.return_value = False
@@ -1293,13 +1336,33 @@ class ManageConfigControllerTest(unittest.IsolatedAsyncioTestCase):
             **self._get_controller_mods(self.controller, ["namespace"]),
         )
         self.view_mock.print_result.assert_called_once_with(
-            'Run "manage recluster" for your changes to rack-id to take affect.'
+            'Run "manage recluster" for your changes to rack-id to take effect.'
         )
 
     async def test_namespace_success_with_pair(self):
         line = "namespace test-ns sub-context param compression-level to test-value with 1.1.1.1 2.2.2.2"
 
         await self.controller.execute(line.split())
+
+    async def test_namespace_prefer_uniform_balance_prints_recluster_msg(self):
+        line = "namespace test-ns param prefer-uniform-balance to true with 1.1.1.1"
+        resp = {"1.1.1.1": ASINFO_RESPONSE_OK}
+        self.cluster_mock.info_set_config_namespace.return_value = resp
+
+        await self.controller.execute(line.split())
+
+        self.view_mock.print_result.assert_called_once_with(
+            'Run "manage recluster" for your changes to prefer-uniform-balance to take effect.'
+        )
+
+    async def test_namespace_param_does_not_print_recluster_msg(self):
+        line = "namespace test-ns param evict-tenths-pct to 5 with 1.1.1.1"
+        resp = {"1.1.1.1": ASINFO_RESPONSE_OK}
+        self.cluster_mock.info_set_config_namespace.return_value = resp
+
+        await self.controller.execute(line.split())
+
+        self.view_mock.print_result.assert_not_called()
 
     async def test_set_prompt(self):
         line = "namespace test-ns set test-set param test-param to test-value with 1.1.1.1 2.2.2.2"

--- a/test/unit/live_cluster/test_manage_controller.py
+++ b/test/unit/live_cluster/test_manage_controller.py
@@ -1180,7 +1180,7 @@ class ManageConfigControllerTest(unittest.IsolatedAsyncioTestCase):
         # Registering a param in require_recluster is all that is needed for
         # the recluster reminder to be printed.
         line = "service param test-param to test-value with 1.1.1.1 2.2.2.2"
-        resp = {"1.1.1.1": ASINFO_RESPONSE_OK}
+        resp = {"1.1.1.1": ASINFO_RESPONSE_OK, "2.2.2.2": ASINFO_RESPONSE_OK}
         self.cluster_mock.info_set_config_service.return_value = resp
 
         with patch.object(
@@ -1188,6 +1188,9 @@ class ManageConfigControllerTest(unittest.IsolatedAsyncioTestCase):
         ):
             await self.controller.execute(line.split())
 
+        self.cluster_mock.info_set_config_service.assert_called_once_with(
+            "test-param", "test-value", nodes=["1.1.1.1", "2.2.2.2"]
+        )
         self.view_mock.print_result.assert_called_once_with(
             'Run "manage recluster" for your changes to test-param to take effect.'
         )


### PR DESCRIPTION
## Problem

[TOOLS-2975](https://aerospike.atlassian.net/browse/TOOLS-2975): `manage config service param cluster-name to <value>` printed `Run "manage recluster" for your changes to cluster-name to take affect.`, but a cluster-name change takes effect immediately and no recluster is needed.

## Changes

- Removed `cluster-name` from the service context's recluster-required params, so the misleading prompt is no longer printed.
- Centralized the mechanism in `ManageConfigLeafController`: a class-level `require_recluster` registry plus a shared `print_recluster_msg_if_needed(param)` helper, replacing the duplicated inline checks in the service and namespace controllers.
- Wired the helper into all param-setting config controllers (service, network, security, namespace, namespace set, xdr, xdr dc, xdr dc namespace). If a param's dynamic behavior changes in a future server version, updating that controller's `require_recluster` set is the only edit needed.
- Namespace context still prompts for `rack-id` and `prefer-uniform-balance`, which genuinely require a recluster.
- Fixed the "take affect" typo ("take effect").

## Testing

New unit tests in `ManageConfigControllerTest`:
- `cluster-name` change prints no recluster prompt (direct TOOLS-2975 regression test).
- Registering a param in `require_recluster` is sufficient for the prompt to appear.
- Guards on the service and namespace registries so params don't drift accidentally.
- Namespace params that do (`prefer-uniform-balance`) and don't (`evict-tenths-pct`) require recluster.

Full unit suite passes: 1432 passed, 1 skipped.

[TOOLS-2975]: https://aerospike.atlassian.net/browse/TOOLS-2975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ