### PR TITLE
fix: TOOLS-3949 asadm execute-mode dispatch (double-run, batch truncation, ';' parsing, Ctrl-C)

### DIFF
--- a/asadm.py
+++ b/asadm.py
@@ -364,32 +364,22 @@ class AerospikeShell(cmd.Cmd, AsyncObject):
         #       new parser or correct shlex behavior.
         commands = []
         command = []
-        build_token = ""
 
         # Maybe someday we should not allow most of the characters below without
         # quotes surrounding them.  These characters below define what can be in
         # an unquotes string.
-        lexer.wordchars += r"`~!@#$;%^&*()_-+={}[]|:<>,./\?"
+        lexer.wordchars += r"`~!@#$%^&*()_-+={}[]|:<>,./\?"
         lexer.escapedquotes += "'"
 
         try:
             for token in lexer:
-                build_token += token
-
                 if token == ";":
                     if command:
                         commands.append(command)
                         command = []
-                elif token.endswith(";"):
-                    command.append(build_token[:-1])
-                    commands.append(command)
-                    command = []
                 else:
-                    command.append(build_token)
-                build_token = ""
+                    command.append(token)
             else:
-                if build_token:
-                    command.append(build_token)
                 if command:
                     commands.append(command)
 
@@ -461,7 +451,11 @@ class AerospikeShell(cmd.Cmd, AsyncObject):
 
         for line in lines:
             if line[0] in self.commands:
-                return " ".join(line)
+                if line[0] in ("exit", "quit", "EOF"):
+                    return " ".join(line)
+
+                await self.onecmd(" ".join(line))
+                continue
 
             if len(lines) > max_commands_to_print_header:
                 if len(line) > 1 and any(
@@ -923,7 +917,6 @@ async def main():
                 command_index_to_print_from=command_index_to_print_from,
             )
 
-            await shell.onecmd(line)
             func = shell.onecmd
             args = (line,)
 
@@ -972,21 +965,23 @@ async def cmdloop(
     use_yappi: bool,
     single_command: bool,
 ):
-    try:
-        if use_yappi:
-            yappi.start()
-            await func(*args)
-            yappi.get_func_stats().print_all()
-        else:
-            await func(*args)
-    except (KeyboardInterrupt, SystemExit):
-        if not single_command:
+    while True:
+        try:
+            if use_yappi:
+                yappi.start()
+                await func(*args)
+                yappi.get_func_stats().print_all()
+            else:
+                await func(*args)
+            return
+        except (KeyboardInterrupt, SystemExit):
+            if single_command:
+                raise
             shell.intro = (
                 terminal.fg_red()
                 + "\nTo exit asadm utility please run the 'exit' command."
                 + terminal.fg_clear()
             )
-        await cmdloop(shell, func, args, use_yappi, single_command)
 
 
 def parse_commands(file):

--- a/asadm.py
+++ b/asadm.py
@@ -369,7 +369,7 @@ class AerospikeShell(cmd.Cmd, AsyncObject):
 
         # Maybe someday we should not allow most of the characters below without
         # quotes surrounding them.  These characters below define what can be in
-        # an unquotes string.
+        # an unquoted string.
         lexer.wordchars += r"`~!@#$%^&*()_-+={}[]|:<>,./\?"
         lexer.escapedquotes += "'"
 

--- a/asadm.py
+++ b/asadm.py
@@ -92,6 +92,8 @@ CMD_FILE_MULTI_LINE_COMMENT_END = "*/"
 
 MULTILEVEL_COMMANDS = ["show", "info", "manage"]
 
+TERMINATOR_COMMANDS = ("exit", "quit", "EOF")
+
 DEFAULT_PROMPT = "Admin> "
 PRIVILEGED_PROMPT = "Admin+> "
 ADMIN_DEFAULT_PROMPT = "ADMIN> "
@@ -379,10 +381,9 @@ class AerospikeShell(cmd.Cmd, AsyncObject):
                         command = []
                 else:
                     command.append(token)
