### PR TITLE
ci(pkg): dynamic-dependency allowlist guard over the PyInstaller bundle

### DIFF
--- a/.github/bin/build_package.sh
+++ b/.github/bin/build_package.sh
@@ -2,6 +2,35 @@
 set -euo pipefail
 [[ -n "${DEBUG:-}" ]] && set -x
 
+function assert_dynamic_deps() {
+	local bundle="$GIT_DIR/build/bin/asadm"
+	local allowed="libc.so.6 libm.so.6 libpthread.so.0 libdl.so.2 librt.so.1 libutil.so.1
+		libgcc_s.so.1 libstdc++.so.6 libz.so.1 libcrypt.so.1
+		ld-linux-x86-64.so.2 ld-linux-aarch64.so.1"
+	local provided
+	provided=$(find "$bundle" -name 'lib*.so*' -printf '%f\n')
+
+	local elf lib needed fail=0
+	while IFS= read -r elf; do
+		needed=$(readelf -d "$elf" 2>/dev/null | awk '/\(NEEDED\)/ { gsub(/[][]/, "", $NF); print $NF }') || true
+		[ -z "$needed" ] && continue
+		for lib in $needed; do
+			if printf '%s\n' "$provided" | grep -qxF "$lib"; then
+				continue
+			fi
+			if ! printf '%s\n' $allowed | grep -qxF "$lib"; then
+				echo "${elf#"$bundle"/} has unexpected dynamic dependency $lib; bundle it or add it to the allowlist and the package depends" >&2
+				fail=1
+			fi
+		done
+	done < <(find "$bundle" -type f)
+
+	if [ "$fail" -eq 0 ]; then
+		echo "assert_dynamic_deps: all host-loaded DT_NEEDED entries within allowlist"
+	fi
+	return $fail
+}
+
 function build_packages() {
 	if [ "${ENV_DISTRO:-}" = "" ]; then
 		echo "ENV_DISTRO is not set" >&2
@@ -28,6 +57,8 @@ function build_packages() {
 	cd "$GIT_DIR" || exit 1
 	make clean
 	make
+
+	assert_dynamic_deps
 
 	# package
 	cd "$GIT_DIR"/pkg || exit 1


### PR DESCRIPTION
## Problem

The asadm one-dir PyInstaller bundle deliberately loads glibc, libstdc++, libgcc_s, zlib, and libcrypt from the host (`excludes_binaries` in pyinstaller-build.spec) while the deb/rpm declare no dependencies at all. Nothing verifies the host-loaded set stays within that intent: a bundled library silently gaining a new host dependency (directly or transitively, e.g. via the bundled `less`) only surfaces at install-test time, and only if it breaks `--help`. Same hardening as aerospike/aql#84, aerospike/aerospike-tools-backup#164, aerospike/aerospike-benchmark#155, aerospike/asconfig#126.

## Changes

- **.github/bin/build_package.sh**: `assert_dynamic_deps` gate between build and packaging. Sweeps every ELF in `build/bin/asadm` (executables plus `_internal/`), subtracts libraries shipped inside the bundle, and fails on any remaining `DT_NEEDED` outside the allowlist (glibc family, libstdc++/libgcc_s, zlib, libcrypt, loaders). Covers transitive deps of bundled libraries too. Runs in every job of both build-and-release and the PR-time build-check.

No package metadata changes: the allowed host libs are present wherever apt/dnf exist (apt and dnf themselves require libstdc++ and zlib), matching the spec's exclusion intent.

## Verification

- Guard logic validated in a container against real ELFs: flags an unexpected host dep, passes once the lib is bundled, and then flags the bundled lib's own missing transitive dep.
- Dry-run Build and Release dispatch on this branch (release=false) exercises the sweep across the full 10-distro × 2-arch matrix; results posted below.