### PR TITLE
fix(docker): restore the C.UTF-8 locale in the image

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -943,6 +943,12 @@ jobs:
           docker run --rm --entrypoint sh "${IMAGE}" -c 'test -f /etc/aerospike/astools.conf' \
             || { echo "ERROR: /etc/aerospike/astools.conf missing in image" >&2; exit 1; }
 
+          # The pre-13.0.3 wrapper exported LC_CTYPE=C.UTF-8; the Dockerfile now
+          # sets it as ENV. Assert glibc resolves a UTF-8 charmap in the image.
+          CHARMAP=$(docker run --rm --entrypoint sh "${IMAGE}" -c 'locale charmap')
+          [[ "${CHARMAP}" == "UTF-8" ]] \
+            || { echo "ERROR: image locale charmap is ${CHARMAP}, expected UTF-8" >&2; exit 1; }
+
           if [[ -n "${SNYK_TOKEN:-}" ]]; then
             snyk container test "${IMAGE}" \
               --platform=linux/${{ matrix.arch }} \

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -945,9 +945,18 @@ jobs:
 
           # The pre-13.0.3 wrapper exported LC_CTYPE=C.UTF-8; the Dockerfile now
           # sets it as ENV. Assert glibc resolves a UTF-8 charmap in the image.
-          CHARMAP=$(docker run --rm --entrypoint sh "${IMAGE}" -c 'locale charmap')
+          CHARMAP=$(docker run --rm --entrypoint sh "${IMAGE}" -c 'locale charmap') \
+            || { echo "ERROR: could not read the locale charmap from ${IMAGE}" >&2; exit 1; }
           [[ "${CHARMAP}" == "UTF-8" ]] \
-            || { echo "ERROR: image locale charmap is ${CHARMAP}, expected UTF-8" >&2; exit 1; }
+            || { echo "ERROR: image locale charmap is '${CHARMAP//$'\n'/ }', expected UTF-8" >&2; exit 1; }
+
+          # LC_CTYPE is pinned so a LANG override to an ungenerated locale cannot
+          # drop the ctype back to ASCII. Without this the pin could be trimmed to
+          # LANG alone and the assertion above would stay green.
+          CHARMAP=$(docker run --rm -e LANG=en_US.UTF-8 --entrypoint sh "${IMAGE}" -c 'locale charmap') \
+            || { echo "ERROR: could not read the locale charmap from ${IMAGE} under a LANG override" >&2; exit 1; }
+          [[ "${CHARMAP}" == "UTF-8" ]] \
+            || { echo "ERROR: LANG override drops the charmap to '${CHARMAP//$'\n'/ }', expected UTF-8 (LC_CTYPE pin lost?)" >&2; exit 1; }
 
           if [[ -n "${SNYK_TOKEN:-}" ]]; then
             snyk container test "${IMAGE}" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,6 +40,15 @@ LABEL org.opencontainers.image.title="Aerospike asadm" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.vendor="Aerospike"
 
+# Restores the UTF-8 ctype the pre-13.0.3 entrypoint wrapper exported, so asadm
+# renders µ in micro-benchmark output. ENV also covers docker exec and
+# --entrypoint overrides, which the wrapper never did. C.UTF-8 is built into
+# glibc, so no locales package is needed; LC_CTYPE is pinned alongside LANG
+# because it is the only locale the image has, so a LANG override to an
+# ungenerated one would otherwise drop back to ASCII.
+ENV LANG=C.UTF-8 \
+    LC_CTYPE=C.UTF-8
+
 SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 
 # Fetch (or copy) → verify SHA → apt-install the .deb. apt resolves any

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,12 +40,14 @@ LABEL org.opencontainers.image.title="Aerospike asadm" \
       org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.vendor="Aerospike"
 