-            else:
-                if command:
-                    commands.append(command)
 
+            if command:
+                commands.append(command)
         except ValueError as e:
             raise ShellException(e)
 
@@ -450,11 +451,14 @@ class AerospikeShell(cmd.Cmd, AsyncObject):
             return ""
 
         for line in lines:
-            if line[0] in self.commands:
-                if line[0] in ("exit", "quit", "EOF"):
-                    return " ".join(line)
+            if line[0] in TERMINATOR_COMMANDS:
+                return " ".join(line)
 
-                await self.onecmd(" ".join(line))
+            if line[0] in self.commands:
+                try:
+                    await self.onecmd(" ".join(line))
+                except Exception as e:
+                    logger.error(e)
                 continue
 
             if len(lines) > max_commands_to_print_header:
@@ -503,13 +507,14 @@ class AerospikeShell(cmd.Cmd, AsyncObject):
                 """
                 Interrupt in the middle of executing a command.
                 """
-                pass
+                if self.execute_only_mode:
+                    raise KeyboardInterrupt
             except Exception as e:
                 logger.error(e)
             finally:
                 for signal in signals:
                     loop.remove_signal_handler(signal)
-        return ""  # line was handled by execute
+        return ""
 
     # overloaded to support async
     async def onecmd(self, line):
@@ -872,80 +877,76 @@ async def main():
     args = ()
     single_command = True
     real_stdout = sys.stdout
-    if not execute_only_mode:
-        if not shell.connected:
-            sys.exit(1)
+    f = None
 
-        func = shell.cmdloop
-        single_command = False
-
-    else:
-        commands_arg = cli_args.execute
-        max_commands_to_print_header = 1
-        command_index_to_print_from = 1
-        if os.path.isfile(commands_arg):
-            commands_arg = parse_commands(commands_arg)
-            max_commands_to_print_header = 0
-            command_index_to_print_from = 0
-
-        if cli_args.out_file:
-            try:
-                f = open(str(cli_args.out_file), "w")
-                sys.stdout = f
-                disable_coloring()
-                max_commands_to_print_header = 0
-                command_index_to_print_from = 0
-            except Exception as e:
-                print(e)
-
-        def cleanup():
-            try:
-                sys.stdout = real_stdout
-                if f:
-                    f.close()
-            except Exception:
-                pass
-
-        if shell.connected:
-            # Print admin port visual cue message in execute mode
-            if shell._has_admin_nodes():
-                print(ADMIN_PORT_VISUAL_CUE_MSG)
-
-            line = await shell.precmd(
-                commands_arg,
-                max_commands_to_print_header=max_commands_to_print_header,
-                command_index_to_print_from=command_index_to_print_from,
-            )
-
-            func = shell.onecmd
-            args = (line,)
-
-        else:
-            if "collectinfo" in commands_arg:
-                logger.warning(
-                    "Collecting only System data. Not able to connect any cluster with "
-                    + str(seeds)
-                    + "."
-                )
-
-                func = common.collect_sys_info(port=cli_args.port)
-
-                cleanup()
-                sys.exit(1)
-
-            cleanup()
-
-    if func:
-        await cmdloop(shell, func, args, use_yappi, single_command)
-
-    await shell.close()
-
-    try:
+    def cleanup():
         sys.stdout = real_stdout
         if f:
