### PR TITLE
fix(pkg): named conflicts with the aerospike-tools bundle via a version bound and a virtual token

### DIFF
--- a/.github/bin/build_package.sh
+++ b/.github/bin/build_package.sh
@@ -31,6 +31,54 @@ function assert_dynamic_deps() {
 	return $fail
 }
 
+# Assert the aerospike-tools relations actually reached the package metadata.
+# Building only proves fpm accepted the flag; these fields are what make the
+# bundle overlap installable, and their absence produces no output anywhere.
+# The negative checks matter as much as the positive ones: a Conflicts on the deb
+# would make plain `dpkg -i` hard-fail, and fpm's --replaces maps to rpm
+# Obsoletes, which would erase the whole bundle instead of taking over files.
+function assert_pkg_relations() {
+	local pkg
+	case "$ENV_DISTRO" in
+		ubuntu*|debian*)
+			pkg=$(find "$GIT_DIR/pkg/target" -name '*.deb' -print -quit)
+			if [ -z "$pkg" ]; then
+				echo "assert_pkg_relations: no .deb found under pkg/target" >&2
+				return 1
+			fi
+			if ! dpkg-deb -f "$pkg" Replaces | grep -qx 'aerospike-tools'; then
+				echo "deb is missing 'Replaces: aerospike-tools'" >&2
+				return 1
+			fi
+			if [ -n "$(dpkg-deb -f "$pkg" Conflicts)" ]; then
+				echo "deb must not declare Conflicts: $(dpkg-deb -f "$pkg" Conflicts)" >&2
+				return 1
+			fi
+			;;
+		el*|amzn*)
+			pkg=$(find "$GIT_DIR/pkg/target" -name '*.rpm' -print -quit)
+			if [ -z "$pkg" ]; then
+				echo "assert_pkg_relations: no .rpm found under pkg/target" >&2
+				return 1
+			fi
+			if ! rpm -qp --qf '%{CONFLICTS}\n' "$pkg" | grep -qx 'aerospike-tools'; then
+				echo "rpm is missing 'Conflicts: aerospike-tools'" >&2
+				return 1
+			fi
+			if rpm -qp --qf '%{OBSOLETES}\n' "$pkg" | grep -qx 'aerospike-tools'; then
+				echo "rpm must not Obsolete aerospike-tools (that erases the bundle)" >&2
+				return 1
+			fi
+			;;
+		*)
+			echo "assert_pkg_relations: no relations declared for $ENV_DISTRO (tar); skipping"
+			return 0
+			;;
+	esac
+	echo "assert_pkg_relations: aerospike-tools relations present and correct"
+	return 0
+}
+
 function build_packages() {
 	if [ "${ENV_DISTRO:-}" = "" ]; then
 		echo "ENV_DISTRO is not set" >&2
@@ -77,4 +125,5 @@ function build_packages() {
 		make tar
 	fi
 
+	assert_pkg_relations
 }

--- a/.github/bin/build_package.sh
+++ b/.github/bin/build_package.sh
@@ -31,14 +31,13 @@ function assert_dynamic_deps() {
 	return $fail
 }
 
-# Print one relation name per line for a deb control field. Debian comma-joins a
-# relation list onto one logical line and may append a version bound, so an
-# exact-line match against the raw field only works for the degenerate
-# single-entry-no-bound case: `Replaces: zzz-other, aerospike-tools` and
-# `Replaces: aerospike-tools (<< 12.0)` both fail it, reporting a field that is
-# in fact present.
 function deb_relations() {
-	dpkg-deb -f "$1" "$2" | tr ',' '\n' | sed 's/^[[:space:]]*//' | awk '{print $1}'
+	dpkg-deb -f "$1" "$2" | tr ',' '\n' \
+		| sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's/[[:space:]][[:space:]]*/ /g'
+}
+
+function tools_split_version() {
+	sed -n 's/^TOOLS_SPLIT_VERSION[[:space:]]*=[[:space:]]*//p' "$GIT_DIR/pkg/Makefile" | head -1
 }
 
 # Print one relation name per line for an rpm array tag. %{TAG} outside a [...]
@@ -69,7 +68,12 @@ function rpm_relations() {
 # default branch that returned 0 while reporting a tar. A gate whose default is
 # success is not a gate.
 function assert_pkg_relations() {
-	local fmt="${1:-}" pkg
+	local fmt="${1:-}" pkg split
+	split=$(tools_split_version)
+	if [ -z "$split" ]; then
+		echo "assert_pkg_relations: TOOLS_SPLIT_VERSION not found in pkg/Makefile" >&2
+		return 1
+	fi
 	case "$fmt" in
 		deb)
 			pkg=$(find "$GIT_DIR/pkg/target" -name '*.deb' -print -quit)
@@ -77,12 +81,21 @@ function assert_pkg_relations() {
 				echo "assert_pkg_relations: no .deb found under pkg/target" >&2
 				return 1
 			fi
-			if ! deb_relations "$pkg" Replaces | grep -qx 'aerospike-tools'; then
-				echo "deb is missing 'Replaces: aerospike-tools'" >&2
+			if ! deb_relations "$pkg" Replaces | grep -qxF "aerospike-tools (<< $split)"; then
+				echo "deb is missing 'Replaces: aerospike-tools (<< $split)'" >&2
 				return 1
 			fi
-			if deb_relations "$pkg" Conflicts | grep -qx 'aerospike-tools'; then
-				echo "deb must not Conflict with aerospike-tools (breaks the Replaces takeover)" >&2
+			if ! deb_relations "$pkg" Breaks | grep -qxF "aerospike-tools (<< $split)"; then
+				echo "deb is missing 'Breaks: aerospike-tools (<< $split)'" >&2
+				return 1
+			fi
+			if deb_relations "$pkg" Replaces | grep -qx 'aerospike-tools' \
+				|| deb_relations "$pkg" Breaks | grep -qx 'aerospike-tools'; then
+				echo "deb carries an UNVERSIONED aerospike-tools relation; it must be bounded (<< $split) or it hits the metapackage too" >&2
+				return 1
+			fi
+			if deb_relations "$pkg" Conflicts | grep -q 'aerospike-tools'; then
+				echo "deb must not Conflict with aerospike-tools (Breaks+Replaces is the split handoff)" >&2
 				return 1
 			fi
 			;;
@@ -92,8 +105,13 @@ function assert_pkg_relations() {
 				echo "assert_pkg_relations: no .rpm found under pkg/target" >&2
 				return 1
 			fi
-			if ! rpm_relations "$pkg" CONFLICTS | grep -qx 'aerospike-tools'; then
-				echo "rpm is missing 'Conflicts: aerospike-tools'" >&2
+			if ! rpm -qp --conflicts "$pkg" | sed 's/[[:space:]][[:space:]]*/ /g' \
+				| grep -qxF "aerospike-tools < $split"; then
+				echo "rpm is missing 'Conflicts: aerospike-tools < $split'" >&2
+				return 1
+			fi
+			if rpm -qp --conflicts "$pkg" | grep -qx 'aerospike-tools'; then
+				echo "rpm carries an UNVERSIONED Conflicts: aerospike-tools; it must be bounded (< $split) or the metapackage becomes unsatisfiable" >&2
 				return 1
 			fi
 			if rpm_relations "$pkg" OBSOLETES | grep -qx 'aerospike-tools'; then
@@ -110,7 +128,7 @@ function assert_pkg_relations() {
 			return 1
 			;;
 	esac
-	echo "assert_pkg_relations: aerospike-tools relations present and correct ($fmt)"
+	echo "assert_pkg_relations: versioned aerospike-tools split relations present and correct ($fmt)"
 	return 0
 }
 
@@ -157,7 +175,9 @@ function _bundle_overlap_cleanup() {
 }
 
 function _bundle_overlap_check() {
-	local fmt="$1" stub_root stub_pkg real_pkg rc out
+	local fmt="$1" stub_root old_pkg meta_pkg real_pkg rc out split
+	split=$(tools_split_version)
+	[ -n "$split" ] || { echo "assert_bundle_overlap: TOOLS_SPLIT_VERSION not found in pkg/Makefile" >&2; return 1; }
 	stub_root=$(mktemp -d)
 	mkdir -p "$stub_root/root/opt/aerospike/bin/asadm"
 	echo "stub bundle payload" > "$stub_root/root/opt/aerospike/bin/asadm/asadm"
@@ -165,52 +185,60 @@ function _bundle_overlap_check() {
 	case "$fmt" in
 		deb)
 			real_pkg=$(find "$GIT_DIR/pkg/target" -name '*.deb' -print -quit)
-			( cd "$stub_root" && fpm --force -s dir -t deb -n aerospike-tools -v 99.0.0 \
-				-C "$stub_root/root" --package "$stub_root/stub.deb" . >/dev/null )
-			stub_pkg="$stub_root/stub.deb"
+			( cd "$stub_root" && fpm --force -s dir -t deb -n aerospike-tools -v 12.0.0 \
+				-C "$stub_root/root" --package "$stub_root/old.deb" . >/dev/null )
+			( cd "$stub_root" && fpm --force -s empty -t deb -n aerospike-tools -v "$split" \
+				--package "$stub_root/meta.deb" >/dev/null )
+			old_pkg="$stub_root/old.deb"
+			meta_pkg="$stub_root/meta.deb"
 
-			dpkg -i "$stub_pkg" >/dev/null || { echo "assert_bundle_overlap: stub bundle would not install" >&2; return 1; }
+			dpkg -i "$old_pkg" >/dev/null || { echo "assert_bundle_overlap: stub old bundle would not install" >&2; return 1; }
 
-			# Promise: this install SUCCEEDS where it used to fail.
-			if ! out=$(dpkg -i "$real_pkg" 2>&1); then
-				echo "assert_bundle_overlap: installing over the bundle FAILED -- Replaces did not resolve the overlap" >&2
+			rc=0
+			out=$(dpkg -i "$real_pkg" 2>&1) || rc=$?
+			if [ "$rc" -eq 0 ]; then
+				echo "assert_bundle_overlap: dpkg -i SUCCEEDED over the old bundle -- Breaks (<< $split) did not take effect" >&2
+				return 1
+			fi
+			if printf '%s\n' "$out" | grep -qi 'trying to overwrite'; then
+				echo "assert_bundle_overlap: dpkg died on a raw file overwrite, not a named break -- the versioned relations did not take effect" >&2
 				printf '%s\n' "$out" >&2
 				return 1
 			fi
-			# Promise: ownership actually transferred (exit 0 with the bundle still
-			# owning the path would silently defeat the fix).
+			if ! printf '%s\n' "$out" | grep -qi 'breaks aerospike-tools'; then
+				echo "assert_bundle_overlap: dpkg failed but not with a named break on aerospike-tools; not actionable" >&2
+				printf '%s\n' "$out" >&2
+				return 1
+			fi
+
+			if ! out=$(dpkg -i "$meta_pkg" "$real_pkg" 2>&1); then
+				echo "assert_bundle_overlap: one-shot migration (metapackage + this package in a single dpkg run) FAILED" >&2
+				printf '%s\n' "$out" >&2
+				return 1
+			fi
 			if ! dpkg -S /opt/aerospike/bin/asadm/asadm 2>/dev/null | grep -q 'aerospike-asadm'; then
-				echo "assert_bundle_overlap: /opt/aerospike/bin/asadm/asadm is not owned by aerospike-asadm after install" >&2
+				echo "assert_bundle_overlap: /opt/aerospike/bin/asadm/asadm is not owned by aerospike-asadm after migration" >&2
 				dpkg -S /opt/aerospike/bin/asadm/asadm >&2 || true
 				return 1
 			fi
-			# Promise: the bundle stays installed rather than being erased.
-			if ! dpkg-query -W -f='${Status}' aerospike-tools 2>/dev/null | grep -q 'install ok installed'; then
-				echo "assert_bundle_overlap: aerospike-tools is no longer installed -- the takeover erased it" >&2
+			if ! dpkg-query -W -f='${Status} ${Version}' aerospike-tools 2>/dev/null | grep -q "install ok installed $split"; then
+				echo "assert_bundle_overlap: aerospike-tools is not installed at the metapackage version $split after migration" >&2
+				dpkg-query -W aerospike-tools >&2 || true
 				return 1
 			fi
-			echo "assert_bundle_overlap: deb installs over the bundle and takes ownership of the overlapping path"
+			echo "assert_bundle_overlap: deb refuses the old bundle with a named break and migrates cleanly through the $split metapackage"
 			;;
 		rpm)
 			real_pkg=$(find "$GIT_DIR/pkg/target" -name '*.rpm' -print -quit)
-			( cd "$stub_root" && fpm --force -s dir -t rpm -n aerospike-tools -v 99.0.0 \
-				-C "$stub_root/root" --package "$stub_root/stub.rpm" . >/dev/null )
-			stub_pkg="$stub_root/stub.rpm"
+			( cd "$stub_root" && fpm --force -s dir -t rpm -n aerospike-tools -v 12.0.0 \
+				-C "$stub_root/root" --package "$stub_root/old.rpm" . >/dev/null )
+			( cd "$stub_root" && fpm --force -s empty -t rpm -n aerospike-tools -v "$split" \
+				--package "$stub_root/meta.rpm" >/dev/null )
+			old_pkg="$stub_root/old.rpm"
+			meta_pkg="$stub_root/meta.rpm"
 
-			rpm -i "$stub_pkg" >/dev/null || { echo "assert_bundle_overlap: stub bundle would not install" >&2; return 1; }
+			rpm -i "$old_pkg" >/dev/null || { echo "assert_bundle_overlap: stub old bundle would not install" >&2; return 1; }
 
-			# Promise: an ACTIONABLE NAMED package conflict, not an opaque file
-			# collision. Checking only "it failed and mentioned aerospike-tools" does
-			# NOT test that -- every outcome below fails and every one names the
-			# package, so the wording is the only discriminator. Verified on ubi10:
-			#
-			#   --conflicts:  error: Failed dependencies:
-			#                   aerospike-tools conflicts with aerospike-asadm-...
-			#   no relation:  file /opt/... from install of aerospike-asadm-...
-			#                   conflicts with file from package aerospike-tools-...
-			#   --replaces:   error: Failed dependencies:
-			#                   aerospike-tools is obsoleted by aerospike-asadm-...
-			#
 			# Uses rpm directly rather than dnf: dnf is a Python program, and by this
 			# point in the build install_deps has put an asdf-managed Python ahead of
 			# the system one on PATH, so `dnf` dies with "ModuleNotFoundError: No
@@ -220,11 +248,11 @@ function _bundle_overlap_check() {
 			rc=0
 			out=$(rpm -i "$real_pkg" 2>&1) || rc=$?
 			if [ "$rc" -eq 0 ]; then
-				echo "assert_bundle_overlap: rpm install SUCCEEDED over the bundle -- Conflicts did not take effect" >&2
+				echo "assert_bundle_overlap: rpm install SUCCEEDED over the old bundle -- Conflicts (< $split) did not take effect" >&2
 				return 1
 			fi
 			if printf '%s\n' "$out" | grep -qi 'conflicts with file from'; then
-				echo "assert_bundle_overlap: rpm died on a raw FILE collision, not a named package conflict -- Conflicts: aerospike-tools did not take effect" >&2
+				echo "assert_bundle_overlap: rpm died on a raw FILE collision, not a named package conflict -- Conflicts did not take effect" >&2
 				printf '%s\n' "$out" >&2
 				return 1
 			fi
@@ -233,12 +261,28 @@ function _bundle_overlap_check() {
 				printf '%s\n' "$out" >&2
 				return 1
 			fi
-			if ! printf '%s\n' "$out" | grep -qi 'aerospike-tools conflicts with'; then
+			if ! printf '%s\n' "$out" | grep -qi 'conflicts with'; then
 				echo "assert_bundle_overlap: rpm failed but not with a named aerospike-tools conflict; not actionable" >&2
 				printf '%s\n' "$out" >&2
 				return 1
 			fi
-			echo "assert_bundle_overlap: rpm refuses with a named aerospike-tools conflict instead of a file collision"
+
+			if ! out=$(rpm -U "$meta_pkg" "$real_pkg" 2>&1); then
+				echo "assert_bundle_overlap: one-shot migration (metapackage + this package in a single rpm transaction) FAILED" >&2
+				printf '%s\n' "$out" >&2
+				return 1
+			fi
+			if ! rpm -qf /opt/aerospike/bin/asadm/asadm 2>/dev/null | grep -q 'aerospike-asadm'; then
+				echo "assert_bundle_overlap: /opt/aerospike/bin/asadm/asadm is not owned by aerospike-asadm after migration" >&2
+				rpm -qf /opt/aerospike/bin/asadm/asadm >&2 || true
+				return 1
+			fi
+			if ! rpm -q --qf '%{VERSION}\n' aerospike-tools 2>/dev/null | grep -qxF "$split"; then
+				echo "assert_bundle_overlap: aerospike-tools is not installed at the metapackage version $split after migration" >&2
+				rpm -q aerospike-tools >&2 || true
+				return 1
+			fi
+			echo "assert_bundle_overlap: rpm refuses the old bundle with a named conflict and migrates cleanly through the $split metapackage"
 			;;
 		tar)
 			echo "assert_bundle_overlap: no relations declared for the tar target; skipping"

--- a/.github/bin/build_package.sh
+++ b/.github/bin/build_package.sh
@@ -199,36 +199,46 @@ function _bundle_overlap_check() {
 
 			rpm -i "$stub_pkg" >/dev/null || { echo "assert_bundle_overlap: stub bundle would not install" >&2; return 1; }
 
-			# Promise: an ACTIONABLE NAMED conflict at depsolve time, not an opaque
-			# file collision at transaction-test time. Checking only "it failed and
-			# mentioned aerospike-tools" does NOT test that -- BOTH outcomes fail and
-			# BOTH name the package. Verified on ubi9 and ubi10 (dnf 4.20):
+			# Promise: an ACTIONABLE NAMED package conflict, not an opaque file
+			# collision. Checking only "it failed and mentioned aerospike-tools" does
+			# NOT test that -- every outcome below fails and every one names the
+			# package, so the wording is the only discriminator. Verified on ubi10:
 			#
-			#   with --conflicts:    Problem: package aerospike-asadm ... conflicts
-			#                        with aerospike-tools provided by ...
-			#   without --conflicts: Transaction test error: file /opt/... conflicts
-			#                        with file from package aerospike-tools-...
+			#   --conflicts:  error: Failed dependencies:
+			#                   aerospike-tools conflicts with aerospike-asadm-...
+			#   no relation:  file /opt/... from install of aerospike-asadm-...
+			#                   conflicts with file from package aerospike-tools-...
+			#   --replaces:   error: Failed dependencies:
+			#                   aerospike-tools is obsoleted by aerospike-asadm-...
 			#
-			# So the discriminator is the ABSENCE of the file-collision shape. That is
-			# the status quo this flag exists to replace; seeing it means the depsolve
-			# conflict never fired.
+			# Uses rpm directly rather than dnf: dnf is a Python program, and by this
+			# point in the build install_deps has put an asdf-managed Python ahead of
+			# the system one on PATH, so `dnf` dies with "ModuleNotFoundError: No
+			# module named 'dnf'". rpm is a compiled binary and unaffected. Testing at
+			# the rpm layer still proves the Conflicts is enforced and names the
+			# package, which is the substance of the promise.
 			rc=0
-			out=$(dnf install -y "$real_pkg" 2>&1) || rc=$?
+			out=$(rpm -i "$real_pkg" 2>&1) || rc=$?
 			if [ "$rc" -eq 0 ]; then
-				echo "assert_bundle_overlap: dnf install SUCCEEDED over the bundle -- Conflicts did not take effect" >&2
+				echo "assert_bundle_overlap: rpm install SUCCEEDED over the bundle -- Conflicts did not take effect" >&2
 				return 1
 			fi
-			if ! printf '%s\n' "$out" | grep -qi 'aerospike-tools'; then
-				echo "assert_bundle_overlap: dnf failed but never named aerospike-tools; the conflict is not actionable" >&2
+			if printf '%s\n' "$out" | grep -qi 'conflicts with file from'; then
+				echo "assert_bundle_overlap: rpm died on a raw FILE collision, not a named package conflict -- Conflicts: aerospike-tools did not take effect" >&2
 				printf '%s\n' "$out" >&2
 				return 1
 			fi
-			if printf '%s\n' "$out" | grep -qiE 'transaction test error|conflicts with file from'; then
-				echo "assert_bundle_overlap: dnf died on a raw FILE conflict, not a named package conflict -- Conflicts: aerospike-tools did not reach depsolve" >&2
+			if printf '%s\n' "$out" | grep -qi 'obsoleted by'; then
+				echo "assert_bundle_overlap: rpm reports aerospike-tools as OBSOLETED, not conflicting -- that erases the bundle instead of refusing" >&2
 				printf '%s\n' "$out" >&2
 				return 1
 			fi
-			echo "assert_bundle_overlap: rpm reports a named aerospike-tools conflict instead of a file collision"
+			if ! printf '%s\n' "$out" | grep -qi 'aerospike-tools conflicts with'; then
+				echo "assert_bundle_overlap: rpm failed but not with a named aerospike-tools conflict; not actionable" >&2
+				printf '%s\n' "$out" >&2
+				return 1
+			fi
+			echo "assert_bundle_overlap: rpm refuses with a named aerospike-tools conflict instead of a file collision"
 			;;
 		tar)
 			echo "assert_bundle_overlap: no relations declared for the tar target; skipping"

--- a/.github/bin/build_package.sh
+++ b/.github/bin/build_package.sh
@@ -31,51 +31,214 @@ function assert_dynamic_deps() {
 	return $fail
 }
 
+# Print one relation name per line for a deb control field. Debian comma-joins a
+# relation list onto one logical line and may append a version bound, so an
+# exact-line match against the raw field only works for the degenerate
+# single-entry-no-bound case: `Replaces: zzz-other, aerospike-tools` and
+# `Replaces: aerospike-tools (<< 12.0)` both fail it, reporting a field that is
+# in fact present.
+function deb_relations() {
+	dpkg-deb -f "$1" "$2" | tr ',' '\n' | sed 's/^[[:space:]]*//' | awk '{print $1}'
+}
+
+# Print one relation name per line for an rpm array tag. %{TAG} outside a [...]
+# iteration block formats only the FIRST element, and rpm normalizes dependency
+# arrays into sorted order -- so which entry is visible depends on alphabetical
+# luck against `aerospike-tools`, not on what the spec declared. That made the
+# Obsoletes check below fail OPEN: verified on ubi9 that a package declaring both
+# `Obsoletes: aaa-other` and `Obsoletes: aerospike-tools` reports only
+# `aaa-other`, so an rpm that erases the bundle passed the guard. The [...] form
+# emits every entry, and emits nothing (not "(none)") for an absent tag, so the
+# positive checks still fail correctly on a missing field.
+function rpm_relations() {
+	rpm -qp --qf "[%{$2}\n]" "$1" | awk '{print $1}'
+}
+
 # Assert the aerospike-tools relations actually reached the package metadata.
 # Building only proves fpm accepted the flag; these fields are what make the
 # bundle overlap installable, and their absence produces no output anywhere.
-# The negative checks matter as much as the positive ones: a Conflicts on the deb
-# would make plain `dpkg -i` hard-fail, and fpm's --replaces maps to rpm
-# Obsoletes, which would erase the whole bundle instead of taking over files.
+# The negative checks matter as much as the positive ones: `Conflicts:
+# aerospike-tools` on the deb would make plain `dpkg -i` hard-fail, and fpm's
+# --replaces maps to rpm Obsoletes, which would erase the whole bundle instead of
+# taking over files.
+#
+# Takes the package format as $1 rather than re-deriving it from $ENV_DISTRO.
+# Deriving it twice meant this guard could disagree with the dispatcher that
+# actually chose the format -- the dispatcher matches substrings (*el*) while a
+# case glob matches prefixes (el*), so `rhel9` built an rpm and then hit a
+# default branch that returned 0 while reporting a tar. A gate whose default is
+# success is not a gate.
 function assert_pkg_relations() {
-	local pkg
-	case "$ENV_DISTRO" in
-		ubuntu*|debian*)
+	local fmt="${1:-}" pkg
+	case "$fmt" in
+		deb)
 			pkg=$(find "$GIT_DIR/pkg/target" -name '*.deb' -print -quit)
 			if [ -z "$pkg" ]; then
 				echo "assert_pkg_relations: no .deb found under pkg/target" >&2
 				return 1
 			fi
-			if ! dpkg-deb -f "$pkg" Replaces | grep -qx 'aerospike-tools'; then
+			if ! deb_relations "$pkg" Replaces | grep -qx 'aerospike-tools'; then
 				echo "deb is missing 'Replaces: aerospike-tools'" >&2
 				return 1
 			fi
-			if [ -n "$(dpkg-deb -f "$pkg" Conflicts)" ]; then
-				echo "deb must not declare Conflicts: $(dpkg-deb -f "$pkg" Conflicts)" >&2
+			if deb_relations "$pkg" Conflicts | grep -qx 'aerospike-tools'; then
+				echo "deb must not Conflict with aerospike-tools (breaks the Replaces takeover)" >&2
 				return 1
 			fi
 			;;
-		el*|amzn*)
+		rpm)
 			pkg=$(find "$GIT_DIR/pkg/target" -name '*.rpm' -print -quit)
 			if [ -z "$pkg" ]; then
 				echo "assert_pkg_relations: no .rpm found under pkg/target" >&2
 				return 1
 			fi
-			if ! rpm -qp --qf '%{CONFLICTS}\n' "$pkg" | grep -qx 'aerospike-tools'; then
+			if ! rpm_relations "$pkg" CONFLICTS | grep -qx 'aerospike-tools'; then
 				echo "rpm is missing 'Conflicts: aerospike-tools'" >&2
 				return 1
 			fi
-			if rpm -qp --qf '%{OBSOLETES}\n' "$pkg" | grep -qx 'aerospike-tools'; then
+			if rpm_relations "$pkg" OBSOLETES | grep -qx 'aerospike-tools'; then
 				echo "rpm must not Obsolete aerospike-tools (that erases the bundle)" >&2
 				return 1
 			fi
 			;;
-		*)
-			echo "assert_pkg_relations: no relations declared for $ENV_DISTRO (tar); skipping"
+		tar)
+			echo "assert_pkg_relations: no relations declared for the tar target; skipping"
 			return 0
 			;;
