### PR TITLE
fix(ci): bump stale get-pip.py checksum pin

### DIFF
--- a/.github/bin/install_deps.sh
+++ b/.github/bin/install_deps.sh
@@ -149,14 +149,41 @@ _install_python_via_asdf_and_fpm() {
     fi
     # Fail on HTTP errors (-f); checksum pins bootstrap.pypa.io content (bump when updating intentionally).
     # bootstrap.pypa.io/get-pip.py is a ROLLING url -- PyPA replaces it in place on
-    # every pip release, so this pin goes stale on their schedule, not ours, and the
-    # build breaks with only "computed checksum did NOT match". Current value is the
-    # file bundling pip 26.2.1 (verified: genuine PyPA header, self-contained base85
-    # zip, no runtime network calls). See the PR for why pinning a rolling url is the
-    # real problem here.
+    # every pip release, so this pin goes stale on their schedule, not ours. Expect
+    # to bump it a few times a year; the mismatch branch below explains itself when
+    # you do. Current value is the file bundling pip 26.2.1 (verified: genuine PyPA
+    # header, self-contained base85 zip, no runtime network calls). See the PR for
+    # why pinning a rolling url is the real problem here.
     local get_pip_expected_sha="${GET_PIP_SHA256:-fb24e693bab954209a063d90953621412ccad4a500905a726286e038f508ddf6}"
     curl -fSL "${CURL_RETRY_OPTS[@]}" https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
-    echo "${get_pip_expected_sha}  /tmp/get-pip.py" | sha256sum -c - >/dev/null
+    # Compare explicitly rather than with `sha256sum -c`, whose only failure output
+    # is "WARNING: 1 computed checksum did NOT match" -- it names neither the file,
+    # the two hashes, nor where the pin lives, so the failure reads as an opaque
+    # exit 1 to whoever is on call. Print the diagnosis and the remedy instead.
+    local get_pip_actual_sha
+    get_pip_actual_sha=$(sha256sum /tmp/get-pip.py | cut -d' ' -f1)
+    if [[ "$get_pip_actual_sha" != "$get_pip_expected_sha" ]]; then
+      cat >&2 <<EOF
+ERROR: get-pip.py checksum mismatch -- https://bootstrap.pypa.io/get-pip.py has
+       changed upstream since this pin was last updated.
+  expected: ${get_pip_expected_sha}
+  actual:   ${get_pip_actual_sha}
+  file:     /tmp/get-pip.py (left in place for inspection)
+  pin:      .github/bin/install_deps.sh, get_pip_expected_sha (this function)
+
+That URL is ROLLING: PyPA replaces the file in place on every pip release, so the
+pin goes stale on their release schedule, not ours. A mismatch is far more often a
+routine pip release than a tampered download -- but it is the only signal we have,
+so confirm which it is before updating the pin.
+
+To fix: check https://pypi.org/project/pip/#history for a release around now, and
+confirm /tmp/get-pip.py is a genuine PyPA get-pip.py (PyPA header, self-contained
+base85 zip, no runtime network calls). Once verified, update get_pip_expected_sha
+above to the actual hash. GET_PIP_SHA256 overrides it for a single run -- use that
+only to test a hash you have already verified, never to wave a build through.
+EOF
+      return 1
+    fi
     "$HOME/.asdf/installs/python/$PYTHON_VERSION/bin/python" /tmp/get-pip.py --no-warn-script-location
     rm -f /tmp/get-pip.py
   fi

--- a/.github/bin/install_deps.sh
+++ b/.github/bin/install_deps.sh
@@ -148,7 +148,13 @@ _install_python_via_asdf_and_fpm() {
       unset PYTHON_CONFIGURE_OPTS
     fi
     # Fail on HTTP errors (-f); checksum pins bootstrap.pypa.io content (bump when updating intentionally).
-    local get_pip_expected_sha="${GET_PIP_SHA256:-25b5c39ade96bab5eabe6404ce83cab6da2deb5fe3c07d9881f43803edb6f9c8}"
+    # bootstrap.pypa.io/get-pip.py is a ROLLING url -- PyPA replaces it in place on
+    # every pip release, so this pin goes stale on their schedule, not ours, and the
+    # build breaks with only "computed checksum did NOT match". Current value is the
+    # file bundling pip 26.2.1 (verified: genuine PyPA header, self-contained base85
+    # zip, no runtime network calls). See the PR for why pinning a rolling url is the
+    # real problem here.
+    local get_pip_expected_sha="${GET_PIP_SHA256:-fb24e693bab954209a063d90953621412ccad4a500905a726286e038f508ddf6}"
     curl -fSL "${CURL_RETRY_OPTS[@]}" https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
     echo "${get_pip_expected_sha}  /tmp/get-pip.py" | sha256sum -c - >/dev/null
     "$HOME/.asdf/installs/python/$PYTHON_VERSION/bin/python" /tmp/get-pip.py --no-warn-script-location


### PR DESCRIPTION
## Summary

`build-artifacts (ubuntu26.04)` fails in **Install build dependencies** with nothing but:

```
sha256sum: WARNING: 1 computed checksum did NOT match
```

`.github/bin/install_deps.sh:150-153` pins the sha256 of `https://bootstrap.pypa.io/get-pip.py`. That is a **rolling URL** — PyPA replaces the file in place on every pip release — so the pin goes stale on their schedule, not ours.

```
pinned : 25b5c39ade96bab5eabe6404ce83cab6da2deb5fe3c07d9881f43803edb6f9c8
actual : fb24e693bab954209a063d90953621412ccad4a500905a726286e038f508ddf6
```

Only ubuntu26.04 is affected because it is the one distro whose asdf-built Python takes the `get-pip.py` bootstrap path. The other 18 matrix builds skip it and were unaffected — which is why this reads as a one-distro flake rather than a stale pin.

## Verified before bumping

A pin exists to catch unexpected changes, so resetting it to whatever upstream currently serves deserves more than a copy-paste. What I checked on the new file:

- Genuine PyPA header (`This is a base85 encoding of a zip file … an entire copy of pip (version 26.2.1)`)
- Self-contained: **zero** runtime network calls (no `urlopen`/`urlretrieve`/`requests`)
- 2,230,488 bytes, sha256 `fb24e693…`
- Reproduces the build's own check: `echo "<sha>  get-pip.py" | sha256sum -c -` → `OK`

So the mismatch has a benign explanation: PyPA rolled the file forward to pip 26.2.1.

## This only resets the clock

Worth being explicit: **this will break again on the next pip release**, and the failure mode is a bare checksum warning with no hint that upstream simply moved. Pinning a rolling URL gets the worst of both worlds — it does not pin content over time, and it converts routine upstream releases into red builds.

The durable fix is to stop bootstrapping from a rolling URL:

- `python -m ensurepip --upgrade` where the interpreter supports it, or
- install a specific pip version from PyPI with a hash-pinned wheel

Both are larger changes that want their own validation run, so they are not bundled here. Filing this as the tracked follow-up.

## Scope

Unrelated to the macOS signing work in #533 — this is the Linux dependency path. Raising it separately because it is what currently blocks a full green release run, and because a supply-chain pin should not be quietly bumped inside an unrelated PR.





## Review follow-up — @mcoberly2 (applied in `b6de800`)

> if checksum fails, print something like "get-pip.py may have been updated upstream; see install_deps.sh" so the next on-call doesn't grep blindly.

Applied. This was already biting: run [31417642139](https://github.com/aerospike/aerospike-admin/actions/runs/31417642139) failed on both ubuntu26.04 shards with nothing but `sha256sum: WARNING: 1 computed checksum did NOT match` — because `sha256sum -c - >/dev/null` discarded the only informative line.

The hashes are now compared explicitly, and the mismatch branch reports expected vs actual, the downloaded file's path, the pin's location, why a rolling URL goes stale on PyPA's schedule rather than ours, and how to verify the new file before trusting it.

It deliberately does **not** print a copy-paste `GET_PIP_SHA256=<actual>` line: handing over the hash that just failed turns the integrity check into a speed bump. The override is documented in the message, but clearing it still requires judging the file genuine.

The comment above the pin was also corrected — it claimed the build "breaks with only `computed checksum did NOT match`", which was true before this commit and wrong after it.

**Verified:** `bash -n` passes; both branches exercised in a harness reproducing the real call chain (helper → `install_deps` under `set -euo pipefail`). Match proceeds to the end of the step; mismatch prints the diagnostic and `return 1`, which propagates and stops the step — checked explicitly, since moving from `set -e`-on-a-pipeline to an `if` block is where a hard failure can silently become a warning. The pinned hash was re-confirmed against the live file, so the happy path still passes.