-            f.close()
-    except Exception:
-        pass
+            try:
+                f.close()
+            except OSError as e:
+                logger.error(e)
+
+    try:
+        if not execute_only_mode:
+            if not shell.connected:
+                sys.exit(1)
+
+            func = shell.cmdloop
+            single_command = False
+
+        else:
+            commands_arg = cli_args.execute
+            max_commands_to_print_header = 1
+            command_index_to_print_from = 1
+            if os.path.isfile(commands_arg):
+                commands_arg = parse_commands(commands_arg)
+                max_commands_to_print_header = 0
+                command_index_to_print_from = 0
+
+            if cli_args.out_file:
+                try:
+                    f = open(str(cli_args.out_file), "w")
+                    sys.stdout = f
+                    disable_coloring()
+                    max_commands_to_print_header = 0
+                    command_index_to_print_from = 0
+                except Exception as e:
+                    print(e)
+
+            if shell.connected:
+                # Print admin port visual cue message in execute mode
+                if shell._has_admin_nodes():
+                    print(ADMIN_PORT_VISUAL_CUE_MSG)
+
+                line = await shell.precmd(
+                    commands_arg,
+                    max_commands_to_print_header=max_commands_to_print_header,
+                    command_index_to_print_from=command_index_to_print_from,
+                )
+
+                func = shell.onecmd
+                args = (line,)
+
+            else:
+                if "collectinfo" in commands_arg:
+                    logger.warning(
+                        "Collecting only System data. Not able to connect any cluster with "
+                        + str(seeds)
+                        + "."
+                    )
+
+                    common.collect_sys_info(port=cli_args.port)
+
+                    sys.exit(1)
+
+        if func:
+            await cmdloop(shell, func, args, use_yappi, single_command)
+    finally:
+        try:
+            await shell.close()
+        finally:
+            cleanup()
 
     sys.exit(get_exit_code())
 

--- a/test/unit/test_aerospike_shell.py
+++ b/test/unit/test_aerospike_shell.py
@@ -519,6 +519,7 @@ class CleanLineTest(unittest.TestCase):
         """Known limitation: posix shlex strips quotes before we see the token."""
         self.assertEqual(self.clean("info ';'"), [["info"]])
         self.assertEqual(self.clean('info ";"'), [["info"]])
+        self.assertEqual(self.clean(r"info \;"), [["info"]])
         self.assertEqual(
             self.clean("grep -s ';' statistics"), [["grep", "-s"], ["statistics"]]
         )

--- a/test/unit/test_aerospike_shell.py
+++ b/test/unit/test_aerospike_shell.py
@@ -574,5 +574,36 @@ class PrecmdDispatchTest(unittest.IsolatedAsyncioTestCase):
         shell.ctrl.execute.assert_not_called()
 
 
+class CmdloopTest(unittest.IsolatedAsyncioTestCase):
+    """Module-level cmdloop re-raises interrupts in single-command (execute)
+    mode and retries func, resetting shell.intro, in interactive mode."""
+
+    async def test_single_command_reraises_keyboard_interrupt(self):
+        func = AsyncMock(side_effect=KeyboardInterrupt)
+        with self.assertRaises(KeyboardInterrupt):
+            await asadm.cmdloop(Mock(), func, (), False, True)
+        func.assert_awaited_once()
+
+    async def test_single_command_reraises_system_exit(self):
+        func = AsyncMock(side_effect=SystemExit)
+        with self.assertRaises(SystemExit):
+            await asadm.cmdloop(Mock(), func, (), False, True)
+        func.assert_awaited_once()
+
+    async def test_normal_completion_runs_once(self):
+        func = AsyncMock(return_value=None)
+        await asadm.cmdloop(Mock(), func, ("line",), False, False)
+        func.assert_awaited_once_with("line")
+
+    async def test_interactive_retries_and_sets_intro(self):
+        func = AsyncMock(side_effect=[KeyboardInterrupt(), None])
+        shell = Mock()
+        await asadm.cmdloop(shell, func, (), False, False)
+        self.assertEqual(func.await_count, 2)
+        self.assertIn(
+            "To exit asadm utility please run the 'exit' command", shell.intro
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/unit/test_aerospike_shell.py
+++ b/test/unit/test_aerospike_shell.py
@@ -705,7 +705,10 @@ class ExecuteModeDoubleRunTest(unittest.IsolatedAsyncioTestCase):
     async def test_emptyline_is_noop(self):
         """Stock cmd.Cmd re-runs lastcmd on a blank line; the override must stay."""
         shell = object.__new__(AerospikeShell)
+        shell.lastcmd = "info network"
+        shell.onecmd = Mock()
         self.assertIsNone(shell.emptyline())
+        shell.onecmd.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/test/unit/test_aerospike_shell.py
+++ b/test/unit/test_aerospike_shell.py
@@ -3,6 +3,7 @@ import asadm
 
 import asyncio
 import unittest
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch, call
 from lib.base_controller import ShellException
 from lib.utils import async_object
@@ -473,8 +474,7 @@ class AdminHomeDirTest(unittest.IsolatedAsyncioTestCase):
 
 
 class CleanLineTest(unittest.TestCase):
-    """clean_line does not touch instance state, so exercise it directly on a
-    bare instance to avoid the async cluster-connect setup."""
+    """Bare instance skips the async cluster-connect setup."""
 
     def clean(self, line):
         shell = object.__new__(AerospikeShell)
@@ -497,8 +497,6 @@ class CleanLineTest(unittest.TestCase):
         )
 
     def test_semicolon_without_spaces_splits(self):