-# Restores the UTF-8 ctype the pre-13.0.3 entrypoint wrapper exported, so asadm
-# renders µ in micro-benchmark output. ENV also covers docker exec and
-# --entrypoint overrides, which the wrapper never did. C.UTF-8 is built into
-# glibc, so no locales package is needed; LC_CTYPE is pinned alongside LANG
-# because it is the only locale the image has, so a LANG override to an
-# ungenerated one would otherwise drop back to ASCII.
+# glibc otherwise resolves the POSIX locale, whose ANSI_X3.4-1968 charmap strips
+# non-ASCII from tool output. ENV rather than an entrypoint export, so docker exec,
+# --entrypoint overrides and K8s pod specs inherit it; the pre-13.0.3 wrapper only
+# covered its own process. C.utf8 is glibc-builtin on trixie: no locales package,
+# no size cost. LC_CTYPE is pinned alongside LANG deliberately -- C.utf8 is the
+# image's only UTF-8 locale, so -e LANG=<ungenerated> would fall back to ASCII.
+# Precedence is LC_ALL > LC_CTYPE > LANG, so override the ctype via LC_ALL or
+# LC_CTYPE. Deviates from python/postgres, which set LANG only and ship locales.
 ENV LANG=C.UTF-8 \
     LC_CTYPE=C.UTF-8
 


### PR DESCRIPTION
## Problem

Every image up to 13.0.2 ran through the `/aerospike/wrapper` entrypoint, whose first act was `export LC_CTYPE=C.UTF-8`. The 13.0.3 rebuild dropped the wrapper and did not replace the locale setting, so 13.0.3 containers start under the POSIX locale:

```
$ docker run --rm --entrypoint sh <13.0.3 image> -c 'locale charmap'
ANSI_X3.4-1968
```

Per the wrapper's own comment that is the setting that let `asadm` render the µ in micro-benchmark output.

## Fix

```dockerfile
ENV LANG=C.UTF-8 \
    LC_CTYPE=C.UTF-8
```

- **`ENV`, not a new entrypoint script.** It applies however the container is invoked: `docker exec`, `--entrypoint` overrides and Kubernetes pod specs, none of which the wrapper covered. It also survives whatever TOOLS-4360 decides about `ENTRYPOINT`.
- **Placed with the base setup, before the install step**, so the build itself runs UTF-8. Setting `LANG` there follows `python`/`postgres`; pinning `LC_CTYPE` alongside it is a deliberate deviation, since those images ship or generate real locales and this one has only `C.utf8`.
- **Both vars, not just `LANG`.** C.UTF-8 is the only locale in the image, and its non-ctype categories are identical to C, so `LANG` alone changes nothing but the charset. But with `LANG` alone a user passing `-e LANG=en_US.UTF-8` silently falls back to ASCII, because that locale is not generated here. Measured on `debian:trixie-slim`:

  | image `ENV` | default `locale charmap` | with `-e LANG=en_US.UTF-8` |
  | --- | --- | --- |
  | none (13.0.3 today) | `ANSI_X3.4-1968` | `ANSI_X3.4-1968` |
  | `LANG` only | `UTF-8` | `ANSI_X3.4-1968` |
  | `LANG` + `LC_CTYPE` | `UTF-8` | `UTF-8` |

  Pinning `LC_CTYPE` holds UTF-8 through the override, which is the regression this ticket is about.
- `C.UTF-8` is built into glibc on trixie, so no `locales` package and no image-size cost.

## Test

The docker smoke test asserts the built image resolves a UTF-8 charmap, per arch:

```bash
CHARMAP=$(docker run --rm --entrypoint sh "${IMAGE}" -c 'locale charmap')
[[ "${CHARMAP}" == "UTF-8" ]] || { ... exit 1; }
```

`locale charmap` is the assertion rather than a grep of the env var: it fails on an unset locale *and* on a locale name glibc cannot resolve, so it proves the charset the tools actually get. It runs in the existing per-arch matrix on native runners, covering `linux/amd64` and `linux/arm64`.

Verified locally against the pinned base digest (table above), `hadolint` clean, `actionlint` clean.

Companion PRs carry the identical change in the other five repos; the other wrapper-removal gaps (`ENTRYPOINT`/`CMD`, missing `ca-certificates`, PID 1 signal handling, tag policy, build attestations) are tracked separately.

TOOLS-4361

