### PR TITLE
fix(pkg): ship one macOS pkg per arch, with an asserted support floor

### DIFF
--- a/.github/bin/check_min_os.sh
+++ b/.github/bin/check_min_os.sh
@@ -23,14 +23,17 @@ version_le() {
 	[[ "$1" == "$2" ]] || [[ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" == "$1" ]]
 }
 
-# LC_BUILD_VERSION on current objects, LC_VERSION_MIN_MACOSX on older ones.
+# Every floor in the file, one per line: LC_BUILD_VERSION on current objects,
+# LC_VERSION_MIN_MACOSX on older ones. A universal binary carries one set of
+# load commands per slice, and `otool -l` prints them in slice order, so
+# stopping at the first would let a later slice's higher floor through.
 read_minos() {
 	otool -l "$1" 2>/dev/null | awk '
-		/LC_BUILD_VERSION/  { in_bv = 1; next }
-		/LC_VERSION_MIN_MAC/ { in_vm = 1; next }
-		in_bv && $1 == "minos"   { print $2; exit }
-		in_vm && $1 == "version" { print $2; exit }
-		/^Load command/ { in_bv = 0; in_vm = 0 }
+		/^Load command/      { bv = 0; vm = 0; next }
+		/LC_BUILD_VERSION/   { bv = 1; next }
+		/LC_VERSION_MIN_MAC/ { vm = 1; next }
+		bv && $1 == "minos"   { print $2; bv = 0 }
+		vm && $1 == "version" { print $2; vm = 0 }
 	'
 }
 
@@ -43,11 +46,17 @@ while IFS= read -r f; do
 	*) continue ;;
 	esac
 	scanned=$((scanned + 1))
-	minos=$(read_minos "$f")
-	# No load command means no floor to violate.
-	[[ -n "$minos" ]] || continue
-	if ! version_le "$minos" "$floor"; then
-		echo "  $minos  $f" >&2
+	# Report the highest offending slice. A file with no load command at all
+	# has no floor to violate.
+	worst=""
+	while IFS= read -r minos; do
+		version_le "$minos" "$floor" && continue
+		if [[ -z "$worst" ]] || ! version_le "$minos" "$worst"; then
+			worst="$minos"
+		fi
+	done < <(read_minos "$f")
+	if [[ -n "$worst" ]]; then
+		echo "  $worst  $f" >&2
 		violations=$((violations + 1))
 	fi
 done < <(find "$@" -type f)

--- a/.github/bin/check_min_os.sh
+++ b/.github/bin/check_min_os.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Fail if any Mach-O in a macOS payload declares a minos above our floor; dyld
+# refuses such a binary on that release, with no override. Catches an unpinned
+# compile inheriting the runner's SDK, and prebuilt files vendored off the runner
+# that no compile flag reaches.
+#
+# Usage: check_min_os.sh <floor> <path>...
+set -euo pipefail
+
+floor="${1:-}"
+shift || true
+if [[ -z "$floor" || $# -eq 0 ]]; then
+	echo "usage: $(basename "$0") <floor> <path>..." >&2
+	exit 1
+fi
+if [[ ! "$floor" =~ ^[0-9]+(\.[0-9]+)*$ ]]; then
+	echo "error: floor '$floor' is not a macOS version" >&2
+	exit 1
+fi
+
+# sort -V, so 14.8 ranks above 14.0 and 9.0 below 10.0.
+version_le() {
+	[[ "$1" == "$2" ]] || [[ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -1)" == "$1" ]]
+}
+
+# LC_BUILD_VERSION on current objects, LC_VERSION_MIN_MACOSX on older ones.
+read_minos() {
+	otool -l "$1" 2>/dev/null | awk '
+		/LC_BUILD_VERSION/  { in_bv = 1; next }
+		/LC_VERSION_MIN_MAC/ { in_vm = 1; next }
+		in_bv && $1 == "minos"   { print $2; exit }
+		in_vm && $1 == "version" { print $2; exit }
+		/^Load command/ { in_bv = 0; in_vm = 0 }
+	'
+}
+
+scanned=0
+violations=0
+while IFS= read -r f; do
+	# Filter on type, not the +x bit: dylibs and .so are not executable.
+	case "$(file -b "$f" 2>/dev/null)" in
+	*Mach-O*) ;;
+	*) continue ;;
+	esac
+	scanned=$((scanned + 1))
+	minos=$(read_minos "$f")
+	# No load command means no floor to violate.
+	[[ -n "$minos" ]] || continue
+	if ! version_le "$minos" "$floor"; then
+		echo "  $minos  $f" >&2
+		violations=$((violations + 1))
+	fi
+done < <(find "$@" -type f)
+
+if ((violations > 0)); then
+	{
+		echo "error: $violations of $scanned Mach-O file(s) above the macOS $floor floor (listed above)."
+		echo "Build against MACOSX_DEPLOYMENT_TARGET=$floor, or stop vendoring the offending file."
+	} >&2
+	exit 1
+fi
+
+if ((scanned == 0)); then
+	echo "error: no Mach-O files found under: $*" >&2
+	exit 1
+fi
+
+echo "==> $scanned Mach-O file(s) all run on macOS $floor or later"

--- a/.github/bin/os_version.sh
+++ b/.github/bin/os_version.sh
@@ -16,12 +16,9 @@
 # removed along with the tools-packaging-common submodule.
 #
 # On macOS it emits "macos<major>" from the product version (26.0 -> macos26).
-# This is the single source of truth for the "macos<major>" FIELD of the .pkg
-# file name; the "<arch>" field beside it is `uname -m`, appended by the caller
-# (pkg/Makefile's MAC_PKG, and the two workflow steps that name and select the
-# artifact). CI must call this script rather than re-deriving the token from a
-# runner label, so the name a release publishes is the name a local
-# `make -C pkg osx-pkg` produces.
+# No longer part of any artifact name -- .pkg files are named per arch, not per
+# macOS generation (see MAC_PKG in pkg/Makefile). Kept for callers that want the
+# build host's generation.
 
 set -euo pipefail
 

--- a/.github/bin/os_version.sh
+++ b/.github/bin/os_version.sh
@@ -28,9 +28,8 @@ OPT_LONG=0
 kernel="$(uname -s)"
 
 if [[ "$kernel" = "Darwin" ]]; then
-    # Records the macOS generation the artifact was built on, not a minimum it
-    # supports: nothing pins MACOSX_DEPLOYMENT_TARGET. It is what keeps one
-    # release's per-runner artifacts distinct.
+    # Identifies the build host's generation only. Not part of any artifact
+    # name, and not a minimum the artifact supports -- see MACOS_MIN_VERSION.
     mac_version="$(sw_vers -productVersion)"
     # `set -e` above already catches an sw_vers that exits non-zero. This
     # guard is for the case it cannot see: exiting 0 having printed nothing,

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -295,9 +295,8 @@ jobs:
         os: [macos-15-intel, macos-14, macos-15, macos-26]
         include:
           # One publisher per arch (the oldest runner): every leg of an arch now
-          # builds the same file name, so a second uploader would collide. Oldest
-          # matters here because asadm vendors binaries off the runner (see the
-          # spec's /usr/bin/less), which carry the runner's own floor.
+          # builds the same file name, so a second uploader would collide. The
+          # floor itself is enforced by check_min_os.sh, not by this choice.
           - os: macos-14
             publish: true
           - os: macos-15-intel

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -293,6 +293,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-15-intel, macos-14, macos-15, macos-26]
+        include:
+          # One publisher per arch (the oldest runner): every leg of an arch now
+          # builds the same file name, so a second uploader would collide. Oldest
+          # matters here because asadm vendors binaries off the runner (see the
+          # spec's /usr/bin/less), which carry the runner's own floor.
+          - os: macos-14
+            publish: true
+          - os: macos-15-intel
+            publish: true
     runs-on: ${{ matrix.os }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -352,7 +361,7 @@ jobs:
           make -C pkg osx-pkg VERSION="${VERSION}"
           # pkg/Makefile emits the shipping name directly -- see the MAC_PKG
           # comment there for the convention
-          # (aerospike-asadm-<release>-macos<major>-<arch>.pkg). Do NOT rebuild
+          # (aerospike-asadm-<release>-macos-<arch>.pkg). Do NOT rebuild
           # the name here: a second copy of the convention is a second place to
           # get it wrong. Move whatever the build produced, asserting there is
           # exactly one so a stale target/ never ships silently.
@@ -369,17 +378,15 @@ jobs:
           mv "${pkgs}" .
           echo "PKG_NAME=$(basename "${pkgs}")" >> "$GITHUB_ENV"
           echo "==> built $(basename "${pkgs}")"
-          # Platform suffix for the upload-artifact container below, in the same
-          # macos<major>-<arch> terms as the pkg it carries. Unique per matrix
-          # leg (macos14-arm64, macos15-arm64, macos26-arm64, macos15-x86_64),
-          # which is all the container name has to guarantee.
-          # Assigned on its own line: a failing command substitution inside an
-          # argument does not trip `set -e`, which would name the artifact
-          # container "...--$(uname -m)" and let the leg pass.
-          plat=$(.github/bin/os_version.sh)
-          echo "PKG_PLATFORM=${plat}-$(uname -m)" >> "$GITHUB_ENV"
+          # Only the two publisher legs upload and they differ by arch, so the
+          # arch alone is unique. Assigned on its own line: a failing command
+          # substitution inside an argument does not trip `set -e`.
+          arch=$(uname -m)
+          [[ -n "${arch}" ]] || { echo "::error::uname -m returned nothing" >&2; exit 1; }
+          echo "PKG_PLATFORM=${arch}" >> "$GITHUB_ENV"
 
       - name: Upload build artifacts
+        if: matrix.publish
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           # Consumers match on the "unsigned-artifacts-<VERSION>" prefix and
@@ -596,15 +603,12 @@ jobs:
           # ${VERIFIED_PKG}, so it cannot install a different file than the one
           # verified here, and an ambiguous match fails instead of silently
           # picking find's first result.
-          # Select this runner's pkg by the platform fields of the shipping
-          # name (see MAC_PKG in pkg/Makefile): macos<major>-<arch>. Derived
-          # from the runner itself via the same script the build used, so a
-          # renamed GitHub runner label cannot silently match zero files -- and
-          # this asserts the artifact really is built for the macOS/arch it
-          # claims, which a runner-label match never did.
-          # Assigned on its own line so `set -e` sees a failure here.
-          plat=$(.github/bin/os_version.sh)
-          pat="*-${plat}-$(uname -m).pkg"
+          # Select by arch alone: one pkg per arch serves every macOS generation,
+          # so all four legs install the same two files. That is the
+          # cross-generation coverage the per-generation naming could not give.
+          arch=$(uname -m)
+          [[ -n "${arch}" ]] || { echo "ERROR: uname -m returned nothing" >&2; exit 1; }
+          pat="*-macos-${arch}.pkg"
           # One find, reused for the count, the error message and the result --
           # three separate walks could disagree with each other. (mapfile would
           # be the idiomatic reader, but the macOS runners ship bash 3.2, which

--- a/lib/view/view.py
+++ b/lib/view/view.py
@@ -70,11 +70,12 @@ class CliView(object):
         if type(out) is not str:
             out = str(out)
         if CliView.pager == CliView.LESS:
+            less_cmd = "less -RSX"
+
             if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
-                # We are running in a bundled app
-                less_cmd = path.join(sys._MEIPASS, "less") + " -RSX"  # type: ignore MEIPASS is set by pyinstaller.
-            else:
-                less_cmd = "less -RSX"
+                bundled_less = path.join(sys._MEIPASS, "less")  # type: ignore MEIPASS is set by pyinstaller.
+                if path.isfile(bundled_less):
+                    less_cmd = bundled_less + " -RSX"
 
             pipepager(out, less_cmd)
         elif CliView.pager == CliView.SCROLL:

--- a/pkg/Makefile
+++ b/pkg/Makefile
@@ -41,19 +41,20 @@ PKG_ID = com.aerospike.asadm
 # interpolate it (<arch> is `uname -m`, the token a cask's `arch` stanza emits;
 # #{version} is the full <version>-<iteration> release string):
 #
-#     aerospike-asadm-<version>-<iteration>-macos<major>-<arch>.pkg
+#     aerospike-asadm-<version>-<iteration>-macos-<arch>.pkg
 #
-# macos<major> is the generation the artifact was BUILT on, not a minimum it
-# supports; it keeps one release's per-runner artifacts distinct, so a cask has
-# to pin the build it ships. A dev build's <version> carries a hyphen of its
-# own (5.0.3-abc123def), so match those with a glob rather than positionally.
-# The bare .pkg is the shipping artifact; there is deliberately no .dmg (a CLI
-# under /usr/local has nothing to drag, and a disk image would be a second
-# container to sign, notarize and staple).
-# Captured once (`:=`), so prep-mac's guard below checks the very token that
-# lands in the file name, and os_version.sh is not re-run per expansion.
-MAC_PLATFORM := $(shell $(PKG_DIR)/../.github/bin/os_version.sh)
-MAC_PKG = $(TARGET_DIR)/$(NAME)-$(RELEASE)-$(MAC_PLATFORM)-$(ARCH).pkg
+# A dev build's <version> carries a hyphen of its own (5.0.3-abc123def), so match
+# those with a glob rather than positionally. The bare .pkg is the shipping
+# artifact; there is deliberately no .dmg (a CLI under /usr/local has nothing to
+# drag, and a disk image would be a second container to sign, notarize and
+# staple).
+#
+# One pkg per architecture, not per macOS generation: macOS is forward
+# compatible, so the oldest-runner build serves every supported release.
+MAC_PKG = $(TARGET_DIR)/$(NAME)-$(RELEASE)-macos-$(ARCH).pkg
+# Support floor, asserted by check_min_os.sh over the whole PyInstaller bundle,
+# so anything vendored off the build runner has to honour it too.
+MACOS_MIN_VERSION = 14.0
 BUILD_DISTRO ?= $(shell $(PKG_DIR)/../.github/bin/os_version.sh)
 NAME = aerospike-$(PACKAGE_NAME)
 MAINTAINER = "Aerospike"
@@ -141,7 +142,8 @@ prep:
 .PHONY: prep-mac
 prep-mac:
 	@test -n "$(PKG_VERSION)" && test -n "$(ITERATION)" || { echo "ERROR: empty version/iteration -- .github/bin/pkg_release.sh failed for VERSION='$(VERSION)'; refusing to build an unnamed pkg" >&2; exit 1; }
-	@test -n "$(MAC_PLATFORM)" || { echo "ERROR: empty macOS platform token -- .github/bin/os_version.sh failed; refusing to build an unnamed pkg" >&2; exit 1; }
+	@echo '$(ARCH)' | grep -qE '^(arm64|x86_64)$$' \
+		|| { echo "ERROR: architecture token is '$(ARCH)', not arm64 or x86_64 -- uname -m failed; refusing to build a misnamed pkg" >&2; exit 1; }
 	install -d $(TARGET_DIR)
 	rm -rf $(MAC_ROOT)
 	install -d $(MAC_ROOT)/usr/local/aerospike/bin/asadm
@@ -155,6 +157,7 @@ prep-mac:
 
 .PHONY: osx-pkg
 osx-pkg: prep-mac
+	$(PKG_DIR)/../.github/bin/check_min_os.sh $(MACOS_MIN_VERSION) $(MAC_ROOT)
 	pkgbuild \
 		--root $(MAC_ROOT) \
 		--identifier $(PKG_ID) \

--- a/pyinstaller-build.spec
+++ b/pyinstaller-build.spec
@@ -34,7 +34,13 @@ options = parser.parse_args()
 #
 
 datas = [('lib/live_cluster/client/schemas/json/aerospike', './lib/live_cluster/client/schemas/json/aerospike')]
-binaries = [('/usr/bin/less','.')]
+binaries = []
+
+# Not on macOS: /usr/bin/less is present on every supported release, and the
+# runner's copy carries that runner's minos, which would set the floor for the
+# whole pkg (see MACOS_MIN_VERSION in pkg/Makefile). CliView falls back to PATH.
+if "darwin" not in platform.system().lower():
+    binaries.append(('/usr/bin/less', '.'))
 hiddenimports = [] # If something fails to import add it here like "pkg_resources.extern"
 
 '''


### PR DESCRIPTION
Follow-up to #538, which named the macOS pkg for Homebrew but kept a `macos<major>` field in it.

## Why

`aerospike-asadm-<version>-<iteration>-macos<major>-<arch>.pkg` records the macOS generation the artifact was **built on**. That is not something a user can act on. macOS is forward compatible and never backward, so the build made on the oldest runner already serves every supported release and the per-generation builds are strictly *less* installable. One release published three arm64 artifacts and pushed the choice of which onto the user.

The floor was also never chosen. Nothing pinned `MACOSX_DEPLOYMENT_TARGET`, so `clang` stamped `minos` from whichever runner GitHub happened to schedule. Measured on the shipping 13.0.2 bundle:

| | arm64 | x86_64 |
|---|---|---|
| aql, asbackup, asrestore, asbench | 14.0 | 15.0 |
| asconfig | 12.0 | 12.0 |
| asadm, asinfo + 63 bundled deps | 11.0 | — |
| `asadm/_internal/less` | **14.8** | **15.7** |

Two different floors for the same release, both accidental, and both set by a vendored `less` rather than by anything we compile.

## What

- Name the pkg `aerospike-asadm-<version>-<iteration>-macos-<arch>.pkg`.
- Add `.github/bin/check_min_os.sh`, run before `pkgbuild`: every Mach-O in the staged payload must have `minos <= MACOS_MIN_VERSION` (14.0). It catches an unpinned compile inheriting the runner's SDK *and* prebuilt files vendored off the runner, which no compile flag reaches.
- Publish from one leg per arch (`macos-14`, `macos-15-intel`). Every leg of an arch now produces the same file name, so a second uploader would collide. The other legs still build and sanity-test — that is what the matrix is for.
- Select by arch in `test-install-mac-and-execute`. All four legs now install the same two pkgs, so the `macos-14` build is actually executed on 15 and 26. Previously each leg installed the pkg built on its own generation, so nothing ever proved a pkg runs off its build host.

## asadm-specific

`/usr/bin/less` was hardcoded in `pyinstaller-build.spec` and copied off the build runner, so it carried that runner's `minos` (14.8 above) and set the floor for the whole package — higher than any binary we compile. It is no longer bundled on macOS, where the system copy is always present; `CliView` falls back to `less` on `PATH` when the bundled copy is absent. Linux, where the bundled copy earns its place, is unchanged.

## Verified

- `pkg_release.bats` — 15/15 pass.
- `test/unit/view/test_view.py` — 59 passed, 4 subtests.
- `check_min_os.sh` validated against the real shipping 13.0.2 artifacts before wiring it in: it flags the arm64 `less` at 14.8 and the x86_64 tools at 15.0/15.7, and passes clean at floor 15.

Companion PRs follow in aql, aerospike-benchmark, aerospike-tools-backup, asconfig and aerospike-tools.