-        """An unquoted ';' separates commands even without surrounding
-        whitespace - ';' was removed from the lexer wordchars."""
         self.assertEqual(
             self.clean("show config;show statistics"),
             [["show", "config"], ["show", "statistics"]],
@@ -513,9 +511,17 @@ class CleanLineTest(unittest.TestCase):
             [["show", "config"], ["show", "statistics"]],
         )
 
-    def test_quoted_semicolon_is_literal(self):
-        """A quoted ';' stays inside its token and does not split the command."""
+    def test_quoted_semicolon_embedded_in_token_is_literal(self):
         self.assertEqual(self.clean("info 'a;b'"), [["info", "a;b"]])
+        self.assertEqual(self.clean("info foo';'bar"), [["info", "foo;bar"]])
+
+    def test_standalone_quoted_semicolon_still_splits(self):
+        """Known limitation: posix shlex strips quotes before we see the token."""
+        self.assertEqual(self.clean("info ';'"), [["info"]])
+        self.assertEqual(self.clean('info ";"'), [["info"]])
+        self.assertEqual(
+            self.clean("grep -s ';' statistics"), [["grep", "-s"], ["statistics"]]
+        )
 
     def test_unterminated_quote_raises_shell_exception(self):
         with self.assertRaises(ShellException):
@@ -523,12 +529,10 @@ class CleanLineTest(unittest.TestCase):
 
 
 class PrecmdDispatchTest(unittest.IsolatedAsyncioTestCase):
-    """precmd routes do_* commands through onecmd and everything else through
-    ctrl.execute, running every command in a multi-command line."""
-
     def make_shell(self):
         shell = object.__new__(AerospikeShell)
-        shell.commands = {"exit", "quit", "EOF", "cake"}
+        shell.commands = set(asadm.TERMINATOR_COMMANDS) | {"cake"}
+        shell.execute_only_mode = False
         shell.ctrl = Mock()
         shell.ctrl.execute = AsyncMock(return_value="")
         shell.onecmd = AsyncMock(return_value=None)
@@ -573,11 +577,44 @@ class PrecmdDispatchTest(unittest.IsolatedAsyncioTestCase):
         shell.onecmd.assert_awaited_once_with("cake")
         shell.ctrl.execute.assert_not_called()
 