+		*)
+			echo "assert_pkg_relations: unknown package format '$fmt'" >&2
+			return 1
+			;;
 	esac
-	echo "assert_pkg_relations: aerospike-tools relations present and correct"
+	echo "assert_pkg_relations: aerospike-tools relations present and correct ($fmt)"
+	return 0
+}
+
+# Exercise the bundle overlap as a real package-manager transaction. Metadata
+# presence (assert_pkg_relations) proves fpm emitted the field; it does NOT prove
+# dpkg resolves the overlap or that dnf names the conflict, which is what the
+# original bug report was about:
+#
+#   dpkg: error processing archive aerospike-asadm_...deb (--install):
+#    trying to overwrite '/opt/aerospike/bin/asadm/asadm', which is also in
+#    package aerospike-tools
+#
+# The real bundle is not reachable from CI, so stand in a stub that ships the one
+# path the report names, built with the fpm that just built the real package. That
+# validates the resolver semantics -- the part in doubt -- rather than the real
+# bundle's file list, which is not.
+#
+# Wrapper so the stub is always removed, including on the failure paths -- leaving
+# a fake aerospike-tools installed would poison anything that ran afterwards.
+function assert_bundle_overlap() {
+	local fmt="$1" rc=0
+	_bundle_overlap_cleanup "$fmt"
+	_bundle_overlap_check "$fmt" || rc=$?
+	_bundle_overlap_cleanup "$fmt"
+	return "$rc"
+}
+
+# Remove BOTH packages, real one first. The real package has to go too: on the
+# Obsoletes mutation dnf erases the stub and leaves aerospike-asadm installed,
+# which then blocks the stub from installing on any later call. Removing only the
+# stub left the check non-repeatable.
+function _bundle_overlap_cleanup() {
+	case "$1" in
+		deb)
+			dpkg --purge aerospike-asadm >/dev/null 2>&1 || true
+			dpkg --purge aerospike-tools >/dev/null 2>&1 || true
+			;;
+		rpm)
+			rpm -e aerospike-asadm >/dev/null 2>&1 || true
+			rpm -e aerospike-tools >/dev/null 2>&1 || true
+			;;
+	esac
+	return 0
+}
+
+function _bundle_overlap_check() {
+	local fmt="$1" stub_root stub_pkg real_pkg rc out
+	stub_root=$(mktemp -d)
+	mkdir -p "$stub_root/root/opt/aerospike/bin/asadm"
+	echo "stub bundle payload" > "$stub_root/root/opt/aerospike/bin/asadm/asadm"
+
+	case "$fmt" in
+		deb)
+			real_pkg=$(find "$GIT_DIR/pkg/target" -name '*.deb' -print -quit)
+			( cd "$stub_root" && fpm --force -s dir -t deb -n aerospike-tools -v 99.0.0 \
+				-C "$stub_root/root" --package "$stub_root/stub.deb" . >/dev/null )
+			stub_pkg="$stub_root/stub.deb"
+
+			dpkg -i "$stub_pkg" >/dev/null || { echo "assert_bundle_overlap: stub bundle would not install" >&2; return 1; }
+
+			# Promise: this install SUCCEEDS where it used to fail.
+			if ! out=$(dpkg -i "$real_pkg" 2>&1); then
+				echo "assert_bundle_overlap: installing over the bundle FAILED -- Replaces did not resolve the overlap" >&2
+				printf '%s\n' "$out" >&2
+				return 1
+			fi
+			# Promise: ownership actually transferred (exit 0 with the bundle still
+			# owning the path would silently defeat the fix).
+			if ! dpkg -S /opt/aerospike/bin/asadm/asadm 2>/dev/null | grep -q 'aerospike-asadm'; then
+				echo "assert_bundle_overlap: /opt/aerospike/bin/asadm/asadm is not owned by aerospike-asadm after install" >&2
+				dpkg -S /opt/aerospike/bin/asadm/asadm >&2 || true
+				return 1
+			fi
+			# Promise: the bundle stays installed rather than being erased.
+			if ! dpkg-query -W -f='${Status}' aerospike-tools 2>/dev/null | grep -q 'install ok installed'; then
+				echo "assert_bundle_overlap: aerospike-tools is no longer installed -- the takeover erased it" >&2
+				return 1
+			fi
+			echo "assert_bundle_overlap: deb installs over the bundle and takes ownership of the overlapping path"
+			;;
+		rpm)
+			real_pkg=$(find "$GIT_DIR/pkg/target" -name '*.rpm' -print -quit)
+			( cd "$stub_root" && fpm --force -s dir -t rpm -n aerospike-tools -v 99.0.0 \
+				-C "$stub_root/root" --package "$stub_root/stub.rpm" . >/dev/null )
+			stub_pkg="$stub_root/stub.rpm"
+
+			rpm -i "$stub_pkg" >/dev/null || { echo "assert_bundle_overlap: stub bundle would not install" >&2; return 1; }
+
+			# Promise: an ACTIONABLE NAMED conflict at depsolve time, not an opaque
+			# file collision at transaction-test time. Checking only "it failed and
+			# mentioned aerospike-tools" does NOT test that -- BOTH outcomes fail and
+			# BOTH name the package. Verified on ubi9 and ubi10 (dnf 4.20):
+			#
+			#   with --conflicts:    Problem: package aerospike-asadm ... conflicts
+			#                        with aerospike-tools provided by ...
+			#   without --conflicts: Transaction test error: file /opt/... conflicts
+			#                        with file from package aerospike-tools-...
+			#
+			# So the discriminator is the ABSENCE of the file-collision shape. That is
+			# the status quo this flag exists to replace; seeing it means the depsolve
+			# conflict never fired.
+			rc=0
+			out=$(dnf install -y "$real_pkg" 2>&1) || rc=$?
+			if [ "$rc" -eq 0 ]; then
+				echo "assert_bundle_overlap: dnf install SUCCEEDED over the bundle -- Conflicts did not take effect" >&2
+				return 1
+			fi
+			if ! printf '%s\n' "$out" | grep -qi 'aerospike-tools'; then
+				echo "assert_bundle_overlap: dnf failed but never named aerospike-tools; the conflict is not actionable" >&2
+				printf '%s\n' "$out" >&2
+				return 1
+			fi
+			if printf '%s\n' "$out" | grep -qiE 'transaction test error|conflicts with file from'; then
+				echo "assert_bundle_overlap: dnf died on a raw FILE conflict, not a named package conflict -- Conflicts: aerospike-tools did not reach depsolve" >&2
+				printf '%s\n' "$out" >&2
+				return 1
+			fi
+			echo "assert_bundle_overlap: rpm reports a named aerospike-tools conflict instead of a file collision"
+			;;
+		tar)
+			echo "assert_bundle_overlap: no relations declared for the tar target; skipping"
+			;;
+		*)
+			echo "assert_bundle_overlap: unknown package format '$fmt'" >&2
+			return 1
+			;;
+	esac
+	rm -rf "$stub_root"
 	return 0
 }
 
