### PR TITLE
fix: TOOLS-3770 standardize 'analyser' -> 'analyzer' spelling (silent backward-compatible aliases)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Description
 Aerospike Admin provides an interface for Aerospike users to view the stat
 of their Aerospike Cluster by fetching information from a running cluster (Cluster mode) 
-a collectinfo file (Collectinfo-Analyzer), or logs (Log-analyser mode).
+a collectinfo file (Collectinfo-Analyzer), or logs (Log-analyzer mode).
 To get started run `asadm` and issue the `help` command. The
 full documentation can be found [here](https://docs.aerospike.com/tools/asadm).
 
@@ -53,7 +53,7 @@ asadm -h <Aerospike Server Address>
 Admin> help
 ```
 
-## Running Aerospike Admin in Log-analyser Mode.
+## Running Aerospike Admin in Log-analyzer Mode.
 ```
 asadm -l [-f <location of logs>]
 Admin> help

--- a/asadm.py
+++ b/asadm.py
@@ -783,10 +783,10 @@ async def main():
     if cli_args.collectinfo:
         mode = AdminMode.COLLECTINFO_ANALYZER
 
-    if cli_args.log_analyser:
+    if cli_args.log_analyzer:
         if cli_args.collectinfo:
             logger.critical(
-                "collectinfo-analyser and log-analyser are mutually exclusive options. Please enable only one."
+                "collectinfo-analyzer and log-analyzer are mutually exclusive options. Please enable only one."
             )
         mode = AdminMode.LOG_ANALYZER
 
@@ -822,7 +822,7 @@ async def main():
     if cli_args.asinfo_mode:
         if mode == AdminMode.COLLECTINFO_ANALYZER or mode == AdminMode.LOG_ANALYZER:
             logger.critical(
-                "asinfo mode cannot work with Collectinfo-analyser or Log-analyser mode."
+                "asinfo mode cannot work with Collectinfo-analyzer or Log-analyzer mode."
             )
 
         commands_arg = cli_args.execute

--- a/lib/collectinfo_analyzer/collectinfo_handler/log_handler.py
+++ b/lib/collectinfo_analyzer/collectinfo_handler/log_handler.py
@@ -37,7 +37,7 @@ SS = 2
 
 # for zipped files
 COLLECTINFO_DIR = constants.ADMIN_HOME + "collectinfo/"
-COLLECTINFO_INTERNAL_DIR = "collectinfo_analyser_extracted_files"
+COLLECTINFO_INTERNAL_DIR = "collectinfo_analyzer_extracted_files"
 
 ######################
 
@@ -314,8 +314,8 @@ class CollectinfoLogHandler(object):
             if os.path.exists(self.collectinfo_dir):
                 # ToDo: Before adding file from collectinfo_dir, we need to check file already exists in input file list or not,
                 # ToDo: collectinfo_parser fails if same file exists twice in input file list. This is possible if input has zip file and
-                # ToDo: user unzipped it but did not remove zipped file, in that case collectinfo-analyser creates new unzipped file,
-                # ToDo: which results in two copies of same file (one unzipped by user and one unzipped by collectinfo-analyser).
+                # ToDo: user unzipped it but did not remove zipped file, in that case collectinfo-analyzer creates new unzipped file,
+                # ToDo: which results in two copies of same file (one unzipped by user and one unzipped by collectinfo-analyzer).
 
                 files += self._get_valid_files(self.collectinfo_dir)
 

--- a/lib/collectinfo_analyzer/show_controller.py
+++ b/lib/collectinfo_analyzer/show_controller.py
@@ -701,7 +701,7 @@ class ShowDistributionController(CollectinfoCommandController):
                 True,
                 self.log_handler.get_cinfo_log_at(timestamp=timestamp),
                 timestamp=timestamp,
-                loganalyser_mode=True,
+                loganalyzer_mode=True,
                 like=self.mods["for"],
             )
 