+    async def test_ctrl_execute_failure_is_logged_and_batch_continues(self):
+        shell = self.make_shell()
+        shell.ctrl.execute = AsyncMock(side_effect=[Exception("boom"), ""])
+        with patch("asadm.asyncio.get_event_loop", return_value=Mock()):
+            with patch("asadm.logger") as mock_logger:
+                result = await shell.precmd("info network ; info statistics")
+        self.assertEqual(result, "")
+        self.assertEqual(shell.ctrl.execute.await_count, 2)
+        mock_logger.error.assert_called_once()
+
+    async def test_inline_do_command_failure_is_logged_and_batch_continues(self):
+        shell = self.make_shell()
+        shell.onecmd = AsyncMock(side_effect=Exception("boom"))
+        with patch("asadm.asyncio.get_event_loop", return_value=Mock()):
+            with patch("asadm.logger") as mock_logger:
+                result = await shell.precmd("cake ; info network")
+        self.assertEqual(result, "")
+        mock_logger.error.assert_called_once()
+        shell.ctrl.execute.assert_called_once_with(["info", "network"])
+
+    async def test_cancel_reraises_keyboard_interrupt_in_execute_mode(self):
+        shell = self.make_shell()
+        shell.execute_only_mode = True
+        shell.ctrl.execute = AsyncMock(side_effect=asyncio.CancelledError)
+        with patch("asadm.asyncio.get_event_loop", return_value=Mock()):
+            with self.assertRaises(KeyboardInterrupt):
+                await shell.precmd("info network")
+
+    async def test_cancel_is_swallowed_in_interactive_mode(self):
+        shell = self.make_shell()
+        shell.execute_only_mode = False
+        shell.ctrl.execute = AsyncMock(side_effect=asyncio.CancelledError)
+        with patch("asadm.asyncio.get_event_loop", return_value=Mock()):
+            result = await shell.precmd("info network")
+        self.assertEqual(result, "")
+
 
 class CmdloopTest(unittest.IsolatedAsyncioTestCase):
-    """Module-level cmdloop re-raises interrupts in single-command (execute)
-    mode and retries func, resetting shell.intro, in interactive mode."""
-
     async def test_single_command_reraises_keyboard_interrupt(self):
         func = AsyncMock(side_effect=KeyboardInterrupt)
         with self.assertRaises(KeyboardInterrupt):
@@ -603,6 +640,71 @@ class CmdloopTest(unittest.IsolatedAsyncioTestCase):
         self.assertIn(
             "To exit asadm utility please run the 'exit' command", shell.intro
         )
+
+    async def test_interactive_retry_is_iterative_not_recursive(self):
+        func = AsyncMock(side_effect=[KeyboardInterrupt()] * 2000 + [None])
+        await asadm.cmdloop(Mock(), func, (), False, False)
+        self.assertEqual(func.await_count, 2001)
+
+
+class ExecuteModeDoubleRunTest(unittest.IsolatedAsyncioTestCase):
+    """The duplicate onecmd call lived in main(), upstream of cmdloop, so only
+    driving main()'s execute path catches a double dispatch."""
+
+    def _make_args(self):
+        return SimpleNamespace(
+            execute="cake",
+            debug=False,
+            help=False,
+            version=False,
+            no_color=False,
+            pmap=False,
+            collectinfo=False,
+            log_analyzer=False,
+            json=False,
+            asinfo_mode=False,
+            services_alumni=False,
+            services_alternate=False,
+            tls_enable=False,
+            auth=None,
+            profile=False,
+            out_file=None,
+            user=None,
+            password=None,
+            log_path=None,
+            single_node=False,
+            enable=False,
+            timeout=5,
+        )
+
+    async def test_do_command_dispatched_exactly_once(self):
+        args = self._make_args()
+        shell = AsyncMock()
+        shell.connected = True
+        shell._has_admin_nodes = Mock(return_value=False)
+        shell.precmd = AsyncMock(return_value="")
+        shell.onecmd = AsyncMock(return_value=None)
+        shell.close = AsyncMock()
+
+        async def make_shell(*a, **k):
+            return shell
+
+        with patch("asadm.conf.get_cli_args", return_value=args), patch(
+            "asadm.conf.loadconfig", return_value=(args, [("1.1.1.1", 3000, None)])
+        ), patch("asadm.parse_tls_input", return_value=None), patch(
+            "asadm.AerospikeShell", side_effect=make_shell
+        ), patch(
+            "os.path.isfile", return_value=False
+        ):
+            with self.assertRaises(SystemExit):
+                await asadm.main()
+
+        shell.onecmd.assert_awaited_once_with("")
+
+    async def test_emptyline_is_noop(self):
+        """Stock cmd.Cmd re-runs lastcmd on a blank line; the override must stay."""
+        shell = object.__new__(AerospikeShell)
+        self.assertIsNone(shell.emptyline())
 
 
 if __name__ == "__main__":