@@ -113,17 +276,18 @@ function build_packages() {
 	make clean
 	echo "building package for $BUILD_DISTRO"
 
-	if [[ $ENV_DISTRO == *"ubuntu"* ]]; then
-		make deb
-	elif [[ $ENV_DISTRO == *"debian"* ]]; then
-		make deb
-	elif [[ $ENV_DISTRO == *"el"* ]]; then
-		make rpm
-	elif [[ $ENV_DISTRO == *"amzn"* ]]; then
-		make rpm
+	# Single source of truth for the package format: chosen once here, then handed
+	# to assert_pkg_relations so the guard cannot disagree with what was built.
+	local pkg_fmt
+	if [[ $ENV_DISTRO == *"ubuntu"* || $ENV_DISTRO == *"debian"* ]]; then
+		pkg_fmt=deb
+	elif [[ $ENV_DISTRO == *"el"* || $ENV_DISTRO == *"amzn"* ]]; then
+		pkg_fmt=rpm
 	else
-		make tar
+		pkg_fmt=tar
 	fi
+	make "$pkg_fmt"
 
-	assert_pkg_relations
+	assert_pkg_relations "$pkg_fmt"
+	assert_bundle_overlap "$pkg_fmt"
 }

--- a/.github/bin/build_package.sh
+++ b/.github/bin/build_package.sh
@@ -36,8 +36,12 @@ function deb_relations() {
 		| sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's/[[:space:]][[:space:]]*/ /g'
 }
 
