### PR TITLE
fix(ci): key the asadm build cache on its inputs, not just VERSION

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -336,7 +336,11 @@ jobs:
         with:
           path: |
             build/bin
-          key: ${{ env.cache-name }}-${{ env.cache-index }}-${{ matrix.os }}-${{ runner.arch }}-${{ steps.system-info.outputs.release }}-${{ env.PYTHON_VERSION }}-${{ needs.get-version.outputs.VERSION }}
+          # Keyed on the BUILD INPUTS, not just VERSION. Keying on VERSION alone
+          # served a stale bundle for every source change within one rc: a
+          # pyinstaller-build.spec fix landed, the key was unchanged, `make
+          # one-dir` was skipped, and the pre-fix binaries shipped.
+          key: ${{ env.cache-name }}-${{ env.cache-index }}-${{ matrix.os }}-${{ runner.arch }}-${{ steps.system-info.outputs.release }}-${{ env.PYTHON_VERSION }}-${{ needs.get-version.outputs.VERSION }}-${{ hashFiles('pyinstaller-build.spec', 'Pipfile.lock', 'makefile', 'asadm.py', 'lib/**/*.py', 'asinfo/**/*.py') }}
 
       - name: Pipenv setup
         if: steps.cache-asadm-asinfo.outputs.cache-hit != 'true'


### PR DESCRIPTION
Fixes the mac failures on master (run [32316403505](https://github.com/aerospike/aerospike-admin/actions/runs/32316403505)).

## What happened

All four mac legs fail with:

```
  14.8  .../asadm/_internal/less
error: 1 of 66 Mach-O file(s) above the macOS 14.0 floor (listed above).
make: *** [osx-pkg] Error 1
```

…even though #541 stopped bundling `less` on macOS. The reason is in the log a few lines up:

```
Cache hit for: cache-asadm-asinfo-4-macos-14-ARM64-14-3.12-5.0.3-rc4
Cache restored successfully
```

The build never ran. `#541` changed `pyinstaller-build.spec` but not `VERSION`, and `VERSION` was the only variable input in the cache key. So the key matched the pre-fix entry, `Build asadm` was skipped by its `cache-hit != 'true'` gate, and the **stale bundle — the one that still contains `less`** — was restored and packaged. `check_min_os.sh` then did exactly its job and failed on it.

So this is not a `check_min_os.sh` problem and not a `less` problem. Both behaved correctly; they were reporting on an artifact the pipeline should never have reused.

## The underlying defect

The key was:

```
...-${{ env.PYTHON_VERSION }}-${{ needs.get-version.outputs.VERSION }}
```

Nothing about the source. Within a single rc, **any** source edit reused an older bundle — a code fix, a dependency bump, a spec change. The `less` incident is the first time that silently produced a wrong artifact loudly enough to notice; before `check_min_os.sh` existed there was nothing to catch it at all.

A build cache has to key on what goes into the build, so the key now includes:

```
hashFiles('pyinstaller-build.spec', 'Pipfile.lock', 'makefile', 'asadm.py', 'lib/**/*.py', 'asinfo/**/*.py')
```

Those are the inputs `make one-dir` consumes (`pipenv run pyinstaller pyinstaller-build.spec`). Re-runs of the same commit still hit the cache; a source change no longer does.

`matrix.os` is already in the key, so the only cache hits this gives up are cross-commit ones — which are exactly the unsafe ones.

## VERSION stays at 5.0.3-rc4

No rc bump is needed. The spec hash alone changes the key, so the poisoned entry is unreachable and the next run rebuilds from source.

One consequence to be aware of: `5.0.3-rc4` is already tagged, and `validate-inputs` rejects a VERSION whose tag exists when dispatching with `release=true` on master without `skip_tagging`. CI builds and PR runs are unaffected; only an actual release dispatch would need the tag removed or `skip_tagging`.

## Same defect elsewhere

Audited the other tools repos:

| repo | key includes | verdict |
|---|---|---|
| asconfig | `VERSION` only | **vulnerable** — fixed in aerospike/asconfig#137 |
| aql | `VERSION` only | **vulnerable** — fixed in aerospike/aql#94 |
| aerospike-benchmark | `github.sha` | safe |
| aerospike-tools-backup | `git describe --abbrev=9` | safe (varies per commit) |
| aerospike-tools | no build cache | safe |