### PR TITLE
ci: update get-pip.py sha256 pin for pip 26.2

### DIFF
--- a/.github/bin/install_deps.sh
+++ b/.github/bin/install_deps.sh
@@ -148,7 +148,7 @@ _install_python_via_asdf_and_fpm() {
       unset PYTHON_CONFIGURE_OPTS
     fi
     # Fail on HTTP errors (-f); checksum pins bootstrap.pypa.io content (bump when updating intentionally).
-    local get_pip_expected_sha="${GET_PIP_SHA256:-a341e1a43e38001c551a1508a73ff23636a11970b61d901d9a1cad2a18f57055}"
+    local get_pip_expected_sha="${GET_PIP_SHA256:-25b5c39ade96bab5eabe6404ce83cab6da2deb5fe3c07d9881f43803edb6f9c8}"
     curl -fSL "${CURL_RETRY_OPTS[@]}" https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
     echo "${get_pip_expected_sha}  /tmp/get-pip.py" | sha256sum -c - >/dev/null
     "$HOME/.asdf/installs/python/$PYTHON_VERSION/bin/python" /tmp/get-pip.py --no-warn-script-location


### PR DESCRIPTION
## Problem

The build-and-release workflow fails on the ubuntu26.04 path:

```
sha256sum: WARNING: 1 computed checksum did NOT match
```

`install_deps.sh` downloads `get-pip.py` from bootstrap.pypa.io and verifies it against a pinned sha256 before bootstrapping pip. PyPA republished the file (it now bundles pip 26.2), so the old pin no longer matches and `set -e` aborts the job.

## Fix

Update the pinned hash to the current file (`25b5c39a...`). Verified the downloaded file is the genuine PyPA base85-encoded pip 26.2 bundle before pinning.

The `GET_PIP_SHA256` env var remains as an override for future rotations.