-function tools_split_version() {
-	sed -n 's/^TOOLS_SPLIT_VERSION[[:space:]]*=[[:space:]]*//p' "$GIT_DIR/pkg/Makefile" | head -1
+function tools_pre_token_bound() {
+	sed -n 's/^TOOLS_PRE_TOKEN_BOUND[[:space:]]*=[[:space:]]*//p' "$GIT_DIR/pkg/Makefile" | head -1
+}
+
+function tools_bundle_token() {
+	sed -n 's/^TOOLS_BUNDLE_TOKEN[[:space:]]*=[[:space:]]*//p' "$GIT_DIR/pkg/Makefile" | head -1
 }
 
 # Print one relation name per line for an rpm array tag. %{TAG} outside a [...]
@@ -68,10 +72,11 @@ function rpm_relations() {
 # default branch that returned 0 while reporting a tar. A gate whose default is
 # success is not a gate.
 function assert_pkg_relations() {
-	local fmt="${1:-}" pkg split
-	split=$(tools_split_version)
-	if [ -z "$split" ]; then
-		echo "assert_pkg_relations: TOOLS_SPLIT_VERSION not found in pkg/Makefile" >&2
+	local fmt="${1:-}" pkg bound token
+	bound=$(tools_pre_token_bound)
+	token=$(tools_bundle_token)
+	if [ -z "$bound" ] || [ -z "$token" ]; then
+		echo "assert_pkg_relations: TOOLS_PRE_TOKEN_BOUND / TOOLS_BUNDLE_TOKEN not found in pkg/Makefile" >&2
 		return 1
 	fi
 	case "$fmt" in
@@ -81,21 +86,21 @@ function assert_pkg_relations() {
 				echo "assert_pkg_relations: no .deb found under pkg/target" >&2
 				return 1
 			fi
-			if ! deb_relations "$pkg" Replaces | grep -qxF "aerospike-tools (<< $split)"; then
-				echo "deb is missing 'Replaces: aerospike-tools (<< $split)'" >&2
+			if ! deb_relations "$pkg" Conflicts | grep -qxF "aerospike-tools (<< $bound)"; then
+				echo "deb is missing 'Conflicts: aerospike-tools (<< $bound)' (pre-token bundles would hit a raw file collision)" >&2
 				return 1
 			fi
-			if ! deb_relations "$pkg" Breaks | grep -qxF "aerospike-tools (<< $split)"; then
-				echo "deb is missing 'Breaks: aerospike-tools (<< $split)'" >&2
+			if ! deb_relations "$pkg" Conflicts | grep -qxF "$token"; then
+				echo "deb is missing 'Conflicts: $token' (file-shipping bundles from $bound on would hit a raw file collision)" >&2
 				return 1
 			fi
-			if deb_relations "$pkg" Replaces | grep -qx 'aerospike-tools' \
-				|| deb_relations "$pkg" Breaks | grep -qx 'aerospike-tools'; then
-				echo "deb carries an UNVERSIONED aerospike-tools relation; it must be bounded (<< $split) or it hits the metapackage too" >&2
+			if deb_relations "$pkg" Conflicts | grep -qx 'aerospike-tools'; then
+				echo "deb carries an UNVERSIONED Conflicts: aerospike-tools; that would also hit a future no-binaries bundle" >&2
 				return 1
 			fi
-			if deb_relations "$pkg" Conflicts | grep -q 'aerospike-tools'; then
-				echo "deb must not Conflict with aerospike-tools (Breaks+Replaces is the split handoff)" >&2
+			if deb_relations "$pkg" Replaces | grep -q 'aerospike-tools' \
+				|| deb_relations "$pkg" Breaks | grep -q 'aerospike-tools'; then
+				echo "deb must not Replace/Break aerospike-tools; the conflict pair is the whole design" >&2
 				return 1
 			fi
 			;;
@@ -106,12 +111,16 @@ function assert_pkg_relations() {
 				return 1
 			fi
 			if ! rpm -qp --conflicts "$pkg" | sed 's/[[:space:]][[:space:]]*/ /g' \
-				| grep -qxF "aerospike-tools < $split"; then
-				echo "rpm is missing 'Conflicts: aerospike-tools < $split'" >&2
+				| grep -qxF "aerospike-tools < $bound"; then
+				echo "rpm is missing 'Conflicts: aerospike-tools < $bound'" >&2
+				return 1
+			fi
+			if ! rpm -qp --conflicts "$pkg" | grep -qxF "$token"; then
+				echo "rpm is missing 'Conflicts: $token'" >&2
 				return 1
 			fi
 			if rpm -qp --conflicts "$pkg" | grep -qx 'aerospike-tools'; then
-				echo "rpm carries an UNVERSIONED Conflicts: aerospike-tools; it must be bounded (< $split) or the metapackage becomes unsatisfiable" >&2
+				echo "rpm carries an UNVERSIONED Conflicts: aerospike-tools; that would also hit a future no-binaries bundle" >&2
 				return 1
 			fi
 			if rpm_relations "$pkg" OBSOLETES | grep -qx 'aerospike-tools'; then
@@ -128,7 +137,7 @@ function assert_pkg_relations() {
 			return 1
 			;;
 	esac
-	echo "assert_pkg_relations: versioned aerospike-tools split relations present and correct ($fmt)"
+	echo "assert_pkg_relations: aerospike-tools conflict pair present and correct ($fmt)"
 	return 0
 }
 
@@ -175,9 +184,10 @@ function _bundle_overlap_cleanup() {
 }
 
 function _bundle_overlap_check() {
-	local fmt="$1" stub_root old_pkg meta_pkg real_pkg rc out split
-	split=$(tools_split_version)
-	[ -n "$split" ] || { echo "assert_bundle_overlap: TOOLS_SPLIT_VERSION not found in pkg/Makefile" >&2; return 1; }
+	local fmt="$1" stub_root old_pkg tok_pkg shell_pkg real_pkg rc out bound token
+	bound=$(tools_pre_token_bound)
+	token=$(tools_bundle_token)
+	{ [ -n "$bound" ] && [ -n "$token" ]; } || { echo "assert_bundle_overlap: TOOLS_PRE_TOKEN_BOUND / TOOLS_BUNDLE_TOKEN not found in pkg/Makefile" >&2; return 1; }
 	stub_root=$(mktemp -d)
 	mkdir -p "$stub_root/root/opt/aerospike/bin/asadm"
 	echo "stub bundle payload" > "$stub_root/root/opt/aerospike/bin/asadm/asadm"
@@ -187,32 +197,53 @@ function _bundle_overlap_check() {
 			real_pkg=$(find "$GIT_DIR/pkg/target" -name '*.deb' -print -quit)
 			( cd "$stub_root" && fpm --force -s dir -t deb -n aerospike-tools -v 12.0.0 \
 				-C "$stub_root/root" --package "$stub_root/old.deb" . >/dev/null )
-			( cd "$stub_root" && fpm --force -s empty -t deb -n aerospike-tools -v "$split" \
-				--package "$stub_root/meta.deb" >/dev/null )
+			( cd "$stub_root" && fpm --force -s dir -t deb -n aerospike-tools -v "$bound" \
+				--provides "$token" \
+				-C "$stub_root/root" --package "$stub_root/tok.deb" . >/dev/null )
+			( cd "$stub_root" && fpm --force -s empty -t deb -n aerospike-tools -v 99.0.0 \
+				--package "$stub_root/shell.deb" >/dev/null )
 			old_pkg="$stub_root/old.deb"
-			meta_pkg="$stub_root/meta.deb"
+			tok_pkg="$stub_root/tok.deb"
+			shell_pkg="$stub_root/shell.deb"
 
 			dpkg -i "$old_pkg" >/dev/null || { echo "assert_bundle_overlap: stub old bundle would not install" >&2; return 1; }
-
 			rc=0
 			out=$(dpkg -i "$real_pkg" 2>&1) || rc=$?
 			if [ "$rc" -eq 0 ]; then
-				echo "assert_bundle_overlap: dpkg -i SUCCEEDED over the old bundle -- Breaks (<< $split) did not take effect" >&2
+				echo "assert_bundle_overlap: dpkg -i SUCCEEDED over the pre-token bundle -- Conflicts (<< $bound) did not take effect" >&2
 				return 1
 			fi
 			if printf '%s\n' "$out" | grep -qi 'trying to overwrite'; then
-				echo "assert_bundle_overlap: dpkg died on a raw file overwrite, not a named break -- the versioned relations did not take effect" >&2
+				echo "assert_bundle_overlap: dpkg died on a raw file overwrite over the pre-token bundle" >&2
 				printf '%s\n' "$out" >&2
 				return 1
 			fi
-			if ! printf '%s\n' "$out" | grep -qi 'breaks aerospike-tools'; then
-				echo "assert_bundle_overlap: dpkg failed but not with a named break on aerospike-tools; not actionable" >&2
+			if ! printf '%s\n' "$out" | grep -qi 'conflicts with'; then
+				echo "assert_bundle_overlap: dpkg failed over the pre-token bundle but not with a named conflict" >&2
 				printf '%s\n' "$out" >&2
 				return 1
 			fi
 
-			if ! out=$(dpkg -i "$meta_pkg" "$real_pkg" 2>&1); then
-				echo "assert_bundle_overlap: one-shot migration (metapackage + this package in a single dpkg run) FAILED" >&2
+			dpkg -i "$tok_pkg" >/dev/null || { echo "assert_bundle_overlap: stub token bundle would not install" >&2; return 1; }
+			rc=0
+			out=$(dpkg -i "$real_pkg" 2>&1) || rc=$?
+			if [ "$rc" -eq 0 ]; then
+				echo "assert_bundle_overlap: dpkg -i SUCCEEDED over the token bundle -- Conflicts: $token did not take effect" >&2
+				return 1
+			fi
+			if printf '%s\n' "$out" | grep -qi 'trying to overwrite'; then
+				echo "assert_bundle_overlap: dpkg died on a raw file overwrite over the token bundle" >&2
+				printf '%s\n' "$out" >&2
+				return 1
+			fi
+			if ! printf '%s\n' "$out" | grep -qi 'conflicts with'; then
+				echo "assert_bundle_overlap: dpkg failed over the token bundle but not with a named conflict" >&2
+				printf '%s\n' "$out" >&2
+				return 1
+			fi
+
+			if ! out=$(dpkg -i "$shell_pkg" "$real_pkg" 2>&1); then
+				echo "assert_bundle_overlap: migration through a no-binaries bundle (single dpkg run) FAILED" >&2
 				printf '%s\n' "$out" >&2
 				return 1
 			fi
@@ -221,21 +252,24 @@ function _bundle_overlap_check() {
 				dpkg -S /opt/aerospike/bin/asadm/asadm >&2 || true
 				return 1
 			fi
-			if ! dpkg-query -W -f='${Status} ${Version}' aerospike-tools 2>/dev/null | grep -q "install ok installed $split"; then
-				echo "assert_bundle_overlap: aerospike-tools is not installed at the metapackage version $split after migration" >&2
-				dpkg-query -W aerospike-tools >&2 || true
+			if ! dpkg-query -W -f='${Status}' aerospike-tools 2>/dev/null | grep -q 'install ok installed'; then
+				echo "assert_bundle_overlap: the no-binaries bundle did not stay installed alongside this package" >&2
 				return 1
 			fi
-			echo "assert_bundle_overlap: deb refuses the old bundle with a named break and migrates cleanly through the $split metapackage"
+			echo "assert_bundle_overlap: deb refuses both file-shipping bundle generations with named conflicts and coexists with a no-binaries bundle"
 			;;
 		rpm)
 			real_pkg=$(find "$GIT_DIR/pkg/target" -name '*.rpm' -print -quit)
 			( cd "$stub_root" && fpm --force -s dir -t rpm -n aerospike-tools -v 12.0.0 \
 				-C "$stub_root/root" --package "$stub_root/old.rpm" . >/dev/null )
-			( cd "$stub_root" && fpm --force -s empty -t rpm -n aerospike-tools -v "$split" \
-				--package "$stub_root/meta.rpm" >/dev/null )
+			( cd "$stub_root" && fpm --force -s dir -t rpm -n aerospike-tools -v "$bound" \
+				--provides "$token" \
+				-C "$stub_root/root" --package "$stub_root/tok.rpm" . >/dev/null )
+			( cd "$stub_root" && fpm --force -s empty -t rpm -n aerospike-tools -v 99.0.0 \
+				--package "$stub_root/shell.rpm" >/dev/null )
 			old_pkg="$stub_root/old.rpm"
-			meta_pkg="$stub_root/meta.rpm"
+			tok_pkg="$stub_root/tok.rpm"
+			shell_pkg="$stub_root/shell.rpm"
 
 			rpm -i "$old_pkg" >/dev/null || { echo "assert_bundle_overlap: stub old bundle would not install" >&2; return 1; }
 
@@ -248,11 +282,11 @@ function _bundle_overlap_check() {
 			rc=0
 			out=$(rpm -i "$real_pkg" 2>&1) || rc=$?
 			if [ "$rc" -eq 0 ]; then
-				echo "assert_bundle_overlap: rpm install SUCCEEDED over the old bundle -- Conflicts (< $split) did not take effect" >&2
+				echo "assert_bundle_overlap: rpm install SUCCEEDED over the pre-token bundle -- Conflicts (< $bound) did not take effect" >&2
 				return 1
 			fi
 			if printf '%s\n' "$out" | grep -qi 'conflicts with file from'; then
-				echo "assert_bundle_overlap: rpm died on a raw FILE collision, not a named package conflict -- Conflicts did not take effect" >&2
+				echo "assert_bundle_overlap: rpm died on a raw FILE collision over the pre-token bundle" >&2
 				printf '%s\n' "$out" >&2
 				return 1
 			fi
@@ -262,13 +296,32 @@ function _bundle_overlap_check() {
 				return 1
 			fi
 			if ! printf '%s\n' "$out" | grep -qi 'conflicts with'; then
-				echo "assert_bundle_overlap: rpm failed but not with a named aerospike-tools conflict; not actionable" >&2
+				echo "assert_bundle_overlap: rpm failed over the pre-token bundle but not with a named conflict" >&2
 				printf '%s\n' "$out" >&2
 				return 1
 			fi
 
-			if ! out=$(rpm -U "$meta_pkg" "$real_pkg" 2>&1); then
-				echo "assert_bundle_overlap: one-shot migration (metapackage + this package in a single rpm transaction) FAILED" >&2
+			rpm -e aerospike-tools >/dev/null 2>&1 || true
+			rpm -i "$tok_pkg" >/dev/null || { echo "assert_bundle_overlap: stub token bundle would not install" >&2; return 1; }
+			rc=0
+			out=$(rpm -i "$real_pkg" 2>&1) || rc=$?
+			if [ "$rc" -eq 0 ]; then
+				echo "assert_bundle_overlap: rpm install SUCCEEDED over the token bundle -- Conflicts: $token did not take effect" >&2
+				return 1
+			fi
+			if printf '%s\n' "$out" | grep -qi 'conflicts with file from'; then
+				echo "assert_bundle_overlap: rpm died on a raw FILE collision over the token bundle" >&2
+				printf '%s\n' "$out" >&2
+				return 1
+			fi
+			if ! printf '%s\n' "$out" | grep -qi 'conflicts with'; then
+				echo "assert_bundle_overlap: rpm failed over the token bundle but not with a named conflict" >&2
+				printf '%s\n' "$out" >&2
+				return 1
+			fi
+
+			if ! out=$(rpm -U "$shell_pkg" "$real_pkg" 2>&1); then
+				echo "assert_bundle_overlap: migration through a no-binaries bundle (single rpm transaction) FAILED" >&2
 				printf '%s\n' "$out" >&2
 				return 1
 			fi
@@ -277,12 +330,11 @@ function _bundle_overlap_check() {
 				rpm -qf /opt/aerospike/bin/asadm/asadm >&2 || true
 				return 1
 			fi
-			if ! rpm -q --qf '%{VERSION}\n' aerospike-tools 2>/dev/null | grep -qxF "$split"; then
-				echo "assert_bundle_overlap: aerospike-tools is not installed at the metapackage version $split after migration" >&2
-				rpm -q aerospike-tools >&2 || true
+			if ! rpm -q aerospike-tools >/dev/null 2>&1; then
+				echo "assert_bundle_overlap: the no-binaries bundle did not stay installed alongside this package" >&2
 				return 1
 			fi
-			echo "assert_bundle_overlap: rpm refuses the old bundle with a named conflict and migrates cleanly through the $split metapackage"
+			echo "assert_bundle_overlap: rpm refuses both file-shipping bundle generations with named conflicts and coexists with a no-binaries bundle"
 			;;
 		tar)
 			echo "assert_bundle_overlap: no relations declared for the tar target; skipping"

--- a/.github/bin/test/test_execute.bats
+++ b/.github/bin/test/test_execute.bats
@@ -1,11 +1,19 @@
 #!/usr/bin/env bats
 
+# `run` captures status and output instead of relying on errexit. The previous
+# form (`asadm --help` followed by `[ "$?" -eq 0 ]`) could not fail: a non-zero
+# exit aborted the body at the first line under errexit, so the check only ever
+# ran when $? was already 0. That matters now that build-and-release.yml runs
+# this file AFTER the astools.conf reinstall cycle, making it the pipeline's last
+# word on whether asadm starts.
 @test "can run asadm" {
-  asadm --help
-  [ "$?" -eq 0 ]
+  run asadm --help
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
 }
 
 @test "can run asinfo" {
-  asinfo --help
-  [ "$?" -eq 0 ]
+  run asinfo --help
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
 }

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -353,16 +353,21 @@ jobs:
     needs:
       - get-version
       - organize-built-artifacts
-    uses: aerospike/shared-workflows/.github/workflows/reusable_sign-mac-artifacts.yaml@v3.6.0
+    uses: aerospike/shared-workflows/.github/workflows/reusable_sign-mac-artifacts.yaml@v3.7.0
     permissions:
       contents: read
       id-token: write
     with:
       gh-unsigned-artifacts: unsigned-artifacts-${{ needs.get-version.outputs.VERSION }}
-      artifact-glob: "**/*.pkg"
+      # As observed in shared-workflows v3.7.0: matches_glob() is a bash `case`
+      # match, not a real globstar matcher, so "**/*.pkg" requires a literal "/"
+      # and never matches our flat artifact tree -- every pkg gets skipped and
+      # the job still exits 0. Do not "fix" this back to "**/*.pkg" unless the
+      # pinned signer above implements real globstar matching.
+      artifact-glob: "*.pkg"
       signing-identity: "Developer ID Application: Aerospike, Inc. (22224RFU67)"
       installer-identity: "Developer ID Installer: Aerospike, Inc. (22224RFU67)"
-      gh-workflows-ref: "v3.6.0"
+      gh-workflows-ref: "v3.7.0"
       gh-retention-days: 1
     secrets:
       apple-application-cert: ${{ secrets.APPLE_APPLICATION_CERT }}
@@ -376,11 +381,11 @@ jobs:
     needs:
       - get-version
       - notarize-mac-artifacts
-    uses: aerospike/shared-workflows/.github/workflows/reusable_sign-artifacts.yaml@v3.6.0
+    uses: aerospike/shared-workflows/.github/workflows/reusable_sign-artifacts.yaml@v3.7.0
     with:
       gh-artifact-name: signed-artifacts-${{ needs.get-version.outputs.VERSION }}
       gh-unsigned-artifacts: unsigned-artifacts-${{ needs.get-version.outputs.VERSION }}
-      gh-workflows-ref: "v3.6.0"
+      gh-workflows-ref: "v3.7.0"
     secrets:
       gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
       gpg-public-key: ${{ secrets.GPG_PUBLIC_KEY }}
@@ -582,7 +587,7 @@ jobs:
     needs:
       - get-version
       - organize-signed-artifacts
-    uses: aerospike/shared-workflows/.github/workflows/reusable_deploy-artifacts.yaml@v3.6.0
+    uses: aerospike/shared-workflows/.github/workflows/reusable_deploy-artifacts.yaml@v3.7.0
     with:
       jf-project: database
       jf-build-name: "aerospike-asadm"
@@ -594,7 +599,7 @@ jobs:
       dry-run: ${{ inputs.release != true }}
       jf-build-id: ${{ needs.get-version.outputs.VERSION }}
       jf-metadata-build-id: ${{ needs.get-version.outputs.VERSION }}-metadata
-      gh-workflows-ref: "v3.6.0"
+      gh-workflows-ref: "v3.7.0"
 
   docker-build-arch:
     name: Docker build, test & push (${{ matrix.arch }})
@@ -795,7 +800,7 @@ jobs:
       - get-version
       - upload-artifacts-to-jfrog
       - docker-manifest
-    uses: aerospike/shared-workflows/.github/workflows/reusable_create-release-bundle.yaml@v3.6.0
+    uses: aerospike/shared-workflows/.github/workflows/reusable_create-release-bundle.yaml@v3.7.0
     with:
       jf-project: "database"
       jf-build-names: "aerospike-asadm:${{ needs.get-version.outputs.VERSION }},aerospike-asadm-docker:${{ needs.get-version.outputs.VERSION }}"
@@ -803,7 +808,7 @@ jobs:
       oidc-provider-name: database-gh-aerospike
       oidc-audience: database-gh-aerospike
       version: ${{ needs.get-version.outputs.VERSION }}
-      gh-workflows-ref: v3.6.0
+      gh-workflows-ref: v3.7.0
       dry-run: false
 
   # Tag-last: created only after every publish step succeeds. A failure

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -481,11 +481,15 @@ jobs:
           "/tmp/bats-core-${BATS_VERSION}/install.sh" /usr/local
           bats --version
 
-      - name: Verify installation
-        run: bats .github/bin/test/test_execute.bats
-
+      # astools.conf lifecycle runs FIRST because it reinstalls the package
+      # several times. Verifying execution afterwards means the pipeline's last
+      # word on "does asadm start" comes from after the install-over-install
+      # cycle, not before it.
       - name: Verify astools.conf lifecycle
         run: bats .github/bin/test/test_astools_conf.bats
+
+      - name: Verify installation
+        run: bats .github/bin/test/test_execute.bats
 
   test-install-mac-and-execute:
     name: Test install & execute (${{ matrix.os }})
@@ -526,11 +530,15 @@ jobs:
       - name: Install bats
         run: brew install bats-core
 
-      - name: Verify installation
-        run: bats .github/bin/test/test_execute.bats
-
+      # astools.conf lifecycle runs FIRST because it reinstalls the package
+      # several times. Verifying execution afterwards means the pipeline's last
+      # word on "does asadm start" comes from after the install-over-install
+      # cycle, not before it.
       - name: Verify astools.conf lifecycle
         run: bats .github/bin/test/test_astools_conf.bats
+
+      - name: Verify installation
+        run: bats .github/bin/test/test_execute.bats
 
   organize-signed-artifacts:
     name: Organize signed artifacts for deploy

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -5,9 +5,11 @@
 # distros × 2 arches + signing + notarization — too heavy for every commit.
 #
 # This workflow exercises both fpm code paths (deb on Ubuntu, rpm on EL) on
-# amd64 so a regression in either format surfaces early. macOS pkg builds
-# are deferred to the release workflow (macOS runners are ~10x more
-# expensive and pkg/Makefile changes are infrequent).
+# amd64 so a regression in either format surfaces early. macOS pkg builds are
+# not here: mac-artifact.yml builds and installs the .pkg (exercising
+# pkg/mac-scripts) on PRs into master. Note that gives macOS narrower coverage
+# than the branches: ["**"] below — a PR into bugfix-* gets the deb/rpm checks
+# but no macOS packaging check.
 #
 # tests.yml verifies the binary build via `make`. This adds coverage for
 # the *packaging* step (install_deps → make → fpm).

--- a/.github/workflows/mac-artifact.yml
+++ b/.github/workflows/mac-artifact.yml
@@ -101,6 +101,35 @@ jobs:
           asadm -e "info" 2>&1 | grep "Not able to connect"
           asinfo || true
           asinfo 2>&1 | grep "Not able to connect"
+      # Builds the .pkg so pkgbuild --scripts (and therefore pkg/mac-scripts) is
+      # exercised on every PR. The release workflow is workflow_dispatch only, so
+      # without this the installer scripts are first run during a release. Runs
+      # after "Sanity Test tools" on purpose: `make install` has already put a
+      # tree at the payload's destination, so the first install exercises the
+      # preinstall against an existing tree. No signing or notarization needed to
+      # produce a locally installable .pkg.
+      - name: Build and install .pkg (exercises pkg/mac-scripts)
+        working-directory: ${{ steps.working-dir.outputs.value }}
+        run: |
+          set -euo pipefail
+          make -C pkg osx-pkg VERSION="${{ steps.tag.outputs.tag }}"
+          pkg=$(find pkg/target -name '*.pkg' -print -quit)
+          [ -n "${pkg}" ] || { echo "::error::no .pkg produced under pkg/target/"; exit 1; }
+          sudo installer -pkg "${pkg}" -target /
+          asadm --version
+          asinfo --version
+          # The preinstall exists because the macOS installer never prunes
+          # obsolete payload files. Plant an orphan, reinstall, and confirm it is
+          # gone -- otherwise a preinstall that silently no-ops would pass.
+          tree=/usr/local/aerospike/bin/asadm
+          sudo touch "${tree}/liborphan-test.so"
+          sudo installer -pkg "${pkg}" -target /
+          if [ -e "${tree}/liborphan-test.so" ]; then
+            echo "::error::preinstall did not clear ${tree}"
+            exit 1
+          fi
+          asadm --version
+          asinfo --version
       - name: Create .tar
         working-directory: ${{ steps.working-dir.outputs.value }}
         run: |

--- a/.github/workflows/mac-artifact.yml
+++ b/.github/workflows/mac-artifact.yml
@@ -102,17 +102,31 @@ jobs:
           asinfo || true
           asinfo 2>&1 | grep "Not able to connect"
       # Builds the .pkg so pkgbuild --scripts (and therefore pkg/mac-scripts) is
-      # exercised on every PR. The release workflow is workflow_dispatch only, so
-      # without this the installer scripts are first run during a release. Runs
-      # after "Sanity Test tools" on purpose: `make install` has already put a
-      # tree at the payload's destination, so the first install exercises the
-      # preinstall against an existing tree. No signing or notarization needed to
-      # produce a locally installable .pkg.
+      # exercised on every PR into master -- the pull_request trigger above filters
+      # on that base branch, so PRs into bugfix-* are NOT covered; widen the filter
+      # if that matters. The release workflow is workflow_dispatch only, so without
+      # this the installer scripts are first run during a release. Runs after
+      # "Sanity Test tools" on purpose: `make install` has already put a tree at the
+      # payload's destination, so the first install exercises the preinstall against
+      # an existing tree. No signing or notarization needed to produce a locally
+      # installable .pkg.
+      #
+      # Skipped on the workflow_call path: the aerospike-tools bundle calls this
+      # workflow for asadm.tar and does not consume this .pkg, so building and
+      # system-installing it there only couples the bundle's artifact build to this
+      # repo's packaging metadata.
+      #
+      # VERSION goes through env rather than a ${{ }} splice into the script: `${{ }}`
+      # is substituted before a shell exists, and a git tag may legally contain
+      # shell metacharacters.
       - name: Build and install .pkg (exercises pkg/mac-scripts)
+        if: inputs.submodule == ''
         working-directory: ${{ steps.working-dir.outputs.value }}
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
           set -euo pipefail
-          make -C pkg osx-pkg VERSION="${{ steps.tag.outputs.tag }}"
+          make -C pkg osx-pkg VERSION="${TAG}"
           pkg=$(find pkg/target -name '*.pkg' -print -quit)
           [ -n "${pkg}" ] || { echo "::error::no .pkg produced under pkg/target/"; exit 1; }
           sudo installer -pkg "${pkg}" -target /

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -51,25 +51,25 @@ ARCH = $(shell uname -m)
 .PHONY: all
 all: deb rpm tar
 
-# aerospike-tools older than TOOLS_SPLIT_VERSION is the monolithic bundle that
-# ships these same /opt/aerospike/bin/asadm paths. From TOOLS_SPLIT_VERSION on
-# it is a transitional metapackage that ships no binaries and Depends on this
-# package instead, on its way to being retired entirely. The versioned
-# relations below are the standard package-split handoff (Debian Policy 7.6.1:
-# files moving between packages get versioned Breaks + Replaces).
+# The aerospike-tools bundle ships these same /opt/aerospike/bin/asadm paths,
+# so the two packages cannot coexist while it does. Two conflicts express
+# that without predicting the bundle's future:
 #
-# Keep this value in step with the metapackage cutover in
-# citrusleaf/aerospike-tools and with the other standalone tool repos.
-TOOLS_SPLIT_VERSION = 13.0.3
-
-# deb: Breaks forces the old file-shipping bundle to be upgraded to the
-# metapackage (or removed) in the same transaction, and Replaces lets dpkg hand
-# the overlapping paths over during that transaction. Both are bounded to
-# (<< TOOLS_SPLIT_VERSION): the metapackage and anything newer ship none of
-# these files, so they coexist freely and no ownership ping-pong is possible.
-# A bare `dpkg -i` over an old bundle refuses with a named break naming
-# aerospike-tools; `apt install` resolves it. fpm has no --deb-breaks flag, so
-# Breaks goes in via --deb-field.
+#   aerospike-tools (<< TOOLS_PRE_TOKEN_BOUND)  every bundle released BEFORE
+#     the bundle started declaring the virtual token below. A frozen fact
+#     about the past; never needs raising.
+#   aerospike-tools-binaries                    a virtual package Provided by
+#     every file-shipping bundle from TOOLS_PRE_TOKEN_BOUND on (see
+#     citrusleaf/aerospike-tools pkg/Makefile.bundle). It travels with the
+#     payload at any version, so no future version commitment exists here.
+#     If the bundle ever stops shipping binaries it drops the token and
+#     coexistence starts working with no change on this side.
+#
+# Installing either side over the other refuses with a named, actionable
+# conflict instead of a raw file collision. Keep both values in step with
+# citrusleaf/aerospike-tools and the other standalone tool repos.
+TOOLS_PRE_TOKEN_BOUND = 13.0.3
+TOOLS_BUNDLE_TOKEN = aerospike-tools-binaries
 .PHONY: deb
 deb: prep
 	fpm --force \
@@ -87,18 +87,14 @@ deb: prep
 		--vendor $(VENDOR) \
 		--after-install $(PKG_DIR)/postinst.sh \
 		--after-upgrade $(PKG_DIR)/postinst.sh \
-		--replaces "aerospike-tools (<< $(TOOLS_SPLIT_VERSION))" \
-		--deb-field "Breaks: aerospike-tools (<< $(TOOLS_SPLIT_VERSION))" \
+		--conflicts "aerospike-tools (<< $(TOOLS_PRE_TOKEN_BOUND))" \
+		--conflicts "$(TOOLS_BUNDLE_TOKEN)" \
 		--package $(TARGET_DIR)/$(NAME)_$(PKG_VERSION)-$(DEB_ITERATION)_$(ARCH).deb
 
-# rpm has no Replaces equivalent for a partial file takeover (fpm's --replaces
-# maps to Obsoletes, which erases the other package wholesale), so the split is
-# expressed as a versioned Conflicts against the file-shipping bundles: a named
-# conflict at depsolve time instead of an opaque file collision at
-# transaction-test time. Upgrading the old bundle to the metapackage and
-# installing this package in one dnf transaction resolves it; the bound means
-# the metapackage (>= TOOLS_SPLIT_VERSION) is never conflicted, so this flag
-# never needs to be revisited.
+# rpm side of the same two conflicts (fpm's --replaces maps to Obsoletes,
+# which would erase the bundle wholesale, so Conflicts is the only correct
+# relation here). dnf names the conflict and the resolution instead of dying
+# on an opaque file collision at transaction-test time.
 .PHONY: rpm
 rpm: prep
 	fpm --force \
@@ -119,7 +115,8 @@ rpm: prep
 		--vendor $(VENDOR) \
 		--after-install $(PKG_DIR)/postinst.sh \
 		--after-upgrade $(PKG_DIR)/postinst.sh \
-		--conflicts "aerospike-tools < $(TOOLS_SPLIT_VERSION)" \
+		--conflicts "aerospike-tools < $(TOOLS_PRE_TOKEN_BOUND)" \
+		--conflicts "$(TOOLS_BUNDLE_TOKEN)" \
 		--package $(TARGET_DIR)/$(NAME)-$(RPM_VERSION)-$(ITERATION).$(BUILD_DISTRO).$(ARCH).rpm
 
 .PHONY: tar

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -51,6 +51,10 @@ ARCH = $(shell uname -m)
 .PHONY: all
 all: deb rpm tar
 
+# The aerospike-tools bundle ships these same /opt/aerospike/bin paths. deb
+# Replaces (without Conflicts) lets dpkg hand file ownership to this package;
+# rpm has no equivalent, so Conflicts turns an opaque file-conflict error into
+# an actionable one.
 .PHONY: deb
 deb: prep
 	fpm --force \
@@ -68,6 +72,7 @@ deb: prep
 		--vendor $(VENDOR) \
 		--after-install $(PKG_DIR)/postinst.sh \
 		--after-upgrade $(PKG_DIR)/postinst.sh \
+		--replaces "aerospike-tools" \
 		--package $(TARGET_DIR)/$(NAME)_$(PKG_VERSION)-$(DEB_ITERATION)_$(ARCH).deb
 
 .PHONY: rpm
@@ -90,6 +95,7 @@ rpm: prep
 		--vendor $(VENDOR) \
 		--after-install $(PKG_DIR)/postinst.sh \
 		--after-upgrade $(PKG_DIR)/postinst.sh \
+		--conflicts "aerospike-tools" \
 		--package $(TARGET_DIR)/$(NAME)-$(RPM_VERSION)-$(ITERATION).$(BUILD_DISTRO).$(ARCH).rpm
 
 .PHONY: tar

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -51,10 +51,17 @@ ARCH = $(shell uname -m)
 .PHONY: all
 all: deb rpm tar
 
-# The aerospike-tools bundle ships these same /opt/aerospike/bin paths. deb
-# Replaces (without Conflicts) lets dpkg hand file ownership to this package;
-# rpm has no equivalent, so Conflicts turns an opaque file-conflict error into
-# an actionable one.
+# The aerospike-tools bundle ships the same /opt/aerospike/bin/asadm paths this
+# package does (see prep, below). deb Replaces without Conflicts lets dpkg hand
+# file ownership to this package while both stay installed; Conflicts would make
+# a plain `dpkg -i` hard-fail instead of resolving.
+#
+# The takeover is NOT sticky. Replaces is evaluated on every unpack, and the
+# bundle declares the mirror Replaces, so a later `apt upgrade` of the bundle
+# takes the paths back. Because the bundle's payload is a superset of this
+# package's file list, that unpack also trips dpkg's disappearance rule and
+# leaves aerospike-asadm not-installed. Recovery is `apt install aerospike-asadm`.
+# Only the metapackage conversion (see the rpm target) makes ownership durable.
 .PHONY: deb
 deb: prep
 	fpm --force \
@@ -75,6 +82,20 @@ deb: prep
 		--replaces "aerospike-tools" \
 		--package $(TARGET_DIR)/$(NAME)_$(PKG_VERSION)-$(DEB_ITERATION)_$(ARCH).deb
 
+# rpm has no Replaces equivalent for a partial file takeover (fpm's --replaces
+# maps to Obsoletes, which erases the other package wholesale), so Conflicts is
+# the best available outcome: a named conflict at depsolve time instead of an
+# opaque file collision at transaction-test time. The bundle must still be
+# removed by hand (dnf remove aerospike-tools) before this package will
+# install — a known gap, not an oversight.
+#
+# Unversioned on purpose: the bundle ships these paths at every version, and a
+# version bound would let rpm attempt the transaction for bundles above it and
+# fail on the raw file conflict instead. But REMOVE this --conflicts before
+# aerospike-tools becomes a metapackage that Requires this package — an
+# unversioned Conflicts makes such a metapackage unsatisfiable. That conversion
+# is tracked against the aerospike-tools bundle; see the Known gap section of
+# the PR that introduced this flag.
 .PHONY: rpm
 rpm: prep
 	fpm --force \

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -62,6 +62,17 @@ all: deb rpm tar
 # package's file list, that unpack also trips dpkg's disappearance rule and
 # leaves aerospike-asadm not-installed. Recovery is `apt install aerospike-asadm`.
 # Only the metapackage conversion (see the rpm target) makes ownership durable.
+#
+# The REMOVAL direction is the sharper edge, and it is silent. Once the takeover
+# has happened the overlapping paths are listed only by this package, so
+# `apt remove aerospike-asadm` DELETES the bundle's asadm/asinfo while
+# aerospike-tools is still installed -- and because dpkg verifies against a
+# manifest that no longer claims those paths, `dpkg -l` still reports the bundle
+# `ii` and `dpkg -V` exits 0 with no output. Nothing warns, and recovery is
+# `apt install --reinstall aerospike-tools`. Verified with real .debs on
+# ubuntu:noble. This is inherent to Replaces-without-Breaks (Breaks would force
+# the bundle off the system, defeating coexistence), so it is a documented
+# consequence rather than something a flag change can fix.
 .PHONY: deb
 deb: prep
 	fpm --force \
@@ -89,13 +100,25 @@ deb: prep
 # removed by hand (dnf remove aerospike-tools) before this package will
 # install — a known gap, not an oversight.
 #
+# The full cost, because "best available outcome" undersells it: a package-level
+# Conflicts is a dependency problem, not a file conflict, so `rpm -i
+# --replacefiles` and `--force` no longer bypass it -- only `--nodeps`, which
+# disables every real dependency check as collateral. `--replacefiles` DID
+# previously produce a working coexisting pair, so this flag makes coexistence
+# unreachable on rpm rather than merely noisier, and any host already in that
+# state can no longer `dnf upgrade aerospike-asadm`. Note that pkg/postinst.sh
+# documents coexistence as a design goal: after this flag, that is a deb-only
+# property.
+#
 # Unversioned on purpose: the bundle ships these paths at every version, and a
 # version bound would let rpm attempt the transaction for bundles above it and
 # fail on the raw file conflict instead. But REMOVE this --conflicts before
 # aerospike-tools becomes a metapackage that Requires this package — an
-# unversioned Conflicts makes such a metapackage unsatisfiable. That conversion
-# is tracked against the aerospike-tools bundle; see the Known gap section of
-# the PR that introduced this flag.
+# unversioned Conflicts makes such a metapackage unsatisfiable, so the flag must
+# be gone from a released aerospike-asadm BEFORE the metapackage ships. The
+# reasoning above is self-contained; for the wider write-up see
+# aerospike/aerospike-admin#532, and the conversion itself is tracked against the
+# aerospike-tools bundle (citrusleaf/aerospike-tools#439).
 .PHONY: rpm
 rpm: prep
 	fpm --force \

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -51,28 +51,25 @@ ARCH = $(shell uname -m)
 .PHONY: all
 all: deb rpm tar
 
-# The aerospike-tools bundle ships the same /opt/aerospike/bin/asadm paths this
-# package does (see prep, below). deb Replaces without Conflicts lets dpkg hand
-# file ownership to this package while both stay installed; Conflicts would make
-# a plain `dpkg -i` hard-fail instead of resolving.
+# aerospike-tools older than TOOLS_SPLIT_VERSION is the monolithic bundle that
+# ships these same /opt/aerospike/bin/asadm paths. From TOOLS_SPLIT_VERSION on
+# it is a transitional metapackage that ships no binaries and Depends on this
+# package instead, on its way to being retired entirely. The versioned
+# relations below are the standard package-split handoff (Debian Policy 7.6.1:
+# files moving between packages get versioned Breaks + Replaces).
 #
-# The takeover is NOT sticky. Replaces is evaluated on every unpack, and the
-# bundle declares the mirror Replaces, so a later `apt upgrade` of the bundle
-# takes the paths back. Because the bundle's payload is a superset of this
-# package's file list, that unpack also trips dpkg's disappearance rule and
-# leaves aerospike-asadm not-installed. Recovery is `apt install aerospike-asadm`.
-# Only the metapackage conversion (see the rpm target) makes ownership durable.
-#
-# The REMOVAL direction is the sharper edge, and it is silent. Once the takeover
-# has happened the overlapping paths are listed only by this package, so
-# `apt remove aerospike-asadm` DELETES the bundle's asadm/asinfo while
-# aerospike-tools is still installed -- and because dpkg verifies against a
-# manifest that no longer claims those paths, `dpkg -l` still reports the bundle
-# `ii` and `dpkg -V` exits 0 with no output. Nothing warns, and recovery is
-# `apt install --reinstall aerospike-tools`. Verified with real .debs on
-# ubuntu:noble. This is inherent to Replaces-without-Breaks (Breaks would force
-# the bundle off the system, defeating coexistence), so it is a documented
-# consequence rather than something a flag change can fix.
+# Keep this value in step with the metapackage cutover in
+# citrusleaf/aerospike-tools and with the other standalone tool repos.
+TOOLS_SPLIT_VERSION = 13.0.3
+
+# deb: Breaks forces the old file-shipping bundle to be upgraded to the
+# metapackage (or removed) in the same transaction, and Replaces lets dpkg hand
+# the overlapping paths over during that transaction. Both are bounded to
+# (<< TOOLS_SPLIT_VERSION): the metapackage and anything newer ship none of
+# these files, so they coexist freely and no ownership ping-pong is possible.
+# A bare `dpkg -i` over an old bundle refuses with a named break naming
+# aerospike-tools; `apt install` resolves it. fpm has no --deb-breaks flag, so
+# Breaks goes in via --deb-field.
 .PHONY: deb
 deb: prep
 	fpm --force \
@@ -90,35 +87,18 @@ deb: prep
 		--vendor $(VENDOR) \
 		--after-install $(PKG_DIR)/postinst.sh \
 		--after-upgrade $(PKG_DIR)/postinst.sh \
-		--replaces "aerospike-tools" \
+		--replaces "aerospike-tools (<< $(TOOLS_SPLIT_VERSION))" \
+		--deb-field "Breaks: aerospike-tools (<< $(TOOLS_SPLIT_VERSION))" \
 		--package $(TARGET_DIR)/$(NAME)_$(PKG_VERSION)-$(DEB_ITERATION)_$(ARCH).deb
 
 # rpm has no Replaces equivalent for a partial file takeover (fpm's --replaces
-# maps to Obsoletes, which erases the other package wholesale), so Conflicts is
-# the best available outcome: a named conflict at depsolve time instead of an
-# opaque file collision at transaction-test time. The bundle must still be
-# removed by hand (dnf remove aerospike-tools) before this package will
-# install — a known gap, not an oversight.
-#
-# The full cost, because "best available outcome" undersells it: a package-level
-# Conflicts is a dependency problem, not a file conflict, so `rpm -i
-# --replacefiles` and `--force` no longer bypass it -- only `--nodeps`, which
-# disables every real dependency check as collateral. `--replacefiles` DID
-# previously produce a working coexisting pair, so this flag makes coexistence
-# unreachable on rpm rather than merely noisier, and any host already in that
-# state can no longer `dnf upgrade aerospike-asadm`. Note that pkg/postinst.sh
-# documents coexistence as a design goal: after this flag, that is a deb-only
-# property.
-#
-# Unversioned on purpose: the bundle ships these paths at every version, and a
-# version bound would let rpm attempt the transaction for bundles above it and
-# fail on the raw file conflict instead. But REMOVE this --conflicts before
-# aerospike-tools becomes a metapackage that Requires this package — an
-# unversioned Conflicts makes such a metapackage unsatisfiable, so the flag must
-# be gone from a released aerospike-asadm BEFORE the metapackage ships. The
-# reasoning above is self-contained; for the wider write-up see
-# aerospike/aerospike-admin#532, and the conversion itself is tracked against the
-# aerospike-tools bundle (citrusleaf/aerospike-tools#439).
+# maps to Obsoletes, which erases the other package wholesale), so the split is
+# expressed as a versioned Conflicts against the file-shipping bundles: a named
+# conflict at depsolve time instead of an opaque file collision at
+# transaction-test time. Upgrading the old bundle to the metapackage and
+# installing this package in one dnf transaction resolves it; the bound means
+# the metapackage (>= TOOLS_SPLIT_VERSION) is never conflicted, so this flag
+# never needs to be revisited.
 .PHONY: rpm
 rpm: prep
 	fpm --force \
@@ -139,7 +119,7 @@ rpm: prep
 		--vendor $(VENDOR) \
 		--after-install $(PKG_DIR)/postinst.sh \
 		--after-upgrade $(PKG_DIR)/postinst.sh \
-		--conflicts "aerospike-tools" \
+		--conflicts "aerospike-tools < $(TOOLS_SPLIT_VERSION)" \
 		--package $(TARGET_DIR)/$(NAME)-$(RPM_VERSION)-$(ITERATION).$(BUILD_DISTRO).$(ARCH).rpm
 
 .PHONY: tar

--- a/pkg/mac-scripts/preinstall
+++ b/pkg/mac-scripts/preinstall
@@ -4,16 +4,26 @@
 # install — including a plain version-to-version upgrade. deb and rpm prune them
 # automatically (Debian Policy 6.6: files in the old version but not in the new
 # are removed), so only macOS accumulates cruft from an older asadm or from the
-# aerospike-tools bundle. Clear the tree first so the onedir does not grow
-# without bound. $3 = target volume ("/" for standard installs).
+# aerospike-tools bundle. Clear the tree first: a merged tree both grows without
+# bound and can change behaviour (see below). $3 = target volume ("/" for
+# standard installs).
 vol="${3:-/}"
 tree="$vol/usr/local/aerospike/bin/asadm"
 # rm -rf is silent for a missing path (that is what -f is for), so a non-zero
 # status here is a real failure: an immutable flag, an ACL, a read-only volume.
-# Warn rather than abort. Stale files in the tree are inert — the loader and the
-# PyInstaller bootloader resolve by recorded name, never by scanning the
-# directory — so a merged tree still runs, and failing the install would be the
-# worse outcome. The warning lands in /var/log/install.log.
+# Warn rather than abort, because aborting leaves the user with no working asadm,
+# which is worse than a merged tree.
+#
+# But a merged tree is NOT harmless. Code resolution is by recorded name (ELF
+# DT_NEEDED, Mach-O install names, the bootloader's CArchive TOC, FrozenImporter
+# ahead of PathFinder), so an orphaned library cannot hijack startup -- however
+# asadm also reads bundled *data* by scanning the directory:
+# lib/live_cluster/client/config_handler.py enumerates the schemas directory with
+# os.listdir and picks the closest version at or below the server build. That
+# directory ships as a real on-disk tree (see `datas` in pyinstaller-build.spec),
+# so an obsolete schema JSON left behind by an older asadm can be selected in
+# preference to the current one. Treat this warning as a real defect, not
+# cosmetic. It lands in /var/log/install.log.
 if ! rm -rf "$tree"; then
     echo "preinstall: could not clear $tree; installing over the existing tree" >&2
 fi

--- a/pkg/mac-scripts/preinstall
+++ b/pkg/mac-scripts/preinstall
@@ -1,9 +1,20 @@
 #!/bin/sh
 # asadm ships as a PyInstaller directory tree. The macOS installer merges a
-# payload over what is already there and never deletes, so a tree left by
-# another package (the aerospike-tools bundle, or an older asadm) keeps its
-# orphan libraries alongside the new ones and asadm can fail to start. Clear
-# the tree first. $3 = target volume ("/" for standard installs).
+# payload over what is already there and never deletes obsolete files, on any
+# install — including a plain version-to-version upgrade. deb and rpm prune them
+# automatically (Debian Policy 6.6: files in the old version but not in the new
+# are removed), so only macOS accumulates cruft from an older asadm or from the
+# aerospike-tools bundle. Clear the tree first so the onedir does not grow
+# without bound. $3 = target volume ("/" for standard installs).
 vol="${3:-/}"
-rm -rf "$vol/usr/local/aerospike/bin/asadm"
+tree="$vol/usr/local/aerospike/bin/asadm"
+# rm -rf is silent for a missing path (that is what -f is for), so a non-zero
+# status here is a real failure: an immutable flag, an ACL, a read-only volume.
+# Warn rather than abort. Stale files in the tree are inert — the loader and the
+# PyInstaller bootloader resolve by recorded name, never by scanning the
+# directory — so a merged tree still runs, and failing the install would be the
+# worse outcome. The warning lands in /var/log/install.log.
+if ! rm -rf "$tree"; then
+    echo "preinstall: could not clear $tree; installing over the existing tree" >&2
+fi
 exit 0

--- a/pkg/mac-scripts/preinstall
+++ b/pkg/mac-scripts/preinstall
@@ -1,0 +1,9 @@
+#!/bin/sh
+# asadm ships as a PyInstaller directory tree. The macOS installer merges a
+# payload over what is already there and never deletes, so a tree left by
+# another package (the aerospike-tools bundle, or an older asadm) keeps its
+# orphan libraries alongside the new ones and asadm can fail to start. Clear
+# the tree first. $3 = target volume ("/" for standard installs).
+vol="${3:-/}"
+rm -rf "$vol/usr/local/aerospike/bin/asadm"
+exit 0


### PR DESCRIPTION
## What this is

The `aerospike-tools` bundle ships the same `/opt/aerospike/bin/asadm` paths as this package, so installing one on a host that has the other used to die on a raw file conflict:

```
dpkg: error processing archive aerospike-asadm_5.0.3-2ubuntu22.04_aarch64.deb (--install):
 trying to overwrite '/opt/aerospike/bin/asadm/asadm', which is also in package aerospike-tools ...
```

The bundle stays a single self-contained package (deliberately: one-file airgap installs), so the two can never coexist on one host. This PR expresses that as named, resolvable conflicts, without predicting the bundle's future:

| relation | covers |
|---|---|
| `Conflicts: aerospike-tools (<< 13.0.3)` | every bundle released before the bundle started declaring the token below. A frozen fact about the past; never needs raising. |
| `Conflicts: aerospike-tools-binaries` | every future file-shipping bundle at any version. The bundle `Provides` this virtual token for as long as it ships binaries (citrusleaf/aerospike-tools#439); if it ever stops (metapackage or retirement, at 14 or whenever), it drops the token and coexistence starts working with **no change on this side**. |
| macOS: new `pkg/mac-scripts/preinstall` | clears `/usr/local/aerospike/bin/asadm` before the payload lands. |

deb `Conflicts` rather than `Breaks`+`Replaces`: coexistence is impossible while the bundle ships binaries, so there is no file handoff to mediate, and nothing unversioned ships against the real package name, so nothing here can ever block a future no-binaries `aerospike-tools`. `TOOLS_PRE_TOKEN_BOUND` and `TOOLS_BUNDLE_TOKEN` in `pkg/Makefile` are the single source of truth; the CI guards read them from there.

### Why macOS needs the preinstall

macOS has no conflict check at all, but the installer merges a payload over what is already on disk and never deletes obsolete files, on any install including a plain version-to-version upgrade (deb and rpm prune automatically, Debian Policy 6.6). asadm is the only tool shipping a PyInstaller onedir rather than a single binary, so only its tree accumulates cruft, from an older asadm or from the bundle. Stale files are not just cosmetic: code resolution is by recorded name and cannot be hijacked, but asadm scans its bundled schemas directory with `os.listdir` (`lib/live_cluster/client/config_handler.py`) and an obsolete schema JSON left behind can be selected over the current one. The preinstall clears the tree; a failure to clear warns rather than aborts (aborting would leave no working asadm at all).

## What users see

- Fresh installs: unchanged.
- Bundle installed, `apt install aerospike-asadm`: apt names the conflict and resolves it by removing the bundle (a plain `dpkg -i` refuses with `conflicts with aerospike-tools`, never `trying to overwrite`).
- Bundle installed, rpm: `dnf` names the conflict and the resolution (`--allowerasing` swaps the bundle out).
- Reverse direction (tools installed, bundle being installed) refuses just as clearly; the conflict is symmetric.
- macOS: installs and upgrades stop accumulating stale files inside the asadm tree.

## Testing

- `assert_pkg_relations` (runs after every `make deb` / `make rpm` in CI) asserts both conflict entries exactly, and the dangerous negatives: an UNVERSIONED `Conflicts: aerospike-tools` fails the build (it would also hit a future no-binaries bundle), as do any `Breaks`/`Replaces` on aerospike-tools (deb) and `Obsoletes` (rpm; fpm's `--replaces` maps to Obsoletes, which would erase the bundle).
- `assert_bundle_overlap` stands up three stubs with the same fpm that built the real package: a pre-token bundle (12.0.0, ships the overlapping path), a token bundle (13.0.3, `Provides: aerospike-tools-binaries`), and a no-binaries bundle (99.0.0, no token). It proves the named refusal over both file-shipping generations (never a raw file error, never an Obsoletes erase) and the one-transaction migration through the no-binaries bundle, with file ownership landing on `aerospike-asadm` and both packages coexisting.
- `mac-artifact.yml` builds the `.pkg` on every PR into master, installs it twice, and asserts a planted orphan file is removed by the preinstall. Previously no PR check invoked `pkgbuild` at all.
- The two `bats` install jobs run the reinstall cycle before the execution check, so the pipeline's last word on "does asadm start" comes after install-over-install.
- Full matrix verified with real packages on `debian:12` and `rockylinux:9`, including a token bundle at a future 14.2.0 to prove version-independence, and apt/dnf auto-resolution.

## Sequencing

All six PRs land together: aerospike/aerospike-tools-backup#169, aerospike/aql#90, aerospike/aerospike-benchmark#160, aerospike/asconfig#133, plus the bundle-side token citrusleaf/aerospike-tools#439. Any bundle released at or above 13.0.3 MUST carry the `Provides` token (the bundle build asserts it), and this tool re-releases with the conflicts before such a bundle ships.