--- a/lib/live_cluster/health_check_controller.py
+++ b/lib/live_cluster/health_check_controller.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 
 @CommandHelp(
-    "Displays health summary. If remote server System credentials provided, then it will collect remote system stats and analyse that also. If credentials are not available then it will collect only localhost system statistics. This command is still in beta and its output should not be directly acted upon without further analysis.",
+    "Displays health summary. If remote server System credentials provided, then it will collect remote system stats and analyze that also. If credentials are not available then it will collect only localhost system statistics. This command is still in beta and its output should not be directly acted upon without further analysis.",
     short_msg="Displays health summary",
     usage=f"[-dv] [-f <query_file>] [-o <output_file>] [-n <num_snapshots>] [-s <sleep_seconds>] [-oc <output_filter_category>] [-wl <output_filter_warn_level>] [{SSH_MODIFIER_USAGE}]",
     modifiers=(

--- a/lib/log_analyzer/log_handler/log_latency.py
+++ b/lib/log_analyzer/log_handler/log_latency.py
@@ -529,17 +529,17 @@ class LogLatency(object):
 
             # Set histogram tag:
             if arg_ns:
-                # Analysing latency for histogram arg_hist for specific namespace arg_ns
+                # Analyzing latency for histogram arg_hist for specific namespace arg_ns
                 # It needs to read single bucket dump for a slice
                 hist_tags = [s % (arg_ns, arg_hist) for s in NS_HIST_TAG_PATTERNS]
 
             elif re.match(HIST_WITH_NS_PATTERN, arg_hist):
-                # Analysing latency for specific histogram for specific namespace ({namespace}-histogram)
+                # Analyzing latency for specific histogram for specific namespace ({namespace}-histogram)
                 # It needs to read single bucket dump for a slice
                 hist_tags = [HIST_TAG_PREFIX + "%s " % (arg_hist)]
 
             else:
-                # Analysing latency for histogram arg_hist
+                # Analyzing latency for histogram arg_hist
                 # It needs to read all bucket dumps for a slice
                 hist_tags = [s % (arg_hist) for s in HIST_TAG_PATTERNS]
                 read_all_dumps = True

--- a/lib/utils/common.py
+++ b/lib/utils/common.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 #############################################################################################################
-# Functions common to multiple modes (online cluster / offline cluster / collectinfo-analyser / log-analyser)
+# Functions common to multiple modes (online cluster / offline cluster / collectinfo-analyzer / log-analyzer)
 #############################################################################################################
 
 import datetime

--- a/lib/utils/conf.py
+++ b/lib/utils/conf.py
@@ -72,7 +72,7 @@ _confdefault = {
         "collectinfo": False,
         "execute": False,
         "enable": False,
-        "log-analyser": False,
+        "log-analyzer": False,
         "log-path": "",
         "pmap": False,
     },
@@ -118,6 +118,7 @@ _confspec = """{
                 "collectinfo": { "type" : "boolean" },
                 "execute": { "type" : "boolean" },
                 "enable": { "type" : "boolean" },
+                "log-analyzer": { "type" : "boolean" },
                 "log-analyser": { "type" : "boolean" },
                 "log-path" : { "type" : "string" }
             },
@@ -227,6 +228,11 @@ def _flatten(conf_dict, instance=None):
                     asadm_conf[decode(k.replace("-", "_"))] = str(v)
                 else:
                     asadm_conf[decode(k.replace("-", "_"))] = decode(v)
+
+    # Backward compatibility: accept the British "log-analyser" spelling from
+    # config files while standardizing on "log-analyzer" internally.
+    if "log_analyser" in asadm_conf:
+        asadm_conf.setdefault("log_analyzer", asadm_conf.pop("log_analyser"))
 
     return asadm_conf
 
@@ -454,7 +460,7 @@ def print_config_help():
     print(" --collectinfo        Start asadm to run against offline collectinfo files.")
     print(" --pmap               Include partition map analysis in collectinfo files.")
     print(
-        " --log-analyser       Start asadm in log-analyser mode and analyse data from log files."
+        " --log-analyzer       Start asadm in log-analyzer mode and analyze data from log files."
     )
     print(
         " -f --log-path=path   Path of cluster collectinfo file or directory \n"
@@ -631,7 +637,11 @@ def get_cli_args():
     add_fn("--enable", action="store_true")
     add_fn("-o", "--out-file")
     add_fn("-c", "--collectinfo", action="store_true")
-    add_fn("-l", "--log-analyser", action="store_true")
+    # "--log-analyser" (British spelling) is kept as a silent, backward-compatible
+    # alias. "--log-analyzer" is the canonical spelling and both set log_analyzer.
+    add_fn(
+        "-l", "--log-analyzer", "--log-analyser", action="store_true", dest="log_analyzer"
+    )
     add_fn("-f", "--log-path")
     add_fn("-j", "--json", action="store_true")
     add_fn("--no-color", action="store_true")
@@ -671,7 +681,7 @@ def get_cli_args():
     # And parameters which needs to be passed through
     # asinfo (they come with underscore).
     add_fn("--line_separator", action="store_true")
-    add_fn("--log_analyser", action="store_true")
+    add_fn("--log_analyzer", "--log_analyser", action="store_true", dest="log_analyzer")
     add_fn("--file_path", dest="log_path")
     add_fn("--asinfo_mode", action="store_true")
     add_fn("--asinfo-mode", action="store_true")

--- a/lib/utils/conf.py
+++ b/lib/utils/conf.py
@@ -640,7 +640,11 @@ def get_cli_args():
     # "--log-analyser" (British spelling) is kept as a silent, backward-compatible
     # alias. "--log-analyzer" is the canonical spelling and both set log_analyzer.
     add_fn(
-        "-l", "--log-analyzer", "--log-analyser", action="store_true", dest="log_analyzer"
+        "-l",
+        "--log-analyzer",
+        "--log-analyser",
+        action="store_true",
+        dest="log_analyzer",
     )
     add_fn("-f", "--log-path")
     add_fn("-j", "--json", action="store_true")

--- a/lib/utils/constants.py
+++ b/lib/utils/constants.py
@@ -119,9 +119,9 @@ AdminMode = Enumeration(
     [
         # Connect to live cluster
         "LIVE_CLUSTER",
-        # Analyse collectinfo
+        # Analyze collectinfo
         "COLLECTINFO_ANALYZER",
-        # Analyse Aerospike logs
+        # Analyze Aerospike logs
         "LOG_ANALYZER",
     ]
 )

--- a/lib/view/view.py
+++ b/lib/view/view.py
@@ -452,7 +452,7 @@ class CliView(object):
         like=None,
         with_=None,
         timestamp="",
-        loganalyser_mode=False,
+        loganalyzer_mode=False,
         **ignore,
     ):
         node_names = cluster.get_node_names(with_)
@@ -489,7 +489,7 @@ class CliView(object):
     @staticmethod
     def format_latency(orig_latency):
         # XXX - eventually, node.py could return this format. Changing here
-        #       because loganalyser also sends this format.
+        #       because loganalyzer also sends this format.
         latency = {}
 
         for node, nodes_data in orig_latency.items():

--- a/test/unit/test_aerospike_shell.py
+++ b/test/unit/test_aerospike_shell.py
@@ -361,7 +361,7 @@ class AdminHomeDirTest(unittest.IsolatedAsyncioTestCase):
                 mock_args.no_color = False
                 mock_args.pmap = False
                 mock_args.collectinfo = False
-                mock_args.log_analyser = False
+                mock_args.log_analyzer = False
                 mock_args.json = False
                 mock_get_cli_args.return_value = mock_args
 
@@ -397,7 +397,7 @@ class AdminHomeDirTest(unittest.IsolatedAsyncioTestCase):
                 mock_args.no_color = False
                 mock_args.pmap = False
                 mock_args.collectinfo = False
-                mock_args.log_analyser = False
+                mock_args.log_analyzer = False
                 mock_args.json = False
                 mock_get_cli_args.return_value = mock_args
 
@@ -446,7 +446,7 @@ class AdminHomeDirTest(unittest.IsolatedAsyncioTestCase):
                 mock_args.no_color = False
                 mock_args.pmap = False
                 mock_args.collectinfo = False
-                mock_args.log_analyser = False
+                mock_args.log_analyzer = False
                 mock_args.json = False
                 mock_get_cli_args.return_value = mock_args
 


### PR DESCRIPTION
## Summary

[TOOLS-3770](https://aerospike.atlassian.net/browse/TOOLS-3770): `asadm` mixed the British "analyser" and American "analyzer" spellings, e.g. the CLI flag was `--log-analyser` while the shell prompt was `Log-analyzer>`.

This standardizes on "analyzer" (z) everywhere the user sees it, while keeping every "analyser" (s) spelling working **silently** for backward compatibility. No existing usage is dropped.

## What changed

- **CLI flag** (`lib/utils/conf.py`): `--log-analyzer` is now the documented flag. `--log-analyser`, `--log_analyzer`, `--log_analyser`, and `-l` all still work and set the same `log_analyzer` dest.
- **Config file** (`lib/utils/conf.py`): `log-analyzer` is the canonical key. `log-analyser` still validates against the schema and is remapped to `log_analyzer` in `_flatten`, so existing `astools.conf` files keep working.
- **User-visible strings** (`asadm.py`): the two mode error messages now read "collectinfo-analyzer" / "log-analyzer".
- **`--help` text**: "Start asadm in log-analyzer mode and analyze data from log files."
- **Internal consistency**: the `loganalyzer_mode` view parameter, the `collectinfo_analyzer_extracted_files` internal dir string (created fresh each run, never looked up by name), README, and the remaining "analyse/analysing" comments were all aligned to "z" to match the already-"z" module/class/enum names.

## Backward compatibility

Silent dual support is preserved. Verified:

| Input | Result |
|---|---|
| `--log-analyzer` / `--log-analyser` / `-l` / `--log_analyzer` / `--log_analyser` | all set `log_analyzer=True` |
| config key `log-analyzer` **and** `log-analyser` | both validate and map to `log_analyzer` |
| no flag | `log_analyzer=False` |

## Testing

- `test/unit/test_aerospike_shell.py` (11) and `test/unit/collectinfo_analyzer/`, `test/unit/view/` (147) pass.
- Confirmed both config spellings validate against the JSON schema.
- `asadm --help` renders the new "log-analyzer" line.


[TOOLS-3770]: https://aerospike.atlassian.net/browse/TOOLS-3770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