--- a/test/unit/test_aerospike_shell.py
+++ b/test/unit/test_aerospike_shell.py
@@ -4,6 +4,7 @@ import asadm
 import asyncio
 import unittest
 from unittest.mock import AsyncMock, Mock, patch, call
+from lib.base_controller import ShellException
 from lib.utils import async_object
 from lib.utils.constants import AdminMode
 
@@ -469,3 +470,109 @@ class AdminHomeDirTest(unittest.IsolatedAsyncioTestCase):
                                 mock_makedirs.assert_not_called()
                                 # isdir should also not be called since we skip the whole block
                                 mock_isdir.assert_not_called()
+
+
+class CleanLineTest(unittest.TestCase):
+    """clean_line does not touch instance state, so exercise it directly on a
+    bare instance to avoid the async cluster-connect setup."""
+
+    def clean(self, line):
+        shell = object.__new__(AerospikeShell)
+        return AerospikeShell.clean_line(shell, line)
+
+    def test_single_command(self):
+        self.assertEqual(self.clean("show config"), [["show", "config"]])
+
+    def test_extra_whitespace_collapsed(self):
+        self.assertEqual(self.clean("  show    config  "), [["show", "config"]])
+
+    def test_empty_and_whitespace_only(self):
+        self.assertEqual(self.clean(""), [])
+        self.assertEqual(self.clean("   "), [])
+
+    def test_semicolon_with_spaces_splits(self):
+        self.assertEqual(
+            self.clean("show config ; show statistics"),
+            [["show", "config"], ["show", "statistics"]],
+        )
+
+    def test_semicolon_without_spaces_splits(self):
+        """An unquoted ';' separates commands even without surrounding
+        whitespace - ';' was removed from the lexer wordchars."""
+        self.assertEqual(
+            self.clean("show config;show statistics"),
+            [["show", "config"], ["show", "statistics"]],
+        )
+
+    def test_leading_and_trailing_semicolons_ignored(self):
+        self.assertEqual(self.clean(";show config;"), [["show", "config"]])
+
+    def test_multiple_consecutive_semicolons(self):
+        self.assertEqual(
+            self.clean("show config ;; show statistics"),
+            [["show", "config"], ["show", "statistics"]],
+        )
+
+    def test_quoted_semicolon_is_literal(self):
+        """A quoted ';' stays inside its token and does not split the command."""
+        self.assertEqual(self.clean("info 'a;b'"), [["info", "a;b"]])
+
+    def test_unterminated_quote_raises_shell_exception(self):
+        with self.assertRaises(ShellException):
+            self.clean("show 'unterminated")
+
+
+class PrecmdDispatchTest(unittest.IsolatedAsyncioTestCase):
+    """precmd routes do_* commands through onecmd and everything else through
+    ctrl.execute, running every command in a multi-command line."""
+
+    def make_shell(self):
+        shell = object.__new__(AerospikeShell)
+        shell.commands = {"exit", "quit", "EOF", "cake"}
+        shell.ctrl = Mock()
+        shell.ctrl.execute = AsyncMock(return_value="")
+        shell.onecmd = AsyncMock(return_value=None)
+        return shell
+
+    async def test_ctrl_command_routes_to_execute(self):
+        shell = self.make_shell()
+        with patch("asadm.asyncio.get_event_loop", return_value=Mock()):
+            result = await shell.precmd("info network")
+        self.assertEqual(result, "")
+        shell.ctrl.execute.assert_called_once_with(["info", "network"])
+        shell.onecmd.assert_not_called()
+
+    async def test_do_command_routes_to_onecmd(self):
+        shell = self.make_shell()
+        with patch("asadm.asyncio.get_event_loop", return_value=Mock()):
+            result = await shell.precmd("cake")
+        self.assertEqual(result, "")
+        shell.onecmd.assert_awaited_once_with("cake")
+        shell.ctrl.execute.assert_not_called()
+
+    async def test_exit_returns_line_without_inline_dispatch(self):
+        shell = self.make_shell()
+        with patch("asadm.asyncio.get_event_loop", return_value=Mock()):
+            result = await shell.precmd("exit")
+        self.assertEqual(result, "exit")
+        shell.onecmd.assert_not_called()
+
+    async def test_multiple_commands_all_run(self):
+        shell = self.make_shell()
+        with patch("asadm.asyncio.get_event_loop", return_value=Mock()):
+            result = await shell.precmd("cake ; info network ; cake")
+        self.assertEqual(result, "")
+        self.assertEqual(shell.onecmd.await_args_list, [call("cake"), call("cake")])
+        shell.ctrl.execute.assert_called_once_with(["info", "network"])
+
+    async def test_exit_after_command_stops_and_skips_rest(self):
+        shell = self.make_shell()
+        with patch("asadm.asyncio.get_event_loop", return_value=Mock()):
+            result = await shell.precmd("cake ; exit ; info network")
+        self.assertEqual(result, "exit")
+        shell.onecmd.assert_awaited_once_with("cake")
+        shell.ctrl.execute.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Fixes four related defects in the `-e` / execute-mode command dispatch path in `asadm.py`. Details and full repro/verification in [TOOLS-3949](https://aerospike.atlassian.net/browse/TOOLS-3949).

## Bugs fixed

1. **`do_*` commands run twice in `-e` mode.** `asadm -e cake` ran the command once explicitly (`await shell.onecmd(line)`) and again via `cmdloop`. Only affected shell-local `do_*` commands (`cake`, `exit`, `quit`, `EOF`); `cake` was the only visible case. Removed the redundant call.

2. **`precmd` truncated a command batch at the first shell-local command.** `-e "cake; show config"` ran only `cake` and silently dropped `show config`. Non-terminator shell-local commands now dispatch inline and the batch loop continues; `exit`/`quit`/`EOF` keep the intentional early return.

3. **Semicolon only separated commands when followed by whitespace.** `-e "info;show config"` failed with `command not found`, and a quoted `;` embedded in a longer token (e.g. `"err;"`) was wrongly split. Removed `;` from `shlex` wordchars so an unquoted `;` always separates and a quoted `;` embedded in a longer token stays literal. Known limitation: a value consisting solely of `;` (`';'`, `";"`, `\;`) still splits; this is pinned by tests and a universal quote-tracking fix is deferred to a follow-up ticket.

4. **Ctrl-C during `-e` re-ran the command instead of exiting.** `cmdloop` recursed on `KeyboardInterrupt`/`SystemExit` even in single-command mode. Made the retry iterative; execute mode now re-raises and exits 130.

## Behavior change (release note)

Unquoted `;` now always separates commands. Unquoted values containing `;`, such as `asinfo -v set-config:context=service;proto-fd-max=9999` or equivalent `manage config` values, are silently split at the `;` and the resulting pieces are executed as separate commands, so the intended command only partially executes. The old parser preserved the `;` when it was not followed by a space. Quote the value (`asinfo -v "set-config:context=service;proto-fd-max=9999"`) to keep the `;` literal.

## Verification

- `-e "cake"`: output once, exit 0
- `-e "cake; show config"`, `-e "show config;cake;info network"`: all commands run, in order, once each
- `-e "info;show config"`: both run
- `-e "info network; exit; show config"`: `exit` terminates the batch (unchanged)
- Quoted `;` embedded in a token preserved: `"set-config:context=service;proto-fd-max=9999"`, `'p;w'`, `"err;"`; a standalone quoted/escaped `;` (`';'`, `";"`, `\;`) still splits (known limitation, pinned by tests)
- SIGINT during `-e cake`: exits 130, no restart
- Interactive mode (piped stdin) works; `test/unit/test_aerospike_shell.py` (37 tests) pass


[TOOLS-3949]: https://aerospike.atlassian.net/browse/TOOLS-3949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
