### PR TITLE
ci: TOOLS-3137 - Drop support for Debian 11

### DIFF
--- a/.github/bin/install_deps.sh
+++ b/.github/bin/install_deps.sh
@@ -6,7 +6,7 @@
 #   source .github/bin/install_deps.sh
 #   install_deps <distro>     # e.g. install_deps ubuntu24.04
 #
-# Supported distros: debian11, debian12, debian13,
+# Supported distros: debian12, debian13,
 #                    ubuntu20.04, ubuntu22.04, ubuntu24.04, ubuntu26.04,
 #                    el8, el9, el10, amzn2023
 #
@@ -23,7 +23,6 @@ export GOLANG_VERSION="${GOLANG_VERSION:-1.24.6}"
 
 export CURL_RETRY_OPTS=(--retry 5 --retry-delay 5)
 
-DEBIAN_11_DEPS='ca-certificates curl git rsync make gcc g++ build-essential xz-utils liblzma-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev libffi-dev libncursesw5-dev uuid-dev tk-dev libssl1.1 libssl-dev ruby-rubygems rpm less'
 DEBIAN_12_DEPS="libreadline8 libreadline-dev ruby-rubygems make rpm git snapd curl binutils rsync libssl3 libssl-dev lzma lzma-dev libffi-dev build-essential gcc g++ less"
 DEBIAN_13_DEPS="libreadline8 libreadline-dev ruby-rubygems make rpm git snapd curl binutils rsync libssl3 libssl-dev lzma liblzma-dev libffi-dev libsqlite3-dev build-essential gcc g++ zlib1g-dev libbz2-dev libreadline-dev libncursesw5-dev libnss3-dev uuid-dev tk-dev xz-utils less"
 UBUNTU_2004_DEPS="libreadline8 libreadline-dev ruby make rpm git snapd curl binutils rsync libssl1.1 libssl-dev lzma lzma-dev libffi-dev build-essential gcc g++ less"
@@ -41,7 +40,6 @@ AMZN2023_DEPS="readline-devel ruby rpmdevtools make git rsync gcc g++ make autom
 
 _pkg_list_for() {
   case "$1" in
-    debian11)    echo "$DEBIAN_11_DEPS" ;;
     debian12)    echo "$DEBIAN_12_DEPS" ;;
     debian13)    echo "$DEBIAN_13_DEPS" ;;
     ubuntu20.04) echo "$UBUNTU_2004_DEPS" ;;
@@ -214,11 +212,6 @@ install_deps() {
   local distro="${1:?install_deps requires a distro argument (e.g. ubuntu24.04)}"
 
   _install_distro_packages "$distro"
-
-  # debian11 ships stale CA bundle; refresh before Go/asdf curl calls.
-  if [[ "$distro" == "debian11" ]]; then
-    update-ca-certificates
-  fi
 
   _install_go
   _install_python_via_asdf_and_fpm "$(_pip_flags_for "$distro")" "$distro"

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -212,7 +212,6 @@ jobs:
           - el9
           - el10
           - amzn2023
-          - debian11
           - debian12
           - debian13
           - ubuntu22.04
@@ -224,7 +223,6 @@ jobs:
         matrix.distro == 'el9' && 'redhat/ubi9:9.6' ||
         matrix.distro == 'el10' && 'redhat/ubi10:10.0' ||
         matrix.distro == 'amzn2023' && 'amazonlinux:2023.9.20251208.0' ||
-        matrix.distro == 'debian11' && 'debian:bullseye-20251208' ||
         matrix.distro == 'debian12' && 'debian:bookworm-20230411' ||
         matrix.distro == 'debian13' && 'debian:trixie-20251020' ||
         matrix.distro == 'ubuntu22.04' && 'ubuntu:jammy-20231004' ||
@@ -476,7 +474,6 @@ jobs:
           - el9
           - el10
           - amzn2023
-          - debian11
           - debian12
           - debian13
           - ubuntu22.04
@@ -488,7 +485,6 @@ jobs:
         matrix.distro == 'el9' && 'redhat/ubi9:9.6' ||
         matrix.distro == 'el10' && 'redhat/ubi10:10.0' ||
         matrix.distro == 'amzn2023' && 'amazonlinux:2023.9.20251208.0' ||
-        matrix.distro == 'debian11' && 'debian:bullseye-20251208' ||
         matrix.distro == 'debian12' && 'debian:bookworm-20230411' ||
         matrix.distro == 'debian13' && 'debian:trixie-20251020' ||
         matrix.distro == 'ubuntu22.04' && 'ubuntu:jammy-20231004' ||


### PR DESCRIPTION
## Why

[TOOLS-3137](https://aerospike.atlassian.net/browse/TOOLS-3137) - "(TOOLS) Remove support for Debian 11":

> After August 31 2026, remove Debian 11 builds from the tools package and all the individual tools.

Debian 11 (bullseye) reached LTS end-of-life on **2026-08-31**, and its `bullseye-security` `Release` file expired on **2026-09-07**. `apt-get update` now fails inside the pinned `debian:bullseye-20251208` container, so every `debian11` job in **Build and Release** dies at *Install prereqs*, before checkout:

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease is expired (invalid since 1d 6h 55min 24s). Updates for this repository will not be applied.
/__w/_temp/b518dda2-84cd-4f38-9744-91baf5ea899b.sh: line 12: git: command not found
##[error]Process completed with exit code 127.
```

Representative failure (aql): https://github.com/aerospike/aql/actions/runs/34309755577

Keeping the jobs alive was considered and rejected: pinning `Acquire::Check-Valid-Until=false` gets past the expiry check, but the bullseye pool is already being purged, and a Debian 11 artifact built after EOL would ship against a base that receives no further security updates.

## What changed

- `.github/workflows/build-and-release.yml` - drop `debian11` from the `build-artifacts` and `test-install-linux-and-execute` matrices and remove its container image mapping.
- `.github/bin/install_deps.sh` - remove `DEBIAN_11_DEPS`, its `_pkg_list_for` case, the supported-distro comment entry, and the debian11-only `update-ca-certificates` refresh.

## Not in this PR

- The `apt-get update && apt-get install ...` one-liner in *Install prereqs* still masks apt failures under `set -e` (bash exempts `&&` lists), which is why the job reported a confusing `git: command not found` instead of the apt error. Worth splitting, but out of scope here.

## Verification

- Both matrices go from 10 distros to 9; no `debian11` entry remains in either.
- Workflow YAML parses.
- `bash -n` clean on every touched shell script.

## Related

Debian 11 removal is already complete everywhere else: TOOLS-3134 (ACT), TOOLS-3135 (ASMT), TOOLS-3136 (ASVALIDATION), CLIENT-3881 (C/C++), CLIENT-3882 (Python), CLIENT-3883 (Node.js), AER-6854, REL-3931, REL-3932, DOCS-3794, DOCS-3901, QE-581, QE-592, and the NEW download listings. TOOLS-3137 is the last open ticket.

Companion PRs on the same branch name (`TOOLS-3137-drop-debian11`) in: aql, aerospike-admin, aerospike-tools-backup, aerospike-benchmark, asconfig, aerospike-tools.


[TOOLS-3137]: https://aerospike.atlassian.net/browse/TOOLS-3137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