### PR TITLE
TOOLS-3662: ship astools.conf via copy-if-absent install script

### DIFF
--- a/.github/bin/test/test_astools_conf.bats
+++ b/.github/bin/test/test_astools_conf.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+#
+# Config-file lifecycle tests. Run ONLY from the linux-install and mac-install
+# jobs (never the docker smoke job, which shims tool binaries onto the host).
+# Requires two env vars exported by the install step:
+#   ASTOOLS_SAMPLE    - absolute path to the packaged astools.conf.sample
+#   ASTOOLS_REINSTALL - command that reinstalls the package from its local file
+
+setup() {
+  CONF=/etc/aerospike/astools.conf
+  SAMPLE="${ASTOOLS_SAMPLE}"
+  if [ "$(id -u)" -eq 0 ]; then SUDO=""; else SUDO="sudo"; fi
+}
+
+@test "astools.conf is created on install and matches the sample" {
+  [ -f "$CONF" ]
+  cmp "$CONF" "$SAMPLE"
+}
+
+@test "astools.conf is recreated after removal + reinstall (after-upgrade wiring)" {
+  $SUDO rm -f "$CONF"
+  [ ! -e "$CONF" ]
+  eval "${ASTOOLS_REINSTALL}"
+  [ -f "$CONF" ]
+  cmp "$CONF" "$SAMPLE"
+}
+
+@test "user edits survive reinstall" {
+  echo "# user edit marker" | $SUDO tee -a "$CONF" >/dev/null
+  eval "${ASTOOLS_REINSTALL}"
+  grep -q "# user edit marker" "$CONF"
+}

--- a/.github/bin/test/test_astools_conf.bats
+++ b/.github/bin/test/test_astools_conf.bats
@@ -14,7 +14,7 @@ setup() {
 
 @test "astools.conf is created on install and matches the sample" {
   [ -f "$CONF" ]
-  cmp "$CONF" "$SAMPLE"
+  [ "$(cat "$CONF")" = "$(cat "$SAMPLE")" ]
 }
 
 @test "astools.conf is recreated after removal + reinstall (after-upgrade wiring)" {
@@ -22,7 +22,7 @@ setup() {
   [ ! -e "$CONF" ]
   eval "${ASTOOLS_REINSTALL}"
   [ -f "$CONF" ]
-  cmp "$CONF" "$SAMPLE"
+  [ "$(cat "$CONF")" = "$(cat "$SAMPLE")" ]
 }
 
 @test "user edits survive reinstall" {

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -438,13 +438,16 @@ jobs:
               pkg=$(find ./packages -name "*_${{ matrix.distro }}_*${arch}*.deb" | head -1)
               [[ -n "${pkg}" ]] || { echo "ERROR: no .deb found for ${{ matrix.distro }}/${arch}" >&2; exit 1; }
               apt-get install -y "${pkg}"
+              echo "ASTOOLS_REINSTALL=dpkg -i ${pkg}" >> "$GITHUB_ENV"
               ;;
             el*|amzn*)
               pkg=$(find ./packages -name "*.${{ matrix.distro }}.*${arch}*.rpm" | head -1)
               [[ -n "${pkg}" ]] || { echo "ERROR: no .rpm found for ${{ matrix.distro }}/${arch}" >&2; exit 1; }
               dnf install -y "${pkg}"
+              echo "ASTOOLS_REINSTALL=dnf reinstall -y ${pkg}" >> "$GITHUB_ENV"
               ;;
           esac
+          echo "ASTOOLS_SAMPLE=/opt/aerospike/doc/asadm/astools.conf.sample" >> "$GITHUB_ENV"
 
       - name: Install bats
         env:
@@ -458,6 +461,9 @@ jobs:
 
       - name: Verify installation
         run: bats .github/bin/test/test_execute.bats
+
+      - name: Verify astools.conf lifecycle
+        run: bats .github/bin/test/test_astools_conf.bats
 
   test-install-mac-and-execute:
     name: Test install & execute (${{ matrix.os }})
@@ -492,12 +498,17 @@ jobs:
           pkg=$(find ./packages -name "*-${{ matrix.os }}-${{ runner.arch }}.pkg" | head -1)
           [[ -n "${pkg}" ]] || { echo "ERROR: no .pkg found for ${{ matrix.os }}-${{ runner.arch }}" >&2; exit 1; }
           sudo installer -pkg "${pkg}" -target /
+          echo "ASTOOLS_REINSTALL=sudo installer -pkg ${pkg} -target /" >> "$GITHUB_ENV"
+          echo "ASTOOLS_SAMPLE=/usr/local/aerospike/doc/asadm/astools.conf.sample" >> "$GITHUB_ENV"
 
       - name: Install bats
         run: brew install bats-core
 
       - name: Verify installation
         run: bats .github/bin/test/test_execute.bats
+
+      - name: Verify astools.conf lifecycle
+        run: bats .github/bin/test/test_astools_conf.bats
 
   organize-signed-artifacts:
     name: Organize signed artifacts for deploy
@@ -641,6 +652,10 @@ jobs:
           BASE_VERSION=$(printf '%s' "${VERSION}" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
           docker run --rm "${IMAGE}" asadm --version | grep -qF "${BASE_VERSION}" \
             || { echo "ERROR: expected ${BASE_VERSION} in --version output" >&2; exit 1; }
+
+          # The postinst seeds astools.conf during image build.
+          docker run --rm --entrypoint sh "${IMAGE}" -c 'test -f /etc/aerospike/astools.conf' \
+            || { echo "ERROR: /etc/aerospike/astools.conf missing in image" >&2; exit 1; }
 
           if [[ -n "${SNYK_TOKEN:-}" ]]; then
             snyk container test "${IMAGE}" \

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -4,6 +4,8 @@ TOP_DIR = $(PKG_DIR)/../build/bin
 BUILD_DIR = $(PKG_DIR)/build
 TARGET_DIR = $(PKG_DIR)/target
 CONFIG_DIR = /etc/aerospike
+DOC_DIR = /opt/aerospike/doc/$(PACKAGE_NAME)
+MAC_DOC_DIR = /usr/local/aerospike/doc/$(PACKAGE_NAME)
 # Package variables
 PACKAGE_NAME = asadm
 # Source of truth for the version, in precedence order:
@@ -52,6 +54,8 @@ deb: prep
 		--license $(LICENSE) \
 		--url $(URL) \
 		--vendor $(VENDOR) \
+		--after-install $(PKG_DIR)/postinst.sh \
+		--after-upgrade $(PKG_DIR)/postinst.sh \
 		--package $(TARGET_DIR)/$(NAME)_$(VERSION)_$(BUILD_DISTRO)_$(ARCH).deb
 
 .PHONY: rpm
@@ -71,6 +75,8 @@ rpm: prep
 		--license $(LICENSE) \
 		--url $(URL) \
 		--vendor $(VENDOR) \
+		--after-install $(PKG_DIR)/postinst.sh \
+		--after-upgrade $(PKG_DIR)/postinst.sh \
 		--package $(TARGET_DIR)/$(NAME)-$(RPM_VERSION).$(BUILD_DISTRO).$(ARCH).rpm
 
 .PHONY: tar
@@ -98,6 +104,8 @@ prep:
 	cp -a $(TOP_DIR)/asadm/. $(BUILD_DIR)/opt/aerospike/bin/asadm/
 	ln -sf /opt/aerospike/bin/asadm/asadm $(BUILD_DIR)/usr/bin/asadm
 	ln -sf /opt/aerospike/bin/asadm/asinfo $(BUILD_DIR)/usr/bin/asinfo
+	install -d $(BUILD_DIR)$(DOC_DIR)
+	install -pm 644 $(PKG_DIR)/astools.conf.sample $(BUILD_DIR)$(DOC_DIR)/astools.conf.sample
 
 # Staging for macOS installer: matches root makefile Darwin INSTALL_ROOT and symlinks.
 .PHONY: prep-mac
@@ -109,6 +117,8 @@ prep-mac:
 	cp -a $(TOP_DIR)/asadm/. $(MAC_ROOT)/usr/local/aerospike/bin/asadm/
 	ln -sf ../aerospike/bin/asadm/asadm $(MAC_ROOT)/usr/local/bin/asadm
 	ln -sf ../aerospike/bin/asadm/asinfo $(MAC_ROOT)/usr/local/bin/asinfo
+	install -d $(MAC_ROOT)$(MAC_DOC_DIR)
+	install -pm 644 $(PKG_DIR)/astools.conf.sample $(MAC_ROOT)$(MAC_DOC_DIR)/astools.conf.sample
 
 .PHONY: osx-pkg
 osx-pkg: prep-mac
@@ -117,6 +127,7 @@ osx-pkg: prep-mac
 		--identifier $(PKG_ID) \
 		--version $(MAC_VERSION) \
 		--install-location / \
+		--scripts $(PKG_DIR)/mac-scripts \
 		$(MAC_PKG)
 
 .PHONY: osx-dmg

--- a/pkg/astools.conf.sample
+++ b/pkg/astools.conf.sample
@@ -22,7 +22,7 @@
 #------------------------------------------------------------------------------
 #
 [cluster]
-# host = "localhost:cluster_a:3000"   # host = "<host>[:<tls-name>][:<port>], ..."
+# host = "localhost:cluster_a:3000"                     # host = "<host>[:<tls-name>][:<port>][,...]"
 # user = ""
 # password = ""
 
@@ -33,8 +33,6 @@
 #
 # tls-enable = false                  # true enables tls, if false all other tls
                                       # config are ignored
-# tls-name = ""                       # the tls substanza defined in your 
-                                      # aerospike.conf
 # tls-protocols = "TLSv1.2"
 # tls-cipher-suite = "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
 # tls-crl-check = true
@@ -58,6 +56,7 @@
 # tls-capath = "/etc/aerospike/x509_certificates/Platinum"
 #
 # tls-certfile = "/etc/aerospike/x509_certificates/multi_chain.pem"
+# tls-cert-blacklist = "/etc/aerospike/x509_certificates/blacklist.txt"
 
 [cluster_secure]
 # host = "localhost:cluster_a:3000"
@@ -67,21 +66,38 @@
 [cluster_tls]
 # host = "localhost:cluster_a:3000"
 # tls-enable = true
-# tls-name = "aerospike-tls"
 # tls-protocols = "-all +TLSv1.2"
 # tls-cipher-suite = "ALL:!COMPLEMENTOFDEFAULT:!eNULL"
 # tls-crl-check = true
 # tls-crl-check-all = true
 # tls-keyfile = "/etc/aerospike/x509_certificates/MultiServer/key.pem"
 # tls-cafile = "/etc/aerospike/x509_certificates/Platinum/cacert.pem"
+# tls-keyfile-password = "file:/etc/aerospike/x509_certificates/MultiServer/keypwd.txt"
 # tls-capath = "/etc/aerospike/x509_certificates/Platinum"
 # tls-certfile = "/etc/aerospike/x509_certificates/multi_chain.pem"
+# tls-cert-blacklist = "/etc/aerospike/x509_certificates/blacklist.txt"
+
 
 # Following are tools specific options
 #
 # Optionally corresponding to named instance in cluster section aql can also
 # have instance specific config
 #
+#------------------------------------------------------------------------------
+# asql specific options
+#------------------------------------------------------------------------------
+[aql]
+# threadpoolsize = 3                # Client internal threadpool size, increase
+                                    # if connecting to large size cluster
+# outputmode = "table"              # Can be one of the json/table/raw/mute
+# outputtypes = true                # Prints the bin type (map/list/sorted map)
+# timeout = 1000                    # in ms for all request
+# socket-timeout = 1000             # in ms for all request
+# udfuser = "/opt/aerospike/usr"
+# udfsys  = "/opt/aerospike/sys"
+
+[aql_secure]
+# timeout = 5000
 
 
 #------------------------------------------------------------------------------
@@ -91,11 +107,77 @@
 # services-alumni = true
 # services-alternate = false
 # timeout = 5
-# enable = true
 
 [asadm_secure]
 # services-alternate = true
 # timeout = 1000
+
+
+#------------------------------------------------------------------------------
+# asbackup specific options
+#------------------------------------------------------------------------------
+[asbackup]
+
+# estimate = true
+
+# directory = "./test_backup"
+# output-file = "test_backup"
+# machine = "run.out"
+
+
+#------------- Data Options ------------------------
+# namespace = "test"
+# set = "demo"
+# bin_list = "bin1,bin2"
+# node-list = ""
+# percent = 100
+
+#-----------Performance and throttling--------------
+# file-limit = 1
+# priority = 2
+# records-per-second = 10000
+# parallel = 4
+# bandwidth = 1
+# compact = true
+
+
+#----------- Meta data options ---------------------
+# no-records = false
+# no-udfs = false
+
+# no-cluster-change = true
+
+#------------------------------------------------------------------------------
+# asrestore specific options
+#------------------------------------------------------------------------------
+[asrestore]
+
+# directory = "./test_backup"
+# input-file = "test_backup"
+# machine = "run.out"
+
+#------------- Data Options ------------------------
+# namespace = "test"
+# bin-list = "bin1,bin2"
+# set-list = "demo"
+
+#----- Mutually exclusive record update options-----
+# unique = true
+# replace = true
+# no-generation = true
+
+
+#----------- Meta data options ---------------------
+# no-udfs = false
+# no-indexes = false
+# no-records = false
+# indexes-last = false
+# wait = false
+
+#-----------Performance and throttling--------------
+# nice-list = "1,10000"
+# threads = 32
+
 
 
 #------------------------------------------------------------------------------
@@ -116,4 +198,3 @@
 [include]
 # file = "./astools.conf"      # include file only if it exists,
 # directory = "/etc/aerospike/conf.d"             # directory 'conf.d'
-

--- a/pkg/mac-scripts/postinstall
+++ b/pkg/mac-scripts/postinstall
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Installer postinstall: create astools.conf only when absent, so user edits
+# survive reinstall/upgrade. $3 = target volume ("/" for standard installs).
+vol="${3:-/}"
+conf="$vol/etc/aerospike/astools.conf"
+sample="$vol/usr/local/aerospike/doc/asadm/astools.conf.sample"
+if [ ! -e "$conf" ] && [ ! -L "$conf" ] && [ -f "$sample" ]; then
+    /usr/bin/install -d -m 755 "$vol/etc/aerospike" && \
+    /usr/bin/install -m 644 "$sample" "$conf"
+fi
+exit 0

--- a/pkg/postinst.sh
+++ b/pkg/postinst.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Create /etc/aerospike/astools.conf from the packaged sample when no config
+# exists yet. The live file is deliberately NOT owned by this package so the
+# standalone tools and the aerospike-tools bundle can coexist without
+# package-manager conflicts over the path. Existing files (the bundle's
+# conffile, user edits) are never touched.
+#
+# Wired as BOTH --after-install and --after-upgrade in pkg/Makefile: on deb,
+# fpm routes an install-only script into an after_upgrade() that never runs on
+# upgrade or reinstall, so both hooks are required for the file to be seeded
+# for users upgrading an already-installed package.
+conf=/etc/aerospike/astools.conf
+sample=/opt/aerospike/doc/asadm/astools.conf.sample
+
+if [ ! -e "$conf" ] && [ ! -L "$conf" ] && [ -f "$sample" ]; then
+    if install -D -m 644 "$sample" "$conf" 2>/dev/null; then
+        [ -x /sbin/restorecon ] && /sbin/restorecon "$conf" 2>/dev/null
+    else
+        echo "warning: could not create $conf (sample at $sample)" >&2
+    fi
+fi
+exit 0


### PR DESCRIPTION
## What

Standalone tool packages ship no `astools.conf`, so a fresh install leaves the user without the config template. This adds it back without re-introducing conffile-ownership conflicts with the `aerospike-tools` bundle.

- New `pkg/astools.conf.sample`: byte-identical copy of the canonical `etc/astools.conf` template.
- New `pkg/postinst.sh` (deb `--after-install` + `--after-upgrade`, rpm `%post`): seeds `/etc/aerospike/astools.conf` from `/opt/aerospike/doc/asadm/astools.conf.sample` **only when the file is absent**.
- New `pkg/mac-scripts/postinstall`: same copy-if-absent logic for the macOS `.pkg`, target-volume aware.
- `pkg/Makefile`: stage the owned sample under `/opt/aerospike/doc/asadm/` (mac: `/usr/local/aerospike/doc/asadm/`); wire the scripts.
- Removed the stale, unreferenced `pkg/astools.conf`.

The live `/etc/aerospike/astools.conf` is deliberately **not owned** by the package. Result: standalone tools and the `aerospike-tools` bundle coexist with no dpkg/rpm conflict over the path, and user edits are never touched.

Wired as **both** `--after-install` and `--after-upgrade`: fpm's deb template routes an install-only hook into `after_upgrade()` that never runs on upgrade or reinstall, so both are required for existing installs to get the file.

## Tests

New `.github/bin/test/test_astools_conf.bats` runs in the linux and mac install jobs (kept out of the shared `test_execute.bats`, which is reused by the docker smoke job on the host):
- file created on install and matches the sample
- file recreated after removal + reinstall (guards the after-upgrade wiring)
- user edits survive reinstall

Docker smoke test asserts the image carries `/etc/aerospike/astools.conf`.

TOOLS-3662