### PR TITLE
ci: include docker images in the release bundle

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -724,6 +724,31 @@ jobs:
             -v "${VERSION}" \
             -r artifact.aerospike.io/database-docker-dev-local
 
+      # Without build-info the images are invisible to the release bundle, so
+      # `jf rbp` would promote the packages to TEST and leave the images in
+      # dev-local forever.
+      - name: Publish docker build-info
+        env:
+          VERSION: ${{ needs.get-version.outputs.VERSION }}
+          IMAGE: artifact.aerospike.io/database-docker-dev-local/aerospike-asadm
+          BUILD_NAME: aerospike-asadm-docker
+        run: |
+          set -euo pipefail
+          for tag in "${VERSION}" "${VERSION}-amd64" "${VERSION}-arm64"; do
+            digest=$(docker buildx imagetools inspect "${IMAGE}:${tag}" --format '{{json .Manifest}}' | jq -r '.digest')
+            [[ -n "${digest}" && "${digest}" != "null" ]] \
+              || { echo "::error::no digest for ${IMAGE}:${tag}" >&2; exit 1; }
+            # build-docker-create takes exactly one image ref per invocation.
+            printf '%s:%s@%s\n' "${IMAGE}" "${tag}" "${digest}" > image.txt
+            cat image.txt
+            jf rt build-docker-create database-docker-dev-local \
+              --image-file image.txt \
+              --build-name "${BUILD_NAME}" \
+              --build-number "${VERSION}" \
+              --project database
+          done
+          jf rt build-publish "${BUILD_NAME}" "${VERSION}" --project database
+
   # Release bundles are JFrog's promotion unit; produced on every publish
   # regardless of branch or skip_tagging.
   create-release-bundle:
@@ -739,7 +764,7 @@ jobs:
     uses: aerospike/shared-workflows/.github/workflows/reusable_create-release-bundle.yaml@v3.6.0
     with:
       jf-project: "database"
-      jf-build-names: "aerospike-asadm:${{ needs.get-version.outputs.VERSION }}"
+      jf-build-names: "aerospike-asadm:${{ needs.get-version.outputs.VERSION }},aerospike-asadm-docker:${{ needs.get-version.outputs.VERSION }}"
       jf-bundle-name: "aerospike-asadm"
       oidc-provider-name: database-gh-aerospike
       oidc-audience: database-gh-aerospike


### PR DESCRIPTION
## Problem

Docker tags are pushed with plain `docker buildx bake --push`, so no JFrog build-info is collected for them. The release bundle is created from build names only, so the images were never part of `aerospike-<tool>:<version>`, and `jf rbp ... TEST` promoted just the deb/rpm/generic packages.

Result: every released image stayed in `database-docker-dev-local` and `database-docker-test-local` was empty, while the matching packages were TEST-promoted. Same version string, two different trust levels.

## Change

In the `docker-manifest` job, after the manifest is stitched:

- resolve the digest of the manifest-list tag and both per-arch tags via `docker buildx imagetools inspect --format '{{json .Manifest}}'`
- register each with `jf rt build-docker-create` (one ref per invocation; the CLI rejects multi-line image files with `unexpected file format`)
- publish as build `aerospike-<tool>-docker:<version>`

Then add that build to the bundle: `jf-build-names: "aerospike-<tool>:<version>,aerospike-<tool>-docker:<version>"`.

`promote-to-test` is unchanged. Registry stays `database-docker-dev-local`; the images reach TEST by promotion, same as the packages.

## Verification

The equivalent command sequence was run by hand against the already-released tags for all five tools, producing backfill bundles that promoted cleanly:

```
"release_bundle_name": "aerospike-asbackup-docker",
"release_bundle_version": "4.5.8",
"environment": "TEST",
"included_repository_keys": ["database-docker-test-local"]
```

Pulled the promoted image from `database-docker-test-local`: digest matches the dev-local manifest list, all four index children (amd64, arm64, 2 attestation manifests) present, `asbackup --version` reports `4.5.8`.

Prior art: `shared-workflows/reusable_docker-build-deploy.yaml` uses the same `build-docker-create` + `build-publish` pattern, and `test-dockerhub-publish:1.1.0` (45 artifacts from `database-docker-dev-local`) has already been promoted through STAGE and PROD in this project.

## Test plan

Dispatch with `release=true` on the default branch and confirm the release bundle artifact count includes the docker layers, and that the image appears in `database-docker-test-local` after `promote-to-test`